### PR TITLE
Refactor frontend modules with unified wiring and styling

### DIFF
--- a/cfg.js
+++ b/cfg.js
@@ -1,101 +1,135 @@
-// cfg.js — transcodification & constantes calculées (auto-généré depuis Excel)
-(function(){
-  const CFG = {};
+(() => {
+    const config = window.CFG || {};
 
-  // ====== Equipment -> Groupes (clé: equipment brut, lowercase) ======
-  CFG.equipmentTranscode = {
-    'body weight': { g1: 'Body weight', g2: 'Body weight' },
-    'weighted': { g1: 'Weighted', g2: 'Body weight' },
-    'band': { g1: 'Band', g2: 'Machine' },
-    'cable': { g1: 'Cable', g2: 'Machine' },
-    'leverage machine': { g1: 'Leverage machine', g2: 'Machine' },
-    'smith machine': { g1: 'Smith machine', g2: 'Machine' },
-    'elliptical machine': { g1: 'Cardio machine', g2: 'Machine' },
-    'skierg machine': { g1: 'Cardio machine', g2: 'Machine' },
-    'stationary bike': { g1: 'Cardio machine', g2: 'Machine' },
-    'stepmill machine': { g1: 'Cardio machine', g2: 'Machine' },
-    'upper body ergometer': { g1: 'Cardio machine', g2: 'Machine' },
-    'stairmaster': { g1: 'Cardio machine', g2: 'Machine' },
-    'treadmill': { g1: 'Cardio machine', g2: 'Machine' },
-    'sled machine': { g1: 'sled Machine', g2: 'Machine' },
-    'barbell': { g1: 'Barbell', g2: 'Free weights' },
-    'ez barbell': { g1: 'Barbell', g2: 'Free weights' },
-    'olympic barbell': { g1: 'Barbell', g2: 'Free weights' },
-    'trap bar': { g1: 'Barbell', g2: 'Free weights' },
-    'dumbbell': { g1: 'Dumbbell', g2: 'Free weights' },
-    'kettlebell': { g1: 'Kettlebell', g2: 'Free weights' },
-    'weighted plate': { g1: 'plate', g2: 'Free weights' },
-	'bosu ball': { g1: 'Ball', g2: 'Other equipment' },
-    'stability ball': { g1: 'Ball', g2: 'Other equipment' },
-    'medicine ball': { g1: 'Ball', g2: 'Other equipment' },
- 	'assisted': { g1: 'Assisted', g2: 'Other equipment' },
-    'resistance band': { g1: 'Band', g2: 'Other equipment' },
-	'rope': { g1: 'Rope', g2: 'Other equipment' },
-	'sled': { g1: 'sled machine', g2: 'Other equipment' },
-	'belt': { g1: 'Belt', g2: 'Other equipment' },
-    'wheel roller': { g1: 'Roller', g2: 'Other equipment' },
-	'roller': { g1: 'Roller', g2: 'Other equipment' },
- 	'tire': { g1: 'Tire', g2: 'Other equipment' },
-	'hammer': { g1: 'Hammer', g2: 'Other equipment' }
+    /* STATE */
+    config.equipmentTranscode = {
+        'body weight': { g1: 'Body weight', g2: 'Body weight' },
+        weighted: { g1: 'Weighted', g2: 'Body weight' },
+        band: { g1: 'Band', g2: 'Machine' },
+        cable: { g1: 'Cable', g2: 'Machine' },
+        'leverage machine': { g1: 'Leverage machine', g2: 'Machine' },
+        'smith machine': { g1: 'Smith machine', g2: 'Machine' },
+        'elliptical machine': { g1: 'Cardio machine', g2: 'Machine' },
+        'skierg machine': { g1: 'Cardio machine', g2: 'Machine' },
+        'stationary bike': { g1: 'Cardio machine', g2: 'Machine' },
+        'stepmill machine': { g1: 'Cardio machine', g2: 'Machine' },
+        'upper body ergometer': { g1: 'Cardio machine', g2: 'Machine' },
+        stairmaster: { g1: 'Cardio machine', g2: 'Machine' },
+        treadmill: { g1: 'Cardio machine', g2: 'Machine' },
+        'sled machine': { g1: 'sled Machine', g2: 'Machine' },
+        barbell: { g1: 'Barbell', g2: 'Free weights' },
+        'ez barbell': { g1: 'Barbell', g2: 'Free weights' },
+        'olympic barbell': { g1: 'Barbell', g2: 'Free weights' },
+        'trap bar': { g1: 'Barbell', g2: 'Free weights' },
+        dumbbell: { g1: 'Dumbbell', g2: 'Free weights' },
+        kettlebell: { g1: 'Kettlebell', g2: 'Free weights' },
+        'weighted plate': { g1: 'plate', g2: 'Free weights' },
+        'bosu ball': { g1: 'Ball', g2: 'Other equipment' },
+        'stability ball': { g1: 'Ball', g2: 'Other equipment' },
+        'medicine ball': { g1: 'Ball', g2: 'Other equipment' },
+        assisted: { g1: 'Assisted', g2: 'Other equipment' },
+        'resistance band': { g1: 'Band', g2: 'Other equipment' },
+        rope: { g1: 'Rope', g2: 'Other equipment' },
+        sled: { g1: 'sled machine', g2: 'Other equipment' },
+        belt: { g1: 'Belt', g2: 'Other equipment' },
+        'wheel roller': { g1: 'Roller', g2: 'Other equipment' },
+        roller: { g1: 'Roller', g2: 'Other equipment' },
+        tire: { g1: 'Tire', g2: 'Other equipment' },
+        hammer: { g1: 'Hammer', g2: 'Other equipment' }
+    };
 
-  };
+    config.muscleTranscode = {
+        lats: { muscle: 'lats', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
+        'upper back': { muscle: 'upper back', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
+        spine: { muscle: 'spine', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
+        traps: { muscle: 'traps', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
+        neck: { muscle: 'neck', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
+        'levator scapulae': { muscle: 'neck', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
+        biceps: { muscle: 'biceps', g1: 'upper arms', g2: 'arms', g3: 'Upper Body' },
+        triceps: { muscle: 'triceps', g1: 'upper arms', g2: 'arms', g3: 'Upper Body' },
+        forearms: { muscle: 'forearms', g1: 'lower arms', g2: 'arms', g3: 'Upper Body' },
+        delts: { muscle: 'shoulders', g1: 'shoulders', g2: 'shoulders', g3: 'Upper Body' },
+        shoulders: { muscle: 'shoulders', g1: 'shoulders', g2: 'shoulders', g3: 'Upper Body' },
+        chest: { muscle: 'chest', g1: 'chest', g2: 'chest', g3: 'Upper Body' },
+        pectorals: { muscle: 'pectorals', g1: 'chest', g2: 'chest', g3: 'Upper Body' },
+        'serratus anterior': { muscle: 'serratus anterior', g1: 'chest', g2: 'chest', g3: 'Upper Body' },
+        abs: { muscle: 'abs', g1: 'waist', g2: 'core', g3: 'Core' },
+        obliques: { muscle: 'obliques', g1: 'waist', g2: 'core', g3: 'Core' },
+        'cardiovascular system': { muscle: 'cardio', g1: 'waist', g2: 'core', g3: 'Core' },
+        glutes: { muscle: 'glutes', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
+        quads: { muscle: 'quads', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
+        hamstrings: { muscle: 'hamstrings', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
+        abductors: { muscle: 'abductors', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
+        adductors: { muscle: 'adductors', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
+        calves: { muscle: 'calves', g1: 'lower legs', g2: 'legs', g3: 'Lower Body' }
+    };
 
-  // ====== TargetMuscle -> Muscle + Groupes (clé: target brut, lowercase) ======
-  CFG.muscleTranscode = {
-    'lats':  { muscle: 'lats', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
-    'upper back': { muscle: 'upper back', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
-    'spine': { muscle: 'spine', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
-    'traps': { muscle: 'traps', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
-    'neck': { muscle: 'neck', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
-    'levator scapulae': { muscle: 'neck', g1: 'upper back', g2: 'back', g3: 'Upper Body' },
-    'biceps': { muscle: 'biceps', g1: 'upper arms', g2: 'arms', g3: 'Upper Body' },
-    'triceps': { muscle: 'triceps', g1: 'upper arms', g2: 'arms', g3: 'Upper Body' },
-    'forearms': { muscle: 'forearms', g1: 'lower arms', g2: 'arms', g3: 'Upper Body' },
-	'delts': { muscle: 'shoulders', g1: 'shoulders', g2: 'shoulders', g3: 'Upper Body' },
-	'shoulders': { muscle: 'shoulders', g1: 'shoulders', g2: 'shoulders', g3: 'Upper Body' },
-    'chest': { muscle: 'chest', g1: 'chest', g2: 'chest', g3: 'Upper Body' },
-    'pectorals': { muscle: 'pectorals', g1: 'chest', g2: 'chest', g3: 'Upper Body' },
-    'serratus anterior': { muscle: 'serratus anterior', g1: 'chest', g2: 'chest', g3: 'Upper Body' },
-    'abs': { muscle: 'abs', g1: 'waist', g2: 'core', g3: 'Core' },
-    'obliques': { muscle: 'obliques', g1: 'waist', g2: 'core', g3: 'Core' },
-    'cardiovascular system': { muscle: 'cardio', g1: 'waist', g2: 'core', g3: 'Core' },
-	'glutes': { muscle: 'glutes', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
-    'quads': { muscle: 'quads', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
-    'hamstrings': { muscle: 'hamstrings', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
-    'abductors': { muscle: 'abductors', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
-    'adductors': { muscle: 'adductors', g1: 'upper legs', g2: 'legs', g3: 'Lower Body' },
-    'calves': { muscle: 'calves', g1: 'lower legs', g2: 'legs', g3: 'Lower Body' }
-  };
+    Object.defineProperty(config, 'equipment', {
+        get() {
+            return Array.from(new Set(Object.values(config.equipmentTranscode).map((item) => item.g2).filter(Boolean)));
+        }
+    });
+    Object.defineProperty(config, 'equipmentG2', {
+        get() {
+            return Array.from(new Set(Object.values(config.equipmentTranscode).map((item) => item.g2).filter(Boolean)));
+        }
+    });
+    Object.defineProperty(config, 'equipmentG1', {
+        get() {
+            return Array.from(new Set(Object.values(config.equipmentTranscode).map((item) => item.g1).filter(Boolean)));
+        }
+    });
+    Object.defineProperty(config, 'musclesG3', {
+        get() {
+            return Array.from(new Set(Object.values(config.muscleTranscode).map((item) => item.g3).filter(Boolean)));
+        }
+    });
+    Object.defineProperty(config, 'musclesG2', {
+        get() {
+            return Array.from(new Set(Object.values(config.muscleTranscode).map((item) => item.g2).filter(Boolean)));
+        }
+    });
+    Object.defineProperty(config, 'musclesG1', {
+        get() {
+            return Array.from(new Set(Object.values(config.muscleTranscode).map((item) => item.g1).filter(Boolean)));
+        }
+    });
 
+    /* WIRE */
 
-	Object.defineProperty(CFG, 'equipment', {
-		get(){ return Array.from(new Set(Object.values(CFG.equipmentTranscode).map(x=>x.g2).filter(Boolean))); }
-	});
-	Object.defineProperty(CFG, 'equipmentG2', {
-		get(){ return Array.from(new Set(Object.values(CFG.equipmentTranscode).map(x=>x.g2).filter(Boolean))); }
-	});
-	Object.defineProperty(CFG, 'equipmentG1', {
-		get(){ return Array.from(new Set(Object.values(CFG.equipmentTranscode).map(x=>x.g1).filter(Boolean))); }
-	});
-	Object.defineProperty(CFG, 'musclesG3', {
-		get(){ return Array.from(new Set(Object.values(CFG.muscleTranscode).map(x=>x.g3).filter(Boolean))); }
-	});
-	Object.defineProperty(CFG, 'musclesG2', {
-		get(){ return Array.from(new Set(Object.values(CFG.muscleTranscode).map(x=>x.g2).filter(Boolean))); }
-	});
-	Object.defineProperty(CFG, 'musclesG1', {
-		get(){ return Array.from(new Set(Object.values(CFG.muscleTranscode).map(x=>x.g1).filter(Boolean))); }
-	});
-  CFG.decodeEquipment = function(raw){
-    if (!raw) return { equipment:null, g1:null, g2:null };
-    const hit = CFG.equipmentTranscode[String(raw).trim().toLowerCase()];
-    return { equipment: raw, g1: hit?.g1 || null, g2: hit?.g2 || null };
-  };
-  CFG.decodeMuscle = function(raw){
-    if (!raw) return { muscle:null, g1:null, g2:null, g3:null };
-    const hit = CFG.muscleTranscode[String(raw).trim().toLowerCase()];
-    return { muscle: hit?.muscle || raw, g1: hit?.g1 || null, g2: hit?.g2 || null, g3: hit?.g3 || null };
-  };
+    /* ACTIONS */
 
-  window.CFG = CFG;
+    /* UTILS */
+    /**
+     * Décodage d'un équipement en groupes hiérarchiques.
+     * @param {string|null} raw Valeur brute fournie par l'API.
+     * @returns {{equipment: string|null, g1: string|null, g2: string|null}} Transcodage.
+     */
+    config.decodeEquipment = function decodeEquipment(raw) {
+        if (!raw) {
+            return { equipment: null, g1: null, g2: null };
+        }
+        const hit = config.equipmentTranscode[String(raw).trim().toLowerCase()];
+        return { equipment: raw, g1: hit?.g1 || null, g2: hit?.g2 || null };
+    };
+
+    /**
+     * Décodage d'un muscle en familles musculaires.
+     * @param {string|null} raw Valeur brute fournie par l'API.
+     * @returns {{muscle: string|null, g1: string|null, g2: string|null, g3: string|null}} Transcodage.
+     */
+    config.decodeMuscle = function decodeMuscle(raw) {
+        if (!raw) {
+            return { muscle: null, g1: null, g2: null, g3: null };
+        }
+        const hit = config.muscleTranscode[String(raw).trim().toLowerCase()];
+        return {
+            muscle: hit?.muscle || raw,
+            g1: hit?.g1 || null,
+            g2: hit?.g2 || null,
+            g3: hit?.g3 || null
+        };
+    };
+
+    window.CFG = config;
 })();

--- a/db.js
+++ b/db.js
@@ -1,171 +1,264 @@
 /* db.js — IndexedDB helpers (stores: exercises, routines, plans, sessions) */
 const db = (() => {
-  const DB_NAME = 'A0-db';
-  const DB_VER  = 1;
-  let _db;
+    /* STATE */
+    const DB_NAME = 'A0-db';
+    const DB_VER = 1;
+    let handle;
 
-  function open() {
-    return new Promise((resolve, reject) => {
-      const req = indexedDB.open(DB_NAME, DB_VER);
-      req.onupgradeneeded = (e) => {
-        const db = e.target.result;
-        if (!db.objectStoreNames.contains('exercises')) db.createObjectStore('exercises', { keyPath:'id' });
-        if (!db.objectStoreNames.contains('routines'))  db.createObjectStore('routines',  { keyPath:'id' });
-        if (!db.objectStoreNames.contains('plans'))     db.createObjectStore('plans',     { keyPath:'id' });
-        if (!db.objectStoreNames.contains('sessions'))  db.createObjectStore('sessions',  { keyPath:'date' }); // 1 séance par date
-      };
-      req.onsuccess = () => resolve(req.result);
-      req.onerror = () => reject(req.error);
-    });
-  }
+    /* WIRE */
 
-  async function init(){ _db = await open(); }
+    /* ACTIONS */
+    /**
+     * Initialise la connexion IndexedDB et mémorise l'instance.
+     * @returns {Promise<void>} Promesse résolue lorsque la connexion est prête.
+     */
+    async function init() {
+        handle = await open();
+    }
 
-  function tx(store, mode='readonly'){ return _db.transaction(store, mode).objectStore(store); }
+    /**
+     * Retourne une valeur depuis un store.
+     * @param {string} store Nom du store cible.
+     * @param {IDBValidKey} key Clé recherchée.
+     * @returns {Promise<unknown>} Valeur trouvée ou `null`.
+     */
+    async function get(store, key) {
+        return new Promise((resolve, reject) => {
+            const request = transaction(store).get(key);
+            request.onsuccess = () => resolve(request.result || null);
+            request.onerror = () => reject(request.error);
+        });
+    }
 
-  async function get(store, key){
-    return new Promise((res,rej)=>{
-      const r = tx(store).get(key);
-      r.onsuccess = ()=>res(r.result||null);
-      r.onerror = ()=>rej(r.error);
-    });
-  }
-  async function put(store, val){
-    return new Promise((res,rej)=>{
-      const r = tx(store,'readwrite').put(val);
-      r.onsuccess = ()=>res(true);
-      r.onerror = ()=>rej(r.error);
-    });
-  }
-  async function getAll(store){
-    return new Promise((res,rej)=>{
-      const r = tx(store).getAll();
-      r.onsuccess = ()=>res(r.result||[]);
-      r.onerror = ()=>rej(r.error);
-    });
-  }
-  async function count(store){
-    return new Promise((res,rej)=>{
-      const r = tx(store).count();
-      r.onsuccess = ()=>res(r.result||0);
-      r.onerror = ()=>rej(r.error);
-    });
-  }
-	async function del(store, key){
-		return new Promise((res, rej)=>{
-		const r = tx(store, 'readwrite').delete(key);
-		r.onsuccess = ()=>res(true);
-			r.onerror   = ()=>rej(r.error);
-		});
-	}
-	
-  // Sessions
-  async function getSession(date){ return get('sessions', date); }
-  async function saveSession(sess){ return put('sessions', sess); }
-  async function listSessionDates(){
-    const all = await getAll('sessions');
-    return all.map(s => ({ date: s.date }));
-  }
+    /**
+     * Écrit une valeur dans un store.
+     * @param {string} store Nom du store cible.
+     * @param {unknown} value Donnée à persister.
+     * @returns {Promise<boolean>} `true` une fois l'opération terminée.
+     */
+    async function put(store, value) {
+        return new Promise((resolve, reject) => {
+            const request = transaction(store, 'readwrite').put(value);
+            request.onsuccess = () => resolve(true);
+            request.onerror = () => reject(request.error);
+        });
+    }
 
-  // Plan actif
-  async function getActivePlan(){
-    const all = await getAll('plans');
-    return all.find(p => p.active) || null;
-  }
+    /**
+     * Liste toutes les valeurs d'un store.
+     * @param {string} store Nom du store cible.
+     * @returns {Promise<unknown[]>} Valeurs présentes.
+     */
+    async function getAll(store) {
+        return new Promise((resolve, reject) => {
+            const request = transaction(store).getAll();
+            request.onsuccess = () => resolve(request.result || []);
+            request.onerror = () => reject(request.error);
+        });
+    }
 
-  // =======================
-  // IMPORT EXTERNAL EXERCISES
-  // =======================
+    /**
+     * Compte les enregistrements d'un store.
+     * @param {string} store Nom du store cible.
+     * @returns {Promise<number>} Nombre d'entrées.
+     */
+    async function count(store) {
+        return new Promise((resolve, reject) => {
+            const request = transaction(store).count();
+            request.onsuccess = () => resolve(request.result || 0);
+            request.onerror = () => reject(request.error);
+        });
+    }
 
-  async function fileExists(url){
-    try {
-      const r = await fetch(url, { method:'HEAD' });
-      return r.ok;
-    } catch { return false; }
-  }
+    /**
+     * Supprime une entrée depuis un store.
+     * @param {string} store Nom du store cible.
+     * @param {IDBValidKey} key Clé à supprimer.
+     * @returns {Promise<boolean>} `true` une fois l'opération réalisée.
+     */
+    async function del(store, key) {
+        return new Promise((resolve, reject) => {
+            const request = transaction(store, 'readwrite').delete(key);
+            request.onsuccess = () => resolve(true);
+            request.onerror = () => reject(request.error);
+        });
+    }
 
-  async function normalizeExercise(ex){
-	// id
-	const id = String(ex.exerciseId || ex.id || ex._id || ex.uuid || '').trim();
-	if (!id) return null;
+    /**
+     * Récupère une séance via sa date.
+     * @param {string} dateKey Clé de date (YYYY-MM-DD).
+     * @returns {Promise<unknown>} Séance ou `null`.
+     */
+    async function getSession(dateKey) {
+        return get('sessions', dateKey);
+    }
 
-	// champs sources (on prend le 1er si tableau) et calcul des groupes par transcodification
-	const rawEquip  = Array.isArray(ex.equipments) && ex.equipments.length ? ex.equipments[0] : ex.equipment;
-	const eq = CFG.decodeEquipment(rawEquip);
+    /**
+     * Sauvegarde une séance.
+     * @param {object} session Objet séance à persister.
+     * @returns {Promise<boolean>} Confirmation d'écriture.
+     */
+    async function saveSession(session) {
+        return put('sessions', session);
+    }
 
-	// champs sources (on prend le 1er si tableau) et calcul des groupes par transcodification
-	const rawTarget = Array.isArray(ex.targetMuscles) && ex.targetMuscles.length ? ex.targetMuscles[0] : ex.target;
-	const rawBody   = Array.isArray(ex.bodyParts)    && ex.bodyParts.length    ? ex.bodyParts[0]    : ex.bodyPart;
-	const mu = CFG.muscleTranscode[String(rawTarget||'').toLowerCase()] || {};
+    /**
+     * Liste les dates disposant d'une séance.
+     * @returns {Promise<Array<{date: string}>>} Dates recensées.
+     */
+    async function listSessionDates() {
+        const all = await getAll('sessions');
+        return all.map((session) => ({ date: session.date }));
+    }
 
-    // Image/GIF : essaye data/media/<filename>.gif avant l’URL d’origine
-	let image = ex.gifUrl || ex.image || null;
-	if (image) {
-	  try {
-		const fname = image.split('/').pop(); // "trmte8s.gif"
-		const localPathAbs = new URL(`data/media/${fname}`, document.baseURI).href;
-		if (await fileExists(localPathAbs)) {
-		  image = localPathAbs; // prend le GIF local si présent
-		}
-	  } catch(_) { /* ignore */ }
-	}
+    /**
+     * Retourne le plan actif.
+     * @returns {Promise<object|null>} Plan actif ou `null`.
+     */
+    async function getActivePlan() {
+        const all = await getAll('plans');
+        return all.find((plan) => plan.active) || null;
+    }
+
+    /**
+     * Importe les exercices externes la première fois.
+     * @returns {Promise<void>} Promesse résolue une fois l'import terminé ou ignoré.
+     */
+    async function importExternalExercisesIfNeeded() {
+        const currentCount = await countStore('exercises');
+        if (currentCount > 0) {
+            return;
+        }
+
+        try {
+            const url = new URL('data/exercises.json', document.baseURI).href;
+            const response = await fetch(url, { cache: 'no-store' });
+            if (!response.ok) {
+                throw new Error('data/exercises.json introuvable');
+            }
+            const data = await response.json();
+            if (!Array.isArray(data)) {
+                console.warn('exercises.json pas un tableau, import ignoré.');
+                return;
+            }
+
+            const BATCH = 200;
+            for (let index = 0; index < data.length; index += BATCH) {
+                const slice = data.slice(index, index + BATCH);
+                const rows = await Promise.all(slice.map(normalizeExercise));
+                for (const row of rows) {
+                    if (row) {
+                        await put('exercises', row);
+                    }
+                }
+            }
+            console.log('Import exercises terminé.');
+        } catch (error) {
+            console.warn('Import externe sauté :', error.message);
+        }
+    }
+
+    /* UTILS */
+    function transaction(store, mode = 'readonly') {
+        return handle.transaction(store, mode).objectStore(store);
+    }
+
+    function open() {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VER);
+            request.onupgradeneeded = (event) => {
+                const database = event.target.result;
+                if (!database.objectStoreNames.contains('exercises')) {
+                    database.createObjectStore('exercises', { keyPath: 'id' });
+                }
+                if (!database.objectStoreNames.contains('routines')) {
+                    database.createObjectStore('routines', { keyPath: 'id' });
+                }
+                if (!database.objectStoreNames.contains('plans')) {
+                    database.createObjectStore('plans', { keyPath: 'id' });
+                }
+                if (!database.objectStoreNames.contains('sessions')) {
+                    database.createObjectStore('sessions', { keyPath: 'date' });
+                }
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    async function fileExists(url) {
+        try {
+            const response = await fetch(url, { method: 'HEAD' });
+            return response.ok;
+        } catch {
+            return false;
+        }
+    }
+
+    async function normalizeExercise(exercise) {
+        const id = String(exercise.exerciseId || exercise.id || exercise._id || exercise.uuid || '').trim();
+        if (!id) {
+            return null;
+        }
+
+        const rawEquipment = Array.isArray(exercise.equipments) && exercise.equipments.length
+            ? exercise.equipments[0]
+            : exercise.equipment;
+        const equipment = CFG.decodeEquipment(rawEquipment);
+
+        const rawTarget = Array.isArray(exercise.targetMuscles) && exercise.targetMuscles.length
+            ? exercise.targetMuscles[0]
+            : exercise.target;
+        const rawBody = Array.isArray(exercise.bodyParts) && exercise.bodyParts.length
+            ? exercise.bodyParts[0]
+            : exercise.bodyPart;
+        const muscle = CFG.muscleTranscode[String(rawTarget || '').toLowerCase()] || {};
+
+        let image = exercise.gifUrl || exercise.image || null;
+        if (image) {
+            try {
+                const fileName = image.split('/').pop();
+                const localPath = new URL(`data/media/${fileName}`, document.baseURI).href;
+                if (await fileExists(localPath)) {
+                    image = localPath;
+                }
+            } catch {
+                /* ignore */
+            }
+        }
+
+        return {
+            id,
+            name: exercise.name || exercise.exercise || id,
+            equipment: rawEquipment || null,
+            equipmentGroup1: equipment.g1 || null,
+            equipmentGroup2: equipment.g2 || null,
+            muscle: rawTarget || null,
+            muscleGroup1: muscle.g1 || null,
+            muscleGroup2: muscle.g2 || null,
+            muscleGroup3: muscle.g3 || null,
+            bodyPart: muscle.g1 || rawBody || null,
+            image,
+            secondaryMuscles: exercise.secondaryMuscles || [],
+            instructions: exercise.instructions || []
+        };
+    }
+
+    async function countStore(store) {
+        return count(store);
+    }
 
     return {
-		 id,
-		name: ex.name || ex.exercise || id,
-		// matières/equipements
-		equipment      : rawEquip || null,
-		equipmentGroup1: eq.g1    || null,
-		equipmentGroup2: eq.g2    || null,
-		// muscles
-		muscle      : rawTarget   || null,
-		muscleGroup1: mu.g1       || null,
-		muscleGroup2: mu.g2       || null,
-		muscleGroup3: mu.g3       || null,
-		// autres
-		bodyPart    : mu.g1 || null,
-		image,
-		secondaryMuscles: ex.secondaryMuscles || [],
-		instructions:ex.instructions || []
-	};
-  }
-
-	async function importExternalExercisesIfNeeded(){
-	  const count = await countStore('exercises');
-	  if (count > 0) return;
-
-	  try {
-		// construit l’URL à partir de la page courante (robuste avec /A0/)
-		const url = new URL('data/exercises.json', document.baseURI).href;
-		const res = await fetch(url, { cache: 'no-store' });
-		if (!res.ok) throw new Error('data/exercises.json introuvable');
-		const data = await res.json();
-
-		if (!Array.isArray(data)) {
-		  console.warn('exercises.json pas un tableau, import ignoré.');
-		  return;
-		}
-
-		const BATCH = 200;
-		for (let i=0; i<data.length; i+=BATCH){
-		  const slice = data.slice(i, i+BATCH);
-		  const rows = await Promise.all(slice.map(normalizeExercise));
-		  for (const ex of rows) if (ex) await put('exercises', ex);
-		}
-		console.log('Import exercises terminé.');
-	  } catch (e) {
-		console.warn('Import externe sauté :', e.message);
-	  }
-	}
-
-
-  // helper interne (évite collision avec fonction globale)
-  async function countStore(store){ return count(store); }
-
-  return {
-    init, get, put, getAll, count, del,
-    getSession, saveSession, listSessionDates,
-    getActivePlan,
-    importExternalExercisesIfNeeded
-  };
+        init,
+        get,
+        put,
+        getAll,
+        count,
+        del,
+        getSession,
+        saveSession,
+        listSessionDates,
+        getActivePlan,
+        importExternalExercisesIfNeeded
+    };
 })();

--- a/init.js
+++ b/init.js
@@ -1,138 +1,197 @@
 // init.js — bootstrap (seed, wiring, premiers rendus)
-(async function(){
-  const A = window.App;
+(() => {
+    const A = window.App;
 
-  // ---------- Helpers navigation écrans & onglets ----------
-  function showOnly(which){
-    const sSessions  = document.getElementById('screenSessions');
-    const sExercises = document.getElementById('screenExercises');
-    const sEdit      = document.getElementById('screenExerciseEdit');
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
 
-    if (sSessions)  sSessions.hidden  = (which !== 'sessions');
-    if (sExercises) sExercises.hidden = (which !== 'exercises');
-    if (sEdit)      sEdit.hidden      = (which !== 'edit'); // on n'ouvre l'éditeur que via openExerciseEdit
-  }
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        assertRefs();
+        wireNavigation();
+        wireCalendar();
+        wireRoutineSelection();
+        void bootstrap();
+    });
 
-  function setActiveTab(id){
-    document.querySelectorAll('.tabbar .tab').forEach(b=>b.classList.remove('active'));
-    const el = document.getElementById(id);
-    if (el) el.classList.add('active');
-  }
+    /* ACTIONS */
+    async function bootstrap() {
+        A.activeDate = A.today();
+        A.currentAnchor = new Date(A.activeDate);
+        A.calendarMonth = new Date(A.activeDate.getFullYear(), A.activeDate.getMonth(), 1);
 
-  // ---------- DOM refs ----------
-  A.el.todayLabel      = document.getElementById('todayLabel');
-  A.el.weekStrip       = document.getElementById('weekStrip');
-  A.el.sessionList     = document.getElementById('sessionList');
-  A.el.selectRoutine   = document.getElementById('selectRoutine');
-  A.el.btnAddRoutine   = document.getElementById('btnAddRoutine');
-  A.el.btnAddExercises = document.getElementById('btnAddExercises');
-  A.el.dlgCalendar     = document.getElementById('dlgCalendar');
-  A.el.bigCalendar     = document.getElementById('bigCalendar');
+        await db.init();
+        try {
+            await db.importExternalExercisesIfNeeded();
+        } catch (error) {
+            console.warn('Import exercices ignoré:', error);
+        }
+        await ensureSeed();
 
-  // ---------- État initial ----------
-  A.activeDate         = A.today();                               // sélection = aujourd’hui
-  A.currentAnchor      = new Date(A.activeDate);                  // ancre semaine
-  A.calendarMonth      = new Date(A.activeDate.getFullYear(), A.activeDate.getMonth(), 1);
+        setActiveTab('tabSessions');
+        showOnly('sessions');
+        await A.populateRoutineSelect();
+        await A.renderWeek();
+        await A.renderSession();
+    }
 
-  // ---------- Boutons calendrier ----------
-  const btnQuick = document.getElementById('btnQuickNav');
-  if (btnQuick) btnQuick.addEventListener('click', ()=>A.openCalendar());
+    function wireNavigation() {
+        const { tabLibraries, tabSessions, screenSessions, screenExercises, screenExerciseEdit } = refs;
 
-  const btnClose = document.getElementById('dlgClose');
-  if (btnClose) btnClose.addEventListener('click', ()=>A.el.dlgCalendar?.close());
+        tabLibraries?.addEventListener('click', async () => {
+            setActiveTab('tabLibraries');
+            showOnly('exercises');
+            await A.openExercises({ callerScreen: 'screenSessions' });
+        });
 
-  const calPrev = document.getElementById('calPrev');
-  if (calPrev) calPrev.addEventListener('click', async ()=>{
-    A.calendarMonth = new Date(A.calendarMonth.getFullYear(), A.calendarMonth.getMonth()-1, 1);
-    await A.openCalendar();
-  });
+        tabSessions?.addEventListener('click', async () => {
+            setActiveTab('tabSessions');
+            showOnly('sessions');
+            await A.populateRoutineSelect();
+            await A.renderWeek();
+            await A.renderSession();
+        });
 
-  const calNext = document.getElementById('calNext');
-  if (calNext) calNext.addEventListener('click', async ()=>{
-    A.calendarMonth = new Date(A.calendarMonth.getFullYear(), A.calendarMonth.getMonth()+1, 1);
-    await A.openCalendar();
-  });
+        screenSessions?.setAttribute('data-screen', 'sessions');
+        screenExercises?.setAttribute('data-screen', 'exercises');
+        screenExerciseEdit?.setAttribute('data-screen', 'edit');
+    }
 
-  // ---------- Initialisation de la base + seed ----------
-  // initialise la base
-  await db.init();        
-  
-  // importe si la base est vide  
-  try {
-    await db.importExternalExercisesIfNeeded(); // ✅ nouvelle forme exportée par db.js
-   } catch(e) {
-    console.warn('Import exercices ignoré:', e);
-   }
+    function wireCalendar() {
+        const { btnQuickNav, dlgClose, calPrev, calNext } = refs;
 
-  // Seed
-  await ensureSeed();
+        btnQuickNav?.addEventListener('click', () => A.openCalendar());
+        dlgClose?.addEventListener('click', () => refs.dlgCalendar?.close());
 
-  // ---------- Premier rendu (écran Séances par défaut) ----------
-  setActiveTab('tabSessions');
-  showOnly('sessions');
-  await A.populateRoutineSelect();
-  await A.renderWeek();
-  await A.renderSession();
+        calPrev?.addEventListener('click', async () => {
+            A.calendarMonth = new Date(A.calendarMonth.getFullYear(), A.calendarMonth.getMonth() - 1, 1);
+            await A.openCalendar();
+        });
+        calNext?.addEventListener('click', async () => {
+            A.calendarMonth = new Date(A.calendarMonth.getFullYear(), A.calendarMonth.getMonth() + 1, 1);
+            await A.openCalendar();
+        });
+    }
 
-  // ---------- Onglets ----------
-  const tabLibraries = document.getElementById('tabLibraries');
-  if (tabLibraries) tabLibraries.addEventListener('click', async ()=>{
-    setActiveTab('tabLibraries');
-    showOnly('exercises');
-    await App.openExercises();     // défini dans ui-exercises.js
-  });
+    function wireRoutineSelection() {
+        const { btnAddRoutine, selectRoutine } = refs;
+        btnAddRoutine?.addEventListener('click', async () => {
+            const id = selectRoutine?.value;
+            if (id) {
+                await A.addRoutineToSession(id);
+            }
+        });
+    }
 
-  const tabSessions = document.getElementById('tabSessions');
-  if (tabSessions) tabSessions.addEventListener('click', async ()=>{
-    setActiveTab('tabSessions');
-    showOnly('sessions');
-    await App.populateRoutineSelect();
-    await App.renderWeek();
-    await App.renderSession();
-  });
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
 
-  // ---------- Actions (2 lignes d’ajout) ----------
-  A.el.btnAddRoutine?.addEventListener('click', async ()=>{
-    const id = A.el.selectRoutine?.value;
-    if (id) await A.addRoutineToSession(id);
-  });
+        refs.todayLabel = document.getElementById('todayLabel');
+        refs.weekStrip = document.getElementById('weekStrip');
+        refs.sessionList = document.getElementById('sessionList');
+        refs.selectRoutine = document.getElementById('selectRoutine');
+        refs.btnAddRoutine = document.getElementById('btnAddRoutine');
+        refs.btnAddExercises = document.getElementById('btnAddExercises');
+        refs.dlgCalendar = document.getElementById('dlgCalendar');
+        refs.bigCalendar = document.getElementById('bigCalendar');
+        refs.btnQuickNav = document.getElementById('btnQuickNav');
+        refs.dlgClose = document.getElementById('dlgClose');
+        refs.calPrev = document.getElementById('calPrev');
+        refs.calNext = document.getElementById('calNext');
+        refs.tabLibraries = document.getElementById('tabLibraries');
+        refs.tabSessions = document.getElementById('tabSessions');
+        refs.screenSessions = document.getElementById('screenSessions');
+        refs.screenExercises = document.getElementById('screenExercises');
+        refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refsResolved = true;
+        return refs;
+    }
 
-  // ---------- Seed minimal ----------
- // ---------- Seed minimal ----------
-	async function ensureSeed(){
-	  const roCount = await db.count('routines');
-	  const plCount = await db.count('plans');
+    function assertRefs() {
+        const required = [
+            'todayLabel',
+            'weekStrip',
+            'sessionList',
+            'selectRoutine',
+            'btnAddRoutine',
+            'dlgCalendar',
+            'bigCalendar',
+            'tabLibraries',
+            'tabSessions'
+        ];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`init.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
+    }
 
-	  // S'assure que 3 exos "seed" existent (si absents) pour que les routines puissent pointer quelque chose.
-	  async function ensureExercise(id, name, targetKey, equipmentKey){
-		const exists = await db.get('exercises', id);
-		if (exists) return;
+    function setActiveTab(id) {
+        document.querySelectorAll('.tabbar .tab').forEach((button) => button.classList.remove('active'));
+        const element = document.getElementById(id);
+        if (element) {
+            element.classList.add('active');
+        }
+    }
 
-		// Décodage via CFG (les clés sont en lowercase : target "chest", "lats", "quads"...)
-		const mu = CFG.decodeMuscle(targetKey);
-		const eq = CFG.decodeEquipment(equipmentKey);
+    function showOnly(which) {
+        const { screenSessions, screenExercises, screenExerciseEdit } = refs;
+        if (screenSessions) {
+            screenSessions.hidden = which !== 'sessions';
+        }
+        if (screenExercises) {
+            screenExercises.hidden = which !== 'exercises';
+        }
+        if (screenExerciseEdit) {
+            screenExerciseEdit.hidden = which !== 'edit';
+        }
+    }
 
-		await db.put('exercises', {
-		  id,
-		  name,
-		  equipment: equipmentKey,
-		  equipmentGroup1: eq.g1,
-		  equipmentGroup2: eq.g2,
-		  muscle: mu.muscle,
-		  muscleGroup1: mu.g1,
-		  muscleGroup2: mu.g2,
-		  muscleGroup3: mu.g3,
-		  target: targetKey,
-		  bodyPart: null,
-		  image: null
-		});
-	  }
+    async function ensureSeed() {
+        const routineCount = await db.count('routines');
+        const planCount = await db.count('plans');
 
-	  // Plan actif
-	  if (!plCount) {
-		await db.put('plans', { id:'active', name:'Plan par défaut', days:{ 1:'r_push', 4:'r_pull' }, active:true });
-	  }
-	}
+        async function ensureExercise(id, name, targetKey, equipmentKey) {
+            const exists = await db.get('exercises', id);
+            if (exists) {
+                return;
+            }
+            const muscle = CFG.decodeMuscle(targetKey);
+            const equipment = CFG.decodeEquipment(equipmentKey);
+            await db.put('exercises', {
+                id,
+                name,
+                equipment: equipmentKey,
+                equipmentGroup1: equipment.g1,
+                equipmentGroup2: equipment.g2,
+                muscle: muscle.muscle,
+                muscleGroup1: muscle.g1,
+                muscleGroup2: muscle.g2,
+                muscleGroup3: muscle.g3,
+                target: targetKey,
+                bodyPart: null,
+                image: null
+            });
+        }
 
-  
+        if (!routineCount) {
+            await ensureExercise('push_up', 'Pompes', 'chest', 'body weight');
+            await ensureExercise('pull_up', 'Tractions', 'lats', 'body weight');
+            await ensureExercise('squat', 'Squat', 'quads', 'barbell');
+        }
+
+        if (!planCount) {
+            await db.put('plans', {
+                id: 'active',
+                name: 'Plan par défaut',
+                days: { 1: 'r_push', 4: 'r_pull' },
+                active: true
+            });
+        }
+    }
 })();

--- a/state.js
+++ b/state.js
@@ -1,20 +1,58 @@
-// state.js — constantes, utilitaires, état global
+(() => {
+    const existing = window.App || {};
 
-window.App = {
-  EMPHASIS: '#0f62fe', // couleur d’emphase (sélection)
+    /* STATE */
+    existing.EMPHASIS = '#0f62fe';
+    existing.el = existing.el || {};
+    existing.activeDate = null;
+    existing.currentAnchor = null;
+    existing.plannedRoutineName = null;
+    existing.calendarMonth = null;
 
-  // Utils dates
-  fmtUI(d) { return d.toLocaleDateString('fr-FR', { day:'numeric', month:'short', year:'2-digit' }).replace('.', ''); },
-  ymd(d)   { return d.toISOString().slice(0,10); },
-  today()  { return new Date(new Date().toDateString()); }, // strip heure
-  addDays(d, n){ const x=new Date(d); x.setDate(x.getDate()+n); return x; },
+    /* WIRE */
 
-  // DOM refs (remplis dans init.js)
-  el: {},
+    /* ACTIONS */
 
-  // État runtime
-  activeDate: null,        // sélection courante (Date)
-  currentAnchor: null,     // ancre semaine (Date)
-  plannedRoutineName: null, // nom de la routine prévue du jour
-  calendarMonth: null      // date du 1er mois affiché dans la modale
-};
+    /* UTILS */
+    /**
+     * Formatte une date pour l'interface utilisateur.
+     * @param {Date} date Date à afficher.
+     * @returns {string} Représentation localisée.
+     */
+    existing.fmtUI = function fmtUI(date) {
+        return date
+            .toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: '2-digit' })
+            .replace('.', '');
+    };
+
+    /**
+     * Retourne la clé ISO YYYY-MM-DD.
+     * @param {Date} date Date source.
+     * @returns {string} Clé normalisée.
+     */
+    existing.ymd = function ymd(date) {
+        return date.toISOString().slice(0, 10);
+    };
+
+    /**
+     * Retourne la date du jour sans composante horaire.
+     * @returns {Date} Date du jour.
+     */
+    existing.today = function today() {
+        return new Date(new Date().toDateString());
+    };
+
+    /**
+     * Ajoute un nombre de jours à une date.
+     * @param {Date} date Date de base.
+     * @param {number} delta Nombre de jours à ajouter.
+     * @returns {Date} Nouvelle date.
+     */
+    existing.addDays = function addDays(date, delta) {
+        const next = new Date(date);
+        next.setDate(next.getDate() + delta);
+        return next;
+    };
+
+    window.App = existing;
+})();

--- a/style.css
+++ b/style.css
@@ -205,7 +205,32 @@ image_big{
   border-radius: var(--radius);
   padding: var(--pad-y) var(--pad-x);
 }
+.exercise-card-row{ display:flex; align-items:center; justify-content:space-between; gap:var(--gap); }
+.exercise-card-left{ display:flex; align-items:center; gap:10px; }
+.exercise-card-text{ display:flex; flex-direction:column; gap:2px; }
+.exercise-card-thumb{
+  width:40px;
+  height:40px;
+  border-radius:8px;
+  object-fit:cover;
+  background:#eee;
+  flex-shrink:0;
+}
+.exercise-card.selected{
+  border-color: var(--emphase);
+  box-shadow:0 0 0 2px rgba(0,128,255,0.2);
+}
 .exercise-card.clickable{ cursor:pointer; user-select:none; }
+.exercise-thumb-placeholder{ object-fit:contain; }
+.exercise-selection-bar{
+  position:sticky;
+  top:0;
+  z-index:10;
+  padding:8px 0;
+  background:var(--white);
+}
+.exercise-selection-bar.hidden{ display:none; }
+.exercise-hero-placeholder{ object-fit:contain; background:var(--lightGray); }
 
 
 /* =========================================================

--- a/ui-calendar.js
+++ b/ui-calendar.js
@@ -1,99 +1,137 @@
 // ui-calendar.js — modale "Calendrier" (navigation mois + swipe)
+(() => {
+    const A = window.App;
 
-(function () {
-  const A = window.App;
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
 
-  A.openCalendar = async function openCalendar() {
-    const dlg = A.el.dlgCalendar;
-    const big = A.el.bigCalendar;
-    big.innerHTML = "";
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', ensureRefs);
 
-    // Mois affiché (ancre)
-    const base =
-      A.calendarMonth ||
-      new Date(A.activeDate.getFullYear(), A.activeDate.getMonth(), 1);
-    const year = base.getFullYear();
-    const month = base.getMonth();
+    /* ACTIONS */
+    /**
+     * Ouvre la modale calendrier et rend les jours du mois courant.
+     * @returns {Promise<void>} Promesse résolue après rendu.
+     */
+    A.openCalendar = async function openCalendar() {
+        const { dlgCalendar, bigCalendar, calTitle } = assertRefs();
+        bigCalendar.innerHTML = '';
 
-    // Titre "mois année"
-    const titleEl = document.getElementById("calTitle");
-    if (titleEl) {
-      titleEl.textContent = base.toLocaleDateString("fr-FR", {
-        month: "long",
-        year: "numeric",
-      });
+        const base =
+            A.calendarMonth || new Date(A.activeDate.getFullYear(), A.activeDate.getMonth(), 1);
+        const year = base.getFullYear();
+        const month = base.getMonth();
+
+        if (calTitle) {
+            calTitle.textContent = base.toLocaleDateString('fr-FR', {
+                month: 'long',
+                year: 'numeric'
+            });
+        }
+
+        const today = A.today();
+        const first = new Date(year, month, 1);
+        const startIndex = (first.getDay() + 6) % 7;
+        const sessionDates = new Set((await db.listSessionDates()).map((item) => item.date));
+
+        const grid = document.createElement('div');
+        grid.className = 'month-grid';
+
+        ['L', 'M', 'M', 'J', 'V', 'S', 'D'].forEach((label) => {
+            const header = document.createElement('div');
+            header.className = 'dow';
+            header.textContent = label;
+            grid.appendChild(header);
+        });
+
+        for (let index = 0; index < startIndex; index += 1) {
+            grid.appendChild(document.createElement('div'));
+        }
+
+        const lastDay = new Date(year, month + 1, 0).getDate();
+        for (let day = 1; day <= lastDay; day += 1) {
+            const date = new Date(year, month, day);
+            const key = A.ymd(date);
+            const isSelected = A.ymd(date) === A.ymd(A.activeDate);
+            const hasSession = sessionDates.has(key);
+            const planned = await isPlannedDate(date);
+            const isFuture = date >= today;
+
+            const cell = document.createElement('button');
+            cell.className = 'day-cell';
+            cell.textContent = String(day);
+
+            if (hasSession) {
+                cell.classList.add('has-session');
+            } else if (planned && isFuture) {
+                cell.classList.add('planned');
+            }
+            if (isSelected) {
+                cell.classList.add('selected');
+            }
+
+            cell.addEventListener('click', async () => {
+                A.activeDate = date;
+                A.currentAnchor = date;
+                await A.populateRoutineSelect();
+                await A.renderWeek();
+                await A.renderSession();
+                dlgCalendar.close();
+            });
+
+            grid.appendChild(cell);
+        }
+
+        bigCalendar.appendChild(grid);
+        dlgCalendar.showModal();
+
+        let touchStartX = null;
+        bigCalendar.ontouchstart = (event) => {
+            touchStartX = event.touches[0].clientX;
+        };
+        bigCalendar.ontouchend = async (event) => {
+            if (touchStartX == null) {
+                return;
+            }
+            const delta = event.changedTouches[0].clientX - touchStartX;
+            touchStartX = null;
+            if (Math.abs(delta) < 40) {
+                return;
+            }
+            A.calendarMonth = new Date(year, month + (delta < 0 ? 1 : -1), 1);
+            await A.openCalendar();
+        };
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.dlgCalendar = document.getElementById('dlgCalendar');
+        refs.bigCalendar = document.getElementById('bigCalendar');
+        refs.calTitle = document.getElementById('calTitle');
+        refsResolved = true;
+        return refs;
     }
 
-    const tdy = A.today();
-    const first = new Date(year, month, 1);
-    const startIdx = (first.getDay() + 6) % 7; // lundi=0
-
-    const sessDates = new Set((await db.listSessionDates()).map((x) => x.date));
-
-    const grid = document.createElement("div");
-    grid.className = "month-grid";
-
-    // En-têtes
-    ["L", "M", "M", "J", "V", "S", "D"].forEach((lbl) => {
-      const h = document.createElement("div");
-      h.className = "dow";
-      h.textContent = lbl;
-      grid.appendChild(h);
-    });
-
-    for (let i = 0; i < startIdx; i++) grid.appendChild(document.createElement("div"));
-
-    const lastDay = new Date(year, month + 1, 0).getDate();
-    for (let d = 1; d <= lastDay; d++) {
-      const dt = new Date(year, month, d);
-      const key = A.ymd(dt);
-      const isSelected = A.ymd(dt) === A.ymd(A.activeDate);
-      const hasSession = sessDates.has(key);
-      const planned = await isPlannedDate(dt);
-      const isFuture = dt >= tdy;
-
-      const cell = document.createElement("button");
-      cell.className = "day-cell";
-      cell.textContent = d;
-
-      if (hasSession) cell.classList.add("has-session");
-      else if (planned && isFuture) cell.classList.add("planned");
-      if (isSelected) cell.classList.add("selected");
-
-      cell.addEventListener("click", async () => {
-        A.activeDate = dt;
-        A.currentAnchor = dt; // recale la barre semaine sur la date choisie
-        await A.populateRoutineSelect();
-        await A.renderWeek();
-        await A.renderSession();
-        dlg.close();
-      });
-
-      grid.appendChild(cell);
+    function assertRefs() {
+        ensureRefs();
+        const required = ['dlgCalendar', 'bigCalendar'];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-calendar.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
     }
 
-    big.appendChild(grid);
-    dlg.showModal();
-
-    // Swipe gauche/droite pour changer de mois
-    let x0 = null;
-    big.ontouchstart = (e) => {
-      x0 = e.touches[0].clientX;
-    };
-    big.ontouchend = async (e) => {
-      if (x0 == null) return;
-      const dx = e.changedTouches[0].clientX - x0;
-      x0 = null;
-      if (Math.abs(dx) < 40) return;
-      A.calendarMonth = new Date(year, month + (dx < 0 ? +1 : -1), 1);
-      await A.openCalendar();
-    };
-  };
-
-  async function isPlannedDate(d) {
-    const plan = await db.getActivePlan();
-    if (!plan) return false;
-    const wd = ((d.getDay() + 6) % 7) + 1; // 1=lundi..7=dimanche
-    return Boolean(plan.days[String(wd)]);
-  }
+    async function isPlannedDate(date) {
+        const plan = await db.getActivePlan();
+        if (!plan) {
+            return false;
+        }
+        const weekday = ((date.getDay() + 6) % 7) + 1;
+        return Boolean(plan.days[String(weekday)]);
+    }
 })();

--- a/ui-exec-edit.js
+++ b/ui-exec-edit.js
@@ -1,334 +1,475 @@
 // ui-exec-edit.js — 3.4.2 (Colonne A) : édition + timer, sans bouton "Enregistrer"
-// - Lignes cliquables pour éditer
-// - Reps/Poids: stepper vertical (+ au-dessus / − au-dessous)
-// - Bouton bas unique "Repos" <-> "Reprendre une série"
-// - Timer en bas (pause/play, -10s / affichage / +10s), visible uniquement pendant le repos
+(() => {
+    const A = window.App;
 
-(function(){
-  const A = window.App;
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
+    let execCtx = { dateKey: null, exerciseId: null, exerciseName: '', callerScreen: 'screenSessions' };
+    let execTimer = { running: false, startSec: 0, remainSec: 0, intervalId: null };
 
-  // Contexte courant
-  A.execCtx = { dateKey:null, exerciseId:null, exerciseName:'' };
+    A.execCtx = execCtx;
+    A.execTimer = execTimer;
 
-  // État du timer
-  A.execTimer = { running:false, startSec:0, remainSec:0, iv:null };
-
-  // -------- Ouvrir l’éditeur --------
-  A.openExecEdit = async function(exerciseId){
-    const key = A.ymd(A.activeDate);
-    const s = await db.getSession(key);
-    if (!s) return alert('Aucune séance pour cette date.');
-    const ex = s.exercises.find(e => e.exerciseId === exerciseId);
-    if (!ex) return alert('Exercice introuvable dans la séance.');
-
-    // normaliser sets
-    ex.sets = (ex.sets||[]).map((x,i)=>({
-      pos: x.pos ?? (i+1),
-      done: !!x.done,
-      reps: x.reps ?? null,
-      weight: x.weight ?? null,
-      rpe: x.rpe ?? null,
-      rest: x.rest ?? 90
-    }));
-
-    A.execCtx = { dateKey:key, exerciseId, exerciseName: ex.exerciseName||'' };
-
-    // entête
-    document.getElementById('execTitle').textContent = ex.exerciseName || 'Exercice';
-    document.getElementById('execDate').textContent  = A.fmtUI(A.activeDate);
-
-    await renderColumnA();
-
-    // afficher écran
-    document.getElementById('screenSessions').hidden = true;
-    document.getElementById('screenExercises').hidden = true;
-    document.getElementById('screenExerciseEdit').hidden = true;
-    document.getElementById('screenExecEdit').hidden = false;
-  };
-
-  // -------- Rendu Colonne A --------
-  async function renderColumnA(editPos=null){
-    const s  = await db.getSession(A.execCtx.dateKey);
-    const ex = s?.exercises.find(e=>e.exerciseId===A.execCtx.exerciseId);
-    if (!ex) return;
-
-    const wrapExec = document.getElementById('execExecuted');
-    const wrapEdit = document.getElementById('execEditable');
-    wrapExec.innerHTML = '';
-    wrapEdit.innerHTML = '';
-
-    // 1) Lignes lues (cliquables pour éditer)
-    for (const it of ex.sets) {
-      if (editPos===it.pos) {
-        wrapEdit.appendChild(rowEditable(it, false));
-      } else {
-        const row = rowReadOnly(it);
-        row.addEventListener('click', ()=> renderColumnA(it.pos)); // éditer en cliquant
-        wrapExec.appendChild(row);
-      }
-    }
-
-    // 2) Si aucune ligne en édition ET il reste des prévues, éditer la première prévue
-    if (!wrapEdit.children.length) {
-      const firstPlanned = ex.sets.find(x=>x.done!==true);
-      if (firstPlanned) wrapEdit.appendChild(rowEditable(firstPlanned, false));
-    }
-
-    // 3) Bouton bas : Repos <-> Reprendre une série
-    const restBtn = document.getElementById('execRestToggle');
-    restBtn.onclick = async ()=>{
-      const timerVisible = !document.getElementById('execTimerBar').hidden;
-
-      if (!timerVisible) {
-        // --- REPOS ---
-        // Sauver la série en cours (ligne éditable) comme done:true
-        const holder = document.querySelector('#execEditable .js-edit-holder');
-        if (!holder || !holder._collect) return alert('Renseigne la série avant le repos.');
-        const payload = JSON.parse(holder.dataset.payload || '{}');
-        const val = holder._collect();
-
-        const s1 = await db.getSession(A.execCtx.dateKey);
-        const ex1 = s1.exercises.find(e => e.exerciseId===A.execCtx.exerciseId);
-        if (payload.isNew) {
-          ex1.sets.push({ pos: ex1.sets.length+1, ...val, done:true });
-        } else {
-          const idx = ex1.sets.findIndex(x=>x.pos===payload.pos);
-          if (idx>=0) ex1.sets[idx] = { ...ex1.sets[idx], ...val, done:true };
-        }
-        await db.saveSession(s1);
-        await renderColumnA(); // repasser en lecture seule
-
-        // Démarrer le timer à partir de ce "rest"
-        startTimer(val.rest);
-        restBtn.textContent = 'Reprendre une série';
-      } else {
-        // --- REPRENDRE UNE SÉRIE ---
-        // Stopper & masquer le timer, et ENREGISTRER LE TEMPS RESTANT dans la DERNIÈRE série
-        const remaining = A.execTimer.remainSec; // demande: "enregistrer le temps restant"
-        const s2 = await db.getSession(A.execCtx.dateKey);
-        const ex2 = s2.exercises.find(e => e.exerciseId===A.execCtx.exerciseId);
-        if (ex2 && ex2.sets.length) {
-          const last = ex2.sets[ex2.sets.length-1];
-          last.rest = Math.max(0, remaining);
-          await db.saveSession(s2);
-          await renderColumnA();
-        }
-        stopTimer();
-        updateTimerUI(); // cache la barre
-        restBtn.textContent = 'Repos';
-
-        // Créer une nouvelle ligne vide en édition
-        const s3  = await db.getSession(A.execCtx.dateKey);
-        const ex3 = s3.exercises.find(e=>e.exerciseId===A.execCtx.exerciseId);
-        const nextPos = (ex3?.sets.length || 0) + 1;
-        wrapEdit.innerHTML = '';
-        wrapEdit.appendChild(rowEditable(defaultNewSet(nextPos), true));
-      }
-    };
-
-    // 4) Bouton OK (valider ce qui est en cours puis retour Séances)
-    document.getElementById('execOk').onclick = async ()=>{
-      const holder = document.querySelector('#execEditable .js-edit-holder');
-      if (holder && holder._collect) {
-        const payload = JSON.parse(holder.dataset.payload || '{}');
-        const val = holder._collect();
-
-        const s4 = await db.getSession(A.execCtx.dateKey);
-        const ex4 = s4.exercises.find(e => e.exerciseId===A.execCtx.exerciseId);
-        if (payload.isNew) {
-          ex4.sets.push({ pos: ex4.sets.length+1, ...val, done:true });
-        } else {
-          const idx = ex4.sets.findIndex(x=>x.pos===payload.pos);
-          if (idx>=0) ex4.sets[idx] = { ...ex4.sets[idx], ...val, done:true };
-        }
-        await db.saveSession(s4);
-      }
-      backToSessions();
-    };
-
-    // 5) Barre timer : masquée tant que non lancée
-    updateTimerUI();
-  }
-
-  // -------- Lignes --------
-  function rowReadOnly(it){
-    const r = document.createElement('div');
-    r.className = 'exec-grid exec-row';
-    r.innerHTML = `
-      <div class="details">${safeInt(it.reps)}</div>
-      <div class="details">${safeInt(it.weight)} kg</div>
-      <div class="details">${rpeChip(it.rpe)}</div>
-      <div class="details">${fmtTime(safeInt(it.rest))}</div>
-      <div></div>
-    `;
-    return r;
-  }
-
-  function rowEditable(it, isNew){
-    const r = document.createElement('div');
-    r.className = 'exec-grid exec-row';
-
-    // Stepper VERTICAUX
-    const reps   = vStepper(safeInt(it.reps),   0, 100);
-    const weight = vStepper(safeInt(it.weight), 0, 999);
-
-    // RPE (5..10)
-    const rpeWrap = document.createElement('div');
-    const rpe = document.createElement('input');
-    rpe.type='number'; rpe.className='input'; rpe.min='5'; rpe.max='10'; rpe.inputMode='numeric';
-    rpe.value = it.rpe==null ? '' : String(it.rpe);
-    rpe.oninput = ()=>{ rpeWrap.dataset.rpe = clampInt(rpe.value,5,10) || ''; };
-    rpeWrap.appendChild(rpe); rpeWrap.className='rpe-wrap';
-
-    // Repos (mm:ss)
-    const rest = document.createElement('input');
-    rest.type='text'; rest.className='input'; rest.placeholder='mm:ss';
-    rest.value = fmtTime(safeInt(it.rest)); rest.pattern='^\\d{1,2}:\\d{2}$';
-
-    // Pas de bouton "Enregistrer" ici — piloté par Repos/Reprendre
-    const holder = document.createElement('div');
-    holder.className = 'js-edit-holder';
-    holder.dataset.payload = JSON.stringify({ pos: it.pos, isNew });
-    holder._collect = ()=>({
-      reps: parseInt(reps.input.value||'0',10),
-      weight: parseInt(weight.input.value||'0',10),
-      rpe: rpe.value ? parseInt(rpe.value,10) : null,
-      rest: parseTime(rest.value)
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        wireNavigation();
+        wireTimerControls();
     });
 
-    r.append(reps.el, weight.el, rpeWrap, rest, holder);
-    return r;
-  }
+    /* ACTIONS */
+    /**
+     * Ouvre l'éditeur d'exécution pour l'exercice courant.
+     * @param {{currentId: string, callerScreen?: string}} [options] Informations de contexte.
+     * @returns {Promise<void>} Promesse résolue après affichage.
+     */
+    A.openExecEdit = async function openExecEdit(options = {}) {
+        const { currentId, callerScreen = 'screenSessions' } = options;
+        if (!currentId) {
+            return;
+        }
 
-  function defaultNewSet(pos){
-    return { pos, reps:8, weight:0, rpe:null, rest:90, done:false };
-  }
+        const dateKey = A.ymd(A.activeDate);
+        const session = await db.getSession(dateKey);
+        if (!session) {
+            alert('Aucune séance pour cette date.');
+            return;
+        }
+        const exercise = session.exercises.find((item) => item.exerciseId === currentId);
+        if (!exercise) {
+            alert('Exercice introuvable dans la séance.');
+            return;
+        }
 
-  // -------- Helpers UI --------
-  // Stepper vertical (+ au-dessus, − en dessous)
-  function vStepper(val, min, max){
-    const wrap = document.createElement('div'); wrap.className='vstepper';
-    const plus  = document.createElement('button'); plus.className='btn'; plus.textContent='+';
-    const input = document.createElement('input'); input.type='number'; input.className='input'; input.inputMode='numeric'; input.value=String(val); input.min=String(min); input.max=String(max);
-    const minus = document.createElement('button'); minus.className='btn'; minus.textContent='−';
-    plus.onclick  = ()=>{ input.value = String(Math.min(max, (parseInt(input.value||'0',10)+1))); };
-    minus.onclick = ()=>{ input.value = String(Math.max(min, (parseInt(input.value||'0',10)-1))); };
-    wrap.append(plus, input, minus);
-    return { el:wrap, input };
-  }
+        exercise.sets = (exercise.sets || []).map((set, index) => ({
+            pos: set.pos ?? index + 1,
+            done: Boolean(set.done),
+            reps: set.reps ?? null,
+            weight: set.weight ?? null,
+            rpe: set.rpe ?? null,
+            rest: set.rest ?? 90
+        }));
 
-  function rpeChip(v){
-    if (v==null || v==='') return '—';
-    const c = getRpeClass(v);
-    return `<span class="rpe-chip ${c}">${v}</span>`;
-  }
-  function getRpeClass(v){
-    const n = parseInt(v,10);
-    if (n<=5) return 'rpe-5';
-    if (n===6) return 'rpe-6';
-    if (n===7) return 'rpe-7';
-    if (n===8) return 'rpe-8';
-    if (n===9) return 'rpe-9';
-    return 'rpe-10';
-  }
+        execCtx = {
+            dateKey,
+            exerciseId: currentId,
+            exerciseName: exercise.exerciseName || '',
+            callerScreen
+        };
+        A.execCtx = execCtx;
 
-  function safeInt(v){ return Number.isFinite(v) ? v : 0; }
-  function clampInt(v, min, max){
-    const n = parseInt(v,10); if (Number.isNaN(n)) return null;
-    return Math.max(min, Math.min(max, n));
-  }
-  function fmtTime(sec){
-    sec = parseInt(sec||0,10);
-    const m = Math.floor(Math.abs(sec)/60), s = Math.abs(sec)%60;
-    const sign = sec<0 ? '-' : '';
-    return `${sign}${m}:${String(s).padStart(2,'0')}`;
-  }
-  function parseTime(str){
-    const m = /^(\d{1,2}):(\d{2})$/.exec(String(str||''));
-    if (!m) return 0;
-    return parseInt(m[1],10)*60 + parseInt(m[2],10);
-  }
+        execTimer = { running: false, startSec: 0, remainSec: 0, intervalId: null };
+        A.execTimer = execTimer;
 
-  // -------- Timer --------
-  function startTimer(startSec){
-    const bar = document.getElementById('execTimerBar');
-    A.execTimer.startSec  = startSec || 0;
-    A.execTimer.remainSec = startSec || 0;
-    A.execTimer.running   = true;
-    bar.hidden = false;
-    runTick();
-    if (A.execTimer.iv) clearInterval(A.execTimer.iv);
-    A.execTimer.iv = setInterval(runTick, 1000);
-    updateTimerUI();
-  }
-  function pauseTimer(){ A.execTimer.running = false; updateTimerUI(); }
-  function resumeTimer(){ A.execTimer.running = true;  updateTimerUI(); }
-  function stopTimer(){ if (A.execTimer.iv) clearInterval(A.execTimer.iv); A.execTimer.iv=null; A.execTimer.running=false; }
+        const { execTitle, execDate } = assertRefs();
+        execTitle.textContent = exercise.exerciseName || 'Exercice';
+        execDate.textContent = A.fmtUI(A.activeDate);
 
-  function runTick(){
-    if (!A.execTimer.running) return;
-    A.execTimer.remainSec -= 1;
-    updateTimerUI();
-    if (A.execTimer.remainSec === 0) {
-      if (navigator.vibrate) { try { navigator.vibrate(200); } catch{} }
+        await renderColumnA();
+        switchScreen('screenExecEdit');
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.screenSessions = document.getElementById('screenSessions');
+        refs.screenExercises = document.getElementById('screenExercises');
+        refs.screenExerciseRead = document.getElementById('screenExerciseRead');
+        refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.execTitle = document.getElementById('execTitle');
+        refs.execDate = document.getElementById('execDate');
+        refs.execExecuted = document.getElementById('execExecuted');
+        refs.execEditable = document.getElementById('execEditable');
+        refs.execRestToggle = document.getElementById('execRestToggle');
+        refs.execOk = document.getElementById('execOk');
+        refs.execBack = document.getElementById('execBack');
+        refs.execTimerBar = document.getElementById('execTimerBar');
+        refs.timerDisplay = document.getElementById('tmrDisplay');
+        refs.timerToggle = document.getElementById('tmrToggle');
+        refs.timerMinus = document.getElementById('tmrMinus');
+        refs.timerPlus = document.getElementById('tmrPlus');
+        refsResolved = true;
+        return refs;
     }
-  }
 
-  async function adjustTimer(delta){
-    // delta en secondes (+/-10)
-    A.execTimer.startSec  += delta;
-    A.execTimer.remainSec += delta;
-
-    // Et on ajuste le "rest" de la dernière série (en repos)
-    const s  = await db.getSession(A.execCtx.dateKey);
-    const ex = s.exercises.find(e=>e.exerciseId===A.execCtx.exerciseId);
-    if (ex && ex.sets.length){
-      const last = ex.sets[ex.sets.length-1];
-      last.rest = Math.max(0, (last.rest||0) + delta);
-      await db.saveSession(s);
-      await renderColumnA(); // refléter le nouveau repos
+    function assertRefs() {
+        ensureRefs();
+        const required = [
+            'screenSessions',
+            'screenExecEdit',
+            'execTitle',
+            'execDate',
+            'execExecuted',
+            'execEditable',
+            'execRestToggle',
+            'execOk',
+            'execTimerBar',
+            'timerDisplay',
+            'timerToggle',
+            'timerMinus',
+            'timerPlus'
+        ];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-exec-edit.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
     }
-    updateTimerUI();
-  }
 
-  function updateTimerUI(){
-    const bar = document.getElementById('execTimerBar');
-    const disp= document.getElementById('tmrDisplay');
-    const tgl = document.getElementById('tmrToggle');
-    if (!bar) return;
+    async function renderColumnA(editPos = null) {
+        const { execExecuted, execEditable, execRestToggle, execOk } = assertRefs();
+        const session = await db.getSession(execCtx.dateKey);
+        const exercise = session?.exercises.find((item) => item.exerciseId === execCtx.exerciseId);
+        if (!exercise) {
+            return;
+        }
 
-    // La barre n'apparaît que pendant un repos (sinon cachée)
-    if (!A.execTimer.iv && !A.execTimer.running && A.execTimer.startSec===0){
-      bar.hidden = true;
-      return;
+        execExecuted.innerHTML = '';
+        execEditable.innerHTML = '';
+
+        exercise.sets.forEach((set) => {
+            if (editPos === set.pos) {
+                execEditable.appendChild(rowEditable(set, false));
+            } else {
+                const row = rowReadOnly(set);
+                row.addEventListener('click', () => {
+                    void renderColumnA(set.pos);
+                });
+                execExecuted.appendChild(row);
+            }
+        });
+
+        if (!execEditable.children.length) {
+            const firstPlanned = exercise.sets.find((set) => set.done !== true);
+            if (firstPlanned) {
+                execEditable.appendChild(rowEditable(firstPlanned, false));
+            }
+        }
+
+        execRestToggle.onclick = async () => {
+            const timerVisible = !refs.execTimerBar.hidden;
+            const holder = execEditable.querySelector('.js-edit-holder');
+            if (!holder || !holder._collect) {
+                alert('Renseigne la série avant le repos.');
+                return;
+            }
+            const payload = JSON.parse(holder.dataset.payload || '{}');
+            const value = holder._collect();
+
+            if (!timerVisible) {
+                await saveSet(payload, value, true);
+                startTimer(value.rest);
+                execRestToggle.textContent = 'Reprendre une série';
+            } else {
+                const remaining = execTimer.remainSec;
+                await saveRemainingRest(remaining);
+                stopTimer();
+                updateTimerUI();
+                execRestToggle.textContent = 'Repos';
+                const sessionAfter = await db.getSession(execCtx.dateKey);
+                const exerciseAfter = sessionAfter.exercises.find((item) => item.exerciseId === execCtx.exerciseId);
+                const nextPos = (exerciseAfter?.sets.length || 0) + 1;
+                execEditable.innerHTML = '';
+                execEditable.appendChild(rowEditable(defaultNewSet(nextPos), true));
+            }
+        };
+
+        execOk.onclick = async () => {
+            const holder = execEditable.querySelector('.js-edit-holder');
+            if (holder && holder._collect) {
+                const payload = JSON.parse(holder.dataset.payload || '{}');
+                const value = holder._collect();
+                await saveSet(payload, value, true);
+            }
+            backToCaller();
+        };
+
+        updateTimerUI();
+        execRestToggle.textContent = refs.execTimerBar?.hidden ? 'Repos' : 'Reprendre une série';
     }
-    bar.hidden = false;
 
-    const t = A.execTimer.remainSec;
-    const sign = t<0 ? '-' : '';
-    const abs = Math.abs(t);
-    const m = Math.floor(abs/60), s = abs%60;
-    disp.textContent = `${sign}${m}:${String(s).padStart(2,'0')}`;
+    async function saveSet(payload, value, markDone) {
+        const session = await db.getSession(execCtx.dateKey);
+        const exercise = session.exercises.find((item) => item.exerciseId === execCtx.exerciseId);
+        if (payload.isNew) {
+            exercise.sets.push({ pos: exercise.sets.length + 1, ...value, done: markDone });
+        } else {
+            const index = exercise.sets.findIndex((set) => set.pos === payload.pos);
+            if (index >= 0) {
+                exercise.sets[index] = { ...exercise.sets[index], ...value, done: markDone };
+            }
+        }
+        await db.saveSession(session);
+        await renderColumnA();
+    }
 
-    tgl.textContent = A.execTimer.running ? '⏸' : '▶︎';
-  }
+    async function saveRemainingRest(remaining) {
+        const session = await db.getSession(execCtx.dateKey);
+        const exercise = session.exercises.find((item) => item.exerciseId === execCtx.exerciseId);
+        if (exercise && exercise.sets.length) {
+            const last = exercise.sets[exercise.sets.length - 1];
+            last.rest = Math.max(0, remaining);
+            await db.saveSession(session);
+            await renderColumnA();
+        }
+    }
 
-  // -------- Navigation --------
-  function backToSessions(){
-    document.getElementById('screenExecEdit').hidden = true;
-    document.getElementById('screenSessions').hidden = false;
-    A.renderWeek().then(()=>A.renderSession());
-  }
+    function rowReadOnly(set) {
+        const row = document.createElement('div');
+        row.className = 'exec-grid exec-row';
+        row.innerHTML = `
+            <div class="details">${safeInt(set.reps)}</div>
+            <div class="details">${safeInt(set.weight)} kg</div>
+            <div class="details">${rpeChip(set.rpe)}</div>
+            <div class="details">${fmtTime(safeInt(set.rest))}</div>
+            <div></div>
+        `;
+        return row;
+    }
 
-  // -------- Wire global --------
-  document.addEventListener('DOMContentLoaded', ()=>{
-    document.getElementById('execBack')?.addEventListener('click', backToSessions);
+    function rowEditable(set, isNew) {
+        const row = document.createElement('div');
+        row.className = 'exec-grid exec-row';
 
-    document.getElementById('tmrToggle')?.addEventListener('click', ()=>{
-      if (A.execTimer.running) pauseTimer(); else resumeTimer();
-    });
-    document.getElementById('tmrMinus')?.addEventListener('click', ()=>adjustTimer(-10));
-    document.getElementById('tmrPlus') ?.addEventListener('click', ()=>adjustTimer(+10));
-    // pas de bouton Next : la reprise est gérée par "Reprendre une série"
-  });
+        const reps = vStepper(safeInt(set.reps), 0, 100);
+        const weight = vStepper(safeInt(set.weight), 0, 999);
+
+        const rpeWrap = document.createElement('div');
+        const rpe = document.createElement('input');
+        rpe.type = 'number';
+        rpe.className = 'input';
+        rpe.min = '5';
+        rpe.max = '10';
+        rpe.inputMode = 'numeric';
+        rpe.value = set.rpe == null ? '' : String(set.rpe);
+        rpe.oninput = () => {
+            rpeWrap.dataset.rpe = clampInt(rpe.value, 5, 10) || '';
+        };
+        rpeWrap.appendChild(rpe);
+        rpeWrap.className = 'rpe-wrap';
+
+        const rest = document.createElement('input');
+        rest.type = 'text';
+        rest.className = 'input';
+        rest.placeholder = 'mm:ss';
+        rest.value = fmtTime(safeInt(set.rest));
+        rest.pattern = '^\\d{1,2}:\\d{2}$';
+
+        const holder = document.createElement('div');
+        holder.className = 'js-edit-holder';
+        holder.dataset.payload = JSON.stringify({ pos: set.pos, isNew });
+        holder._collect = () => ({
+            reps: parseInt(reps.input.value || '0', 10),
+            weight: parseInt(weight.input.value || '0', 10),
+            rpe: rpe.value ? parseInt(rpe.value, 10) : null,
+            rest: parseTime(rest.value)
+        });
+
+        row.append(reps.el, weight.el, rpeWrap, rest, holder);
+        return row;
+    }
+
+    function defaultNewSet(pos) {
+        return { pos, reps: 8, weight: 0, rpe: null, rest: 90, done: false };
+    }
+
+    function vStepper(val, min, max) {
+        const wrap = document.createElement('div');
+        wrap.className = 'vstepper';
+        const plus = document.createElement('button');
+        plus.className = 'btn';
+        plus.textContent = '+';
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.className = 'input';
+        input.inputMode = 'numeric';
+        input.value = String(val);
+        input.min = String(min);
+        input.max = String(max);
+        const minus = document.createElement('button');
+        minus.className = 'btn';
+        minus.textContent = '−';
+        plus.onclick = () => {
+            input.value = String(Math.min(max, parseInt(input.value || '0', 10) + 1));
+        };
+        minus.onclick = () => {
+            input.value = String(Math.max(min, parseInt(input.value || '0', 10) - 1));
+        };
+        wrap.append(plus, input, minus);
+        return { el: wrap, input };
+    }
+
+    function rpeChip(value) {
+        if (value == null || value === '') {
+            return '—';
+        }
+        const cssClass = getRpeClass(value);
+        return `<span class="rpe-chip ${cssClass}">${value}</span>`;
+    }
+
+    function getRpeClass(value) {
+        const numeric = parseInt(value, 10);
+        if (numeric <= 5) return 'rpe-5';
+        if (numeric === 6) return 'rpe-6';
+        if (numeric === 7) return 'rpe-7';
+        if (numeric === 8) return 'rpe-8';
+        if (numeric === 9) return 'rpe-9';
+        return 'rpe-10';
+    }
+
+    function safeInt(value) {
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    function clampInt(value, min, max) {
+        const numeric = parseInt(value, 10);
+        if (Number.isNaN(numeric)) {
+            return null;
+        }
+        return Math.max(min, Math.min(max, numeric));
+    }
+
+    function fmtTime(seconds) {
+        const safe = parseInt(seconds || 0, 10);
+        const minutes = Math.floor(Math.abs(safe) / 60);
+        const secs = Math.abs(safe) % 60;
+        const sign = safe < 0 ? '-' : '';
+        return `${sign}${minutes}:${String(secs).padStart(2, '0')}`;
+    }
+
+    function parseTime(raw) {
+        const match = /^(\d{1,2}):(\d{2})$/.exec(String(raw || ''));
+        if (!match) {
+            return 0;
+        }
+        return parseInt(match[1], 10) * 60 + parseInt(match[2], 10);
+    }
+
+    function startTimer(startSec) {
+        execTimer.startSec = startSec || 0;
+        execTimer.remainSec = startSec || 0;
+        execTimer.running = true;
+        if (execTimer.intervalId) {
+            clearInterval(execTimer.intervalId);
+        }
+        execTimer.intervalId = window.setInterval(runTick, 1000);
+        A.execTimer = execTimer;
+        updateTimerUI();
+    }
+
+    function pauseTimer() {
+        execTimer.running = false;
+        updateTimerUI();
+    }
+
+    function resumeTimer() {
+        execTimer.running = true;
+        updateTimerUI();
+    }
+
+    function stopTimer() {
+        if (execTimer.intervalId) {
+            clearInterval(execTimer.intervalId);
+        }
+        execTimer.intervalId = null;
+        execTimer.running = false;
+    }
+
+    function runTick() {
+        if (!execTimer.running) {
+            return;
+        }
+        execTimer.remainSec -= 1;
+        if (execTimer.remainSec === 0 && navigator.vibrate) {
+            try {
+                navigator.vibrate(200);
+            } catch {
+                /* ignore */
+            }
+        }
+        updateTimerUI();
+    }
+
+    async function adjustTimer(delta) {
+        execTimer.startSec += delta;
+        execTimer.remainSec += delta;
+
+        const session = await db.getSession(execCtx.dateKey);
+        const exercise = session.exercises.find((item) => item.exerciseId === execCtx.exerciseId);
+        if (exercise && exercise.sets.length) {
+            const last = exercise.sets[exercise.sets.length - 1];
+            last.rest = Math.max(0, (last.rest || 0) + delta);
+            await db.saveSession(session);
+            await renderColumnA();
+        }
+        updateTimerUI();
+    }
+
+    function updateTimerUI() {
+        const { execTimerBar, timerDisplay, timerToggle } = assertRefs();
+        if (!execTimerBar) {
+            return;
+        }
+
+        const shouldHide = !execTimer.intervalId && !execTimer.running && execTimer.startSec === 0;
+        execTimerBar.hidden = shouldHide;
+        if (shouldHide) {
+            return;
+        }
+
+        const remaining = execTimer.remainSec;
+        const sign = remaining < 0 ? '-' : '';
+        const abs = Math.abs(remaining);
+        const minutes = Math.floor(abs / 60);
+        const seconds = abs % 60;
+        timerDisplay.textContent = `${sign}${minutes}:${String(seconds).padStart(2, '0')}`;
+        timerToggle.textContent = execTimer.running ? '⏸' : '▶︎';
+    }
+
+    function wireNavigation() {
+        const { execBack } = assertRefs();
+        execBack?.addEventListener('click', backToCaller);
+    }
+
+    function wireTimerControls() {
+        const { timerToggle, timerMinus, timerPlus } = assertRefs();
+        timerToggle?.addEventListener('click', () => {
+            if (execTimer.running) {
+                pauseTimer();
+            } else {
+                resumeTimer();
+            }
+        });
+        timerMinus?.addEventListener('click', () => {
+            void adjustTimer(-10);
+        });
+        timerPlus?.addEventListener('click', () => {
+            void adjustTimer(10);
+        });
+    }
+
+    function backToCaller() {
+        switchScreen(execCtx.callerScreen || 'screenSessions');
+        void A.renderWeek().then(() => A.renderSession());
+    }
+
+    function switchScreen(target) {
+        const { screenSessions, screenExercises, screenExerciseEdit, screenExecEdit, screenExerciseRead } = assertRefs();
+        const map = {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExecEdit,
+            screenExerciseRead
+        };
+        Object.entries(map).forEach(([key, element]) => {
+            if (element) {
+                element.hidden = key !== target;
+            }
+        });
+    }
 })();

--- a/ui-exercises_list.js
+++ b/ui-exercises_list.js
@@ -1,273 +1,336 @@
 // ui-exercices_list.js — 3.1.1 Bibliothèque d’exercices (liste + filtres + lazy images)
-(function(){
-  const A = window.App || (window.App = {});
-  A.el = A.el || {};
+(() => {
+    const A = window.App;
 
-  let currentId = null;       // null = ajout
-  let callerScreen = null;    // mémorise l'écran d'origine
-  let listMode = 'view';      // 'add' | 'view'
-  let onAddCallback = null;   // callback(ids: string[]) quand on confirme en mode add
-  let filtersInited = false;
-  let selection = new Set();  // ids sélectionnés en mode 'add'
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
+    const state = {
+        listMode: 'view',
+        callerScreen: 'screenExercises',
+        onAddCallback: null,
+        filtersInited: false,
+        selection: new Set(),
+        lazyObserver: null
+    };
 
-  // ----- Navigation: montrer/masquer écrans -----
-  function showScreen(id){
-    for (const s of document.querySelectorAll('.screen')) s.hidden = true;
-    document.getElementById(id).hidden = false;
-  }
-
-  // ----- Lazy loading des images -----
-  let lazyObserver = null;
-  function ensureLazyObserver(){
-    if (lazyObserver) return lazyObserver;
-    lazyObserver = new IntersectionObserver(entries=>{
-      entries.forEach(entry=>{
-        if (entry.isIntersecting){
-          const img = entry.target;
-          const src = img.getAttribute('data-src');
-          if (src){
-            img.src = src;
-            img.removeAttribute('data-src');
-          }
-          lazyObserver.unobserve(img);
-        }
-      });
-    }, { rootMargin: '200px' });
-    return lazyObserver;
-  }
-
-  // ----- Barre sticky “Ajouter les exercices (N)” (mode add) -----
-  function ensureSelectionBar(){
-    if (!A.el.exSelectBar){
-      const bar = document.createElement('div');
-      bar.id = 'exSelectBar';
-      bar.style.position = 'sticky';
-      bar.style.top = '0';
-      bar.style.zIndex = '10';
-      bar.style.padding = '8px 0';
-      bar.style.background = 'var(--white)';
-      bar.style.display = 'none';
-
-      const btn = document.createElement('button');
-      btn.id = 'btnAddSelected';
-      btn.className = 'btn primary full';
-      btn.textContent = 'Ajouter les exercices';
-      btn.addEventListener('click', ()=>{
-        if (!selection.size) return;
-        const ids = Array.from(selection);
-        if (typeof onAddCallback === 'function') onAddCallback(ids);
-        // retour à l'écran appelant si connu
-        if (callerScreen && document.getElementById(callerScreen)){
-          for (const s of document.querySelectorAll('.screen')) s.hidden = true;
-          document.getElementById(callerScreen).hidden = false;
-        }
-      });
-
-      bar.appendChild(btn);
-      const content = document.querySelector('#screenExercises .content');
-      content?.insertBefore(bar, document.getElementById('exList'));
-      A.el.exSelectBar = bar;
-      A.el.btnAddSelected = btn;
-    }
-  }
-
-  function updateSelectionBar(){
-    if (listMode !== 'add'){ A.el.exSelectBar && (A.el.exSelectBar.style.display='none'); return; }
-    ensureSelectionBar();
-    const has = selection.size > 0;
-    A.el.exSelectBar.style.display = has ? 'block' : 'none';
-    if (A.el.btnAddSelected){
-      A.el.btnAddSelected.textContent = has
-        ? `Ajouter les exercices (${selection.size})`
-        : 'Ajouter les exercices';
-    }
-  }
-
-  // ----- Rendu d'un item -----
-  function renderItem(ex){
-    const card = document.createElement('article');
-    card.className = 'exercise-card';
-    card.setAttribute('role', 'button');
-
-    const row = document.createElement('div');
-    row.className = 'row between';
-
-    const left = document.createElement('div');
-    left.style.display='flex';
-    left.style.alignItems='center';
-    left.style.gap='10px';
-
-    // image (lazy)
-    const img = document.createElement('img');
-    img.alt = ex.name || 'exercice';
-    img.width = 40; img.height = 40;
-    img.style.width='40px'; img.style.height='40px';
-    img.style.borderRadius='8px'; img.style.objectFit='cover';
-    img.style.background='#eee'; img.style.marginRight='10px';
-    img.loading = 'lazy'; img.decoding = 'async';
-
-    if (ex.image) {
-      img.setAttribute('data-src', ex.image);   // ./data/media/<fname>.gif ou URL d’origine
-      ensureLazyObserver().observe(img);
-    } else {
-      img.src = './icons/placeholder-64.png';
-    }
-
-    const txtWrap    = document.createElement('div');
-    const name       = document.createElement('div');
-    name.className   = 'element';
-    name.textContent = ex.name || '—';
-
-    // Détails : Équipement (fin) • Muscle ciblé, muscles secondaires
-    const details = document.createElement('div');
-    details.className = 'details';
-
-    const eq_details = (ex.equipmentGroup2 || ex.equipment || '-').toString().trim();
-    const target     = (ex.muscle || ex.muscleGroup2 || ex.muscleGroup3 || '-').toString().trim();
-    const secondary  = Array.isArray(ex.secondaryMuscles) ? ex.secondaryMuscles.filter(Boolean) : [];
-    const mu_details = [target, ...secondary].filter(Boolean);
-
-    details.textContent = `${eq_details} • ${mu_details.join(', ')}`;
-
-    txtWrap.append(name, details);
-    left.append(img, txtWrap);
-
-    // Comportement selon le mode
-    if (listMode === 'add'){
-      if (selection.has(ex.id)) card.classList.add('selected');
-      card.addEventListener('click', ()=>{
-        if (selection.has(ex.id)) selection.delete(ex.id);
-        else selection.add(ex.id);
-        card.classList.toggle('selected');
-        updateSelectionBar();
-      });
-      row.append(left); // pas de bouton à droite
-    } else {
-      card.addEventListener('click', ()=> A.openExerciseRead(ex.id, 'screenExercises'));
-      row.append(left);
-    }
-
-    card.appendChild(row);
-    return card;
-  }
-
-  // ----- Chargement / filtrage -----
-  A.refreshExerciseList = async function(){
-    const q = (A.el.exSearch?.value || '').toLowerCase().trim();
-    const g = (A.el.exFilterGroup?.value || '').trim(); // muscleGroup2
-    const e = (A.el.exFilterEquip?.value || '').trim(); // equipmentGroup2
-
-    const all = await db.getAll('exercises');
-
-    // Filtrage STRICT sur G2
-    const filtered = all.filter(x=>{
-      if (q && !String(x.name||'').toLowerCase().includes(q)) return false;
-      if (g) {
-        const mg2 = (x.muscleGroup2 || '').toString().trim();
-        if (mg2 !== g) return false;
-      }
-      if (e) {
-        const eg2 = (x.equipmentGroup2 || '').toString().trim();
-        if (eg2 !== e) return false;
-      }
-      return true;
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        assertRefs();
+        wireFilters();
     });
 
-    const list = A.el.exList;
-    list.innerHTML = '';
+    /* ACTIONS */
+    /**
+     * Actualise la liste des exercices selon les filtres courants.
+     * @returns {Promise<void>} Promesse résolue après rendu.
+     */
+    A.refreshExerciseList = async function refreshExerciseList() {
+        const { exSearch, exFilterGroup, exFilterEquip, exList } = assertRefs();
+        const query = (exSearch.value || '').toLowerCase().trim();
+        const groupFilter = (exFilterGroup.value || '').trim();
+        const equipFilter = (exFilterEquip.value || '').trim();
 
-    if (!filtered.length) {
-      const empty = document.createElement('div');
-      empty.className='empty';
-      empty.textContent = 'Aucun exercice.';
-      list.appendChild(empty);
-      updateSelectionBar();
-      return;
-    }
+        const all = await db.getAll('exercises');
+        const filtered = all.filter((exercise) => {
+            if (query && !String(exercise.name || '').toLowerCase().includes(query)) {
+                return false;
+            }
+            if (groupFilter) {
+                const mg2 = (exercise.muscleGroup2 || '').toString().trim();
+                if (mg2 !== groupFilter) {
+                    return false;
+                }
+            }
+            if (equipFilter) {
+                const eg2 = (exercise.equipmentGroup2 || '').toString().trim();
+                if (eg2 !== equipFilter) {
+                    return false;
+                }
+            }
+            return true;
+        });
 
-    for (const ex of filtered) list.appendChild(renderItem(ex));
-    updateSelectionBar();
-  };
-
-  /**
-   * Ouvrir la bibliothèque d’exercices
-   * @param {Object} opts
-   *   - mode: 'add' | 'view'
-   *   - from: id de l'écran appelant (ex: 'screenSessions', 'screenRoutine'…)
-   *   - onAdd: function(ids: string[])  // callback quand on confirme en mode add
-   */
-  A.openExercises = async function(opts = {}){
-    listMode = opts.mode === 'add' ? 'add' : 'view';
-    callerScreen = opts.from || 'screenExercises';
-    onAddCallback = typeof opts.onAdd === 'function' ? opts.onAdd : null;
-
-    showScreen('screenExercises');
-
-    // Remplir les filtres depuis CFG (G2) une seule fois
-    if (!filtersInited) {
-      if (A.el.exFilterGroup) fillSelect(A.el.exFilterGroup, CFG.musclesG2, 'Groupe musculaire');
-      if (A.el.exFilterEquip) fillSelect(A.el.exFilterEquip, CFG.equipmentG2 || CFG.equipment, 'Matériel');
-      // handlers de filtres + recherche
-      A.el.exSearch?.addEventListener('input',  A.refreshExerciseList);
-      A.el.exFilterGroup?.addEventListener('change', A.refreshExerciseList);
-      A.el.exFilterEquip?.addEventListener('change', A.refreshExerciseList);
-      filtersInited = true;
-    }
-
-    // Réinitialiser filtres et recherche à chaque ouverture
-    if (A.el.exFilterGroup) A.el.exFilterGroup.value = '';
-    if (A.el.exFilterEquip) A.el.exFilterEquip.value = '';
-    if (A.el.exSearch)      A.el.exSearch.value      = '';
-
-    // Prépare barre de sélection + vide la sélection (mode add)
-    ensureSelectionBar();
-    selection.clear();
-    updateSelectionBar();
-
-    // En-tête : bouton droit “Ajouter” → création d’un exercice
-    if (!A.el.exOkList)   A.el.exOkList   = document.getElementById('exOkList');
-    if (!A.el.exBackList) A.el.exBackList = document.getElementById('exBackList');
-
-    if (A.el.exOkList){
-      A.el.exOkList.textContent = 'Créer nouveau';
-      A.el.exOkList.onclick = ()=> A.openExerciseEdit(null, 'screenExercises');
-    }
-
-    // Retour : en mode add → ne rien ajouter, revenir à l’appelant si connu
-    if (A.el.exBackList){
-      A.el.exBackList.onclick = ()=>{
-        if (listMode === 'add' && callerScreen && document.getElementById(callerScreen)){
-          for (const s of document.querySelectorAll('.screen')) s.hidden = true;
-          document.getElementById(callerScreen).hidden = false;
-        } else {
-          // fallback
-          showScreen('screenSessions');
+        exList.innerHTML = '';
+        if (!filtered.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty';
+            empty.textContent = 'Aucun exercice.';
+            exList.appendChild(empty);
+            updateSelectionBar();
+            return;
         }
-      };
+
+        filtered.forEach((exercise) => {
+            exList.appendChild(renderItem(exercise));
+        });
+        updateSelectionBar();
+    };
+
+    /**
+     * Ouvre la bibliothèque d'exercices.
+     * @param {{mode?: 'add'|'view', callerScreen?: string, onAdd?: (ids: string[]) => void}} [options] Paramètres d'ouverture.
+     * @returns {Promise<void>} Promesse résolue après rendu.
+     */
+    A.openExercises = async function openExercises(options = {}) {
+        const { mode = 'view', callerScreen = 'screenExercises', onAdd = null } = options;
+        ensureRefs();
+        assertRefs();
+
+        state.listMode = mode === 'add' ? 'add' : 'view';
+        state.callerScreen = callerScreen;
+        state.onAddCallback = typeof onAdd === 'function' ? onAdd : null;
+
+        switchScreen('screenExercises');
+        initializeFilters();
+        resetFilters();
+        ensureSelectionBar();
+        state.selection.clear();
+        updateSelectionBar();
+        configureHeaderButtons();
+        await A.refreshExerciseList();
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.screenExercises = document.getElementById('screenExercises');
+        refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refs.screenExerciseRead = document.getElementById('screenExerciseRead');
+        refs.screenSessions = document.getElementById('screenSessions');
+        refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.content = document.querySelector('#screenExercises .content');
+        refs.exSearch = document.getElementById('exSearch');
+        refs.exFilterGroup = document.getElementById('exFilterGroup');
+        refs.exFilterEquip = document.getElementById('exFilterEquip');
+        refs.exList = document.getElementById('exList');
+        refs.exBackList = document.getElementById('exBackList');
+        refs.exOkList = document.getElementById('exOkList');
+        refsResolved = true;
+        return refs;
     }
 
-    await A.refreshExerciseList();
-  };
-
-  // ----- Handlers init -----
-  document.addEventListener('DOMContentLoaded', ()=>{
-    // refs
-    A.el.exSearch      = document.getElementById('exSearch');
-    A.el.exFilterGroup = document.getElementById('exFilterGroup');
-    A.el.exFilterEquip = document.getElementById('exFilterEquip');
-    A.el.exList        = document.getElementById('exList');
-    A.el.exBackList    = document.getElementById('exBackList');
-    A.el.exOkList      = document.getElementById('exOkList');
-  });
-
-  function fillSelect(sel, items, placeholder){
-    if (!sel) return;
-    sel.innerHTML = '';
-    const opt0 = document.createElement('option');
-    opt0.value = ''; opt0.textContent = placeholder; sel.appendChild(opt0);
-    for (const v of items) {
-      const o = document.createElement('option');
-      o.value = v; o.textContent = v; sel.appendChild(o);
+    function assertRefs() {
+        ensureRefs();
+        const required = [
+            'screenExercises',
+            'exSearch',
+            'exFilterGroup',
+            'exFilterEquip',
+            'exList',
+            'exBackList',
+            'exOkList'
+        ];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-exercises_list.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
     }
-  }
+
+    function wireFilters() {
+        const { exSearch, exFilterGroup, exFilterEquip } = assertRefs();
+        exSearch.addEventListener('input', () => {
+            void A.refreshExerciseList();
+        });
+        exFilterGroup.addEventListener('change', () => {
+            void A.refreshExerciseList();
+        });
+        exFilterEquip.addEventListener('change', () => {
+            void A.refreshExerciseList();
+        });
+    }
+
+    function initializeFilters() {
+        if (state.filtersInited) {
+            return;
+        }
+        const { exFilterGroup, exFilterEquip } = assertRefs();
+        fillSelect(exFilterGroup, CFG.musclesG2, 'Groupe musculaire');
+        fillSelect(exFilterEquip, CFG.equipmentG2 || CFG.equipment, 'Matériel');
+        state.filtersInited = true;
+    }
+
+    function resetFilters() {
+        const { exFilterGroup, exFilterEquip, exSearch } = assertRefs();
+        exFilterGroup.value = '';
+        exFilterEquip.value = '';
+        exSearch.value = '';
+    }
+
+    function ensureSelectionBar() {
+        if (refs.exSelectBar) {
+            return;
+        }
+        const bar = document.createElement('div');
+        bar.id = 'exSelectBar';
+        bar.className = 'exercise-selection-bar hidden';
+
+        const button = document.createElement('button');
+        button.id = 'btnAddSelected';
+        button.className = 'btn primary full';
+        button.textContent = 'Ajouter les exercices';
+        button.addEventListener('click', () => {
+            if (!state.selection.size) {
+                return;
+            }
+            const ids = Array.from(state.selection);
+            if (state.onAddCallback) {
+                state.onAddCallback(ids);
+            }
+            switchScreen(state.callerScreen || 'screenExercises');
+        });
+
+        bar.appendChild(button);
+        refs.content?.insertBefore(bar, refs.exList);
+        refs.exSelectBar = bar;
+        refs.btnAddSelected = button;
+    }
+
+    function updateSelectionBar() {
+        if (state.listMode !== 'add' || !refs.exSelectBar) {
+            refs.exSelectBar?.classList.add('hidden');
+            return;
+        }
+        const hasSelection = state.selection.size > 0;
+        refs.exSelectBar.classList.toggle('hidden', !hasSelection);
+        if (refs.btnAddSelected) {
+            refs.btnAddSelected.textContent = hasSelection
+                ? `Ajouter les exercices (${state.selection.size})`
+                : 'Ajouter les exercices';
+        }
+    }
+
+    function renderItem(exercise) {
+        const card = document.createElement('article');
+        card.className = 'exercise-card';
+        card.setAttribute('role', 'button');
+
+        const row = document.createElement('div');
+        row.className = 'exercise-card-row';
+
+        const left = document.createElement('div');
+        left.className = 'exercise-card-left';
+
+        const image = document.createElement('img');
+        image.alt = exercise.name || 'exercice';
+        image.width = 40;
+        image.height = 40;
+        image.className = 'exercise-card-thumb';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        if (exercise.image) {
+            image.setAttribute('data-src', exercise.image);
+            ensureLazyObserver().observe(image);
+        } else {
+            image.src = new URL('icons/placeholder-64.png', document.baseURI).href;
+            image.classList.add('exercise-thumb-placeholder');
+        }
+
+        const textWrapper = document.createElement('div');
+        textWrapper.className = 'exercise-card-text';
+        const name = document.createElement('div');
+        name.className = 'element';
+        name.textContent = exercise.name || '—';
+        const details = document.createElement('div');
+        details.className = 'details';
+        const equipmentDetails = (exercise.equipmentGroup2 || exercise.equipment || '-').toString().trim();
+        const target = (exercise.muscle || exercise.muscleGroup2 || exercise.muscleGroup3 || '-').toString().trim();
+        const secondary = Array.isArray(exercise.secondaryMuscles)
+            ? exercise.secondaryMuscles.filter(Boolean)
+            : [];
+        const muscles = [target, ...secondary].filter(Boolean);
+        details.textContent = `${equipmentDetails} • ${muscles.join(', ')}`;
+        textWrapper.append(name, details);
+
+        left.append(image, textWrapper);
+
+        if (state.listMode === 'add') {
+            if (state.selection.has(exercise.id)) {
+                card.classList.add('selected');
+            }
+            card.addEventListener('click', () => {
+                if (state.selection.has(exercise.id)) {
+                    state.selection.delete(exercise.id);
+                } else {
+                    state.selection.add(exercise.id);
+                }
+                card.classList.toggle('selected');
+                updateSelectionBar();
+            });
+            row.append(left);
+        } else {
+            card.addEventListener('click', () => {
+                A.openExerciseRead({ currentId: exercise.id, callerScreen: 'screenExercises' });
+            });
+            row.append(left);
+        }
+
+        card.appendChild(row);
+        return card;
+    }
+
+    function ensureLazyObserver() {
+        if (state.lazyObserver) {
+            return state.lazyObserver;
+        }
+        state.lazyObserver = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    const img = entry.target;
+                    const src = img.getAttribute('data-src');
+                    if (src) {
+                        img.src = src;
+                        img.removeAttribute('data-src');
+                    }
+                    state.lazyObserver?.unobserve(img);
+                }
+            });
+        }, { rootMargin: '200px' });
+        return state.lazyObserver;
+    }
+
+    function fillSelect(select, items, placeholder) {
+        select.innerHTML = '';
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = placeholder;
+        select.appendChild(option);
+        items.forEach((value) => {
+            const opt = document.createElement('option');
+            opt.value = value;
+            opt.textContent = value;
+            select.appendChild(opt);
+        });
+    }
+
+    function configureHeaderButtons() {
+        const { exOkList, exBackList } = assertRefs();
+        exOkList.textContent = 'Créer nouveau';
+        exOkList.onclick = () => {
+            A.openExerciseEdit({ callerScreen: 'screenExercises' });
+        };
+        exBackList.onclick = () => {
+            switchScreen(state.callerScreen || 'screenSessions');
+        };
+    }
+
+    function switchScreen(target) {
+        const { screenExercises, screenExerciseEdit, screenExerciseRead, screenSessions, screenExecEdit } = assertRefs();
+        const map = {
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenSessions,
+            screenExecEdit
+        };
+        Object.entries(map).forEach(([key, element]) => {
+            if (element) {
+                element.hidden = key !== target;
+            }
+        });
+    }
 })();

--- a/ui-session.js
+++ b/ui-session.js
@@ -1,160 +1,227 @@
 // ui-session.js — liste de la séance du jour + ajouts (2 lignes)
+(() => {
+    const A = window.App;
 
-(function(){
-  const A = window.App;
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
 
-  // Donne l'id de la routine prévue pour une date (via plan actif), sinon null
-  A.getPlannedRoutineId = async function(date){
-    const plan = await db.getActivePlan();
-    if (!plan) return null;
-    const wd = (date.getDay() + 6) % 7 + 1; // 1..7 (lun..dim)
-    return plan.days?.[String(wd)] || null;
-  };
-
-  // Remplit le sélecteur avec la routine prévue en premier (pré-sélectionnée), puis les autres
-  A.populateRoutineSelect = async function populateRoutineSelect(){
-    const sel = A.el.selectRoutine;
-    const all = await db.getAll('routines');
-    const plannedId = await A.getPlannedRoutineId(A.activeDate);
-
-    // Réinitialise
-    sel.innerHTML = `<option value="">Ajouter une routine…</option>`;
-
-    // Construit la liste : [planned en 1er si existe] + autres (sans doublon)
-    const ordered = [];
-    if (plannedId) {
-      const p = all.find(r => r.id === plannedId);
-      if (p) ordered.push(p);
-    }
-    for (const r of all) {
-      if (!ordered.some(o => o.id === r.id)) ordered.push(r);
-    }
-
-    // Injecte options
-    for (const r of ordered) {
-      const opt = document.createElement('option');
-      opt.value = r.id;
-      opt.textContent = r.name;
-      sel.appendChild(opt);
-    }
-
-    // Sélection par défaut = routine prévue du jour si existe, sinon placeholder
-    sel.value = plannedId || '';
-  };
-
-  // Rendu de la séance du jour
-  A.renderSession = async function renderSession(){
-    A.el.todayLabel.textContent = A.fmtUI(A.activeDate);
-
-    const key = A.ymd(A.activeDate);
-    const session = await db.getSession(key);
-    const list = A.el.sessionList;
-    list.innerHTML = '';
-
-    if (!(session?.exercises?.length)) {
-      list.innerHTML = `<div class="empty">Aucun exercice pour cette date.</div>`;
-      return;
-    }
-
-    for (const ex of session.exercises) {
-      const card = document.createElement('article'); card.className='exercise-card';
-
-      const top  = document.createElement('div'); top.className='row between';
-      const name = document.createElement('div'); name.className='element'; name.textContent = ex.exerciseName;
-      const btn  = document.createElement('button'); btn.className='btn'; btn.textContent='Répétitions ✏️';
-      btn.addEventListener('click', ()=>A.openExecEdit(ex.exerciseId));
-      top.append(name, btn); card.appendChild(top);
-
-      const grid = document.createElement('div'); grid.className='set-grid';
-      for (const s of ex.sets) {
-        const cell = document.createElement('div'); cell.className='set-cell';
-        const reps = s.reps ?? 0;
-        const w    = s.weight ?? 0;
-        const rpeSmall = s.rpe ? `<sup>${s.rpe}</sup>` : '';
-        cell.innerHTML = `<span class="details">${reps}×${w} kg ${rpeSmall}</span>`;
-        grid.appendChild(cell);
-      }
-      card.appendChild(grid);
-
-      card.addEventListener('click', ()=>btn.click());
-      list.appendChild(card);
-    }
-  };
-  
-// === Ajout d'exercices sélectionnés à la séance courante ===
-A.addExercisesToCurrentSession = async function addExercisesToCurrentSession(ids){
-  if (!Array.isArray(ids) || !ids.length) return;
-
-  const key = A.ymd(A.activeDate);
-  let s = await db.getSession(key) || { date:key, exercises:[] };
-
-  // Construire un set des exercices déjà présents pour éviter les doublons
-  const existing = new Set((s.exercises || []).map(e => e.exerciseId));
-
-  for (const id of ids){
-    if (existing.has(id)) continue; // skip doublons
-    const ex = await db.get('exercises', id);
-    if (!ex) continue;
-
-    s.exercises.push({
-      pos: (s.exercises?.length || 0) + 1,
-      exerciseId: ex.id,
-      exerciseName: ex.name || 'Exercice',
-      // une ligne de set vide par défaut (tu peux adapter)
-      sets: [{ pos:1, reps:null, weight:null, rpe:null, rest:null, done:false }]
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        assertRefs();
+        wireAddExercisesButton();
     });
-  }
 
-  await db.saveSession(s);
-  await A.renderWeek?.();
-  await A.renderSession?.();
-};
-
-
-
-  // Ajouter la routine choisie (sélecteur) à la séance
-  A.addRoutineToSession = async function addRoutineToSession(routineId){
-    const r = await db.get('routines', routineId);
-    if (!r) return;
-    const key = A.ymd(A.activeDate);
-    let s = await db.getSession(key) || { date:key, exercises:[] };
-
-    for (const m of r.moves) {
-      if (s.exercises.some(e => e.exerciseId === m.exerciseId)) continue;
-      s.exercises.push({
-        pos: s.exercises.length+1,
-        exerciseId: m.exerciseId,
-        exerciseName: m.exerciseName,
-        sets: m.sets.map(x=>({ pos:x.pos, reps:x.reps ?? null, weight:null, rpe:null, rest:x.rest ?? null, done:false }))     
-      });
-    }
-    await db.saveSession(s);
-    await A.populateRoutineSelect(); // garder la cohérence du sélecteur
-    await A.renderWeek();
-    await A.renderSession();
-  };
-
-
-  // === Init refs & handlers ===
-  document.addEventListener('DOMContentLoaded', ()=>{
-    A.el = A.el || {};
-    A.el.btnAddExercises = document.getElementById('btnAddExercises');
-    A.el.selectRoutine   = document.getElementById('selectRoutine');
-    A.el.todayLabel      = document.getElementById('todayLabel');
-    A.el.sessionList     = document.getElementById('sessionList');
-
-    // Ouvrir la bibliothèque en MODE AJOUT depuis l'écran Séance
-    A.el.btnAddExercises?.addEventListener('click', ()=>{
-      A.openExercises({
-        mode: 'add',
-        from: 'screenSessions',
-        onAdd: async (ids)=> {
-          await A.addExercisesToCurrentSession(ids);
-          // Le retour visuel à l'écran Séance est géré côté ui-exercices_list
+    /* ACTIONS */
+    /**
+     * Retourne l'identifiant de la routine planifiée pour une date.
+     * @param {Date} date Date ciblée.
+     * @returns {Promise<string|null>} Identifiant ou `null`.
+     */
+    A.getPlannedRoutineId = async function getPlannedRoutineId(date) {
+        const plan = await db.getActivePlan();
+        if (!plan) {
+            return null;
         }
-      });
-    });
-  });
-  
-  
+        const weekday = (date.getDay() + 6) % 7 + 1;
+        return plan.days?.[String(weekday)] || null;
+    };
+
+    /**
+     * Met à jour le sélecteur de routine en mettant la routine planifiée en premier.
+     * @returns {Promise<void>} Promesse résolue après rendu.
+     */
+    A.populateRoutineSelect = async function populateRoutineSelect() {
+        const { selectRoutine } = assertRefs();
+        const all = await db.getAll('routines');
+        const plannedId = await A.getPlannedRoutineId(A.activeDate);
+
+        selectRoutine.innerHTML = '<option value="">Ajouter une routine…</option>';
+
+        const ordered = [];
+        if (plannedId) {
+            const planned = all.find((routine) => routine.id === plannedId);
+            if (planned) {
+                ordered.push(planned);
+            }
+        }
+        for (const routine of all) {
+            if (!ordered.some((item) => item.id === routine.id)) {
+                ordered.push(routine);
+            }
+        }
+
+        ordered.forEach((routine) => {
+            const option = document.createElement('option');
+            option.value = routine.id;
+            option.textContent = routine.name;
+            selectRoutine.appendChild(option);
+        });
+
+        selectRoutine.value = plannedId || '';
+    };
+
+    /**
+     * Rend la séance du jour.
+     * @returns {Promise<void>} Promesse résolue après affichage.
+     */
+    A.renderSession = async function renderSession() {
+        const { todayLabel, sessionList } = assertRefs();
+        todayLabel.textContent = A.fmtUI(A.activeDate);
+
+        const key = A.ymd(A.activeDate);
+        const session = await db.getSession(key);
+        sessionList.innerHTML = '';
+
+        if (!(session?.exercises?.length)) {
+            sessionList.innerHTML = '<div class="empty">Aucun exercice pour cette date.</div>';
+            return;
+        }
+
+        session.exercises.forEach((exercise) => {
+            const card = document.createElement('article');
+            card.className = 'exercise-card';
+
+            const top = document.createElement('div');
+            top.className = 'row between';
+            const name = document.createElement('div');
+            name.className = 'element';
+            name.textContent = exercise.exerciseName;
+            const button = document.createElement('button');
+            button.className = 'btn';
+            button.textContent = 'Répétitions ✏️';
+            button.addEventListener('click', () => A.openExecEdit({
+                currentId: exercise.exerciseId,
+                callerScreen: 'screenSessions'
+            }));
+            top.append(name, button);
+            card.appendChild(top);
+
+            const grid = document.createElement('div');
+            grid.className = 'set-grid';
+            exercise.sets.forEach((set) => {
+                const cell = document.createElement('div');
+                cell.className = 'set-cell';
+                const reps = set.reps ?? 0;
+                const weight = set.weight ?? 0;
+                const rpeSmall = set.rpe ? `<sup>${set.rpe}</sup>` : '';
+                cell.innerHTML = `<span class="details">${reps}×${weight} kg ${rpeSmall}</span>`;
+                grid.appendChild(cell);
+            });
+            card.appendChild(grid);
+            card.addEventListener('click', () => button.click());
+
+            sessionList.appendChild(card);
+        });
+    };
+
+    /**
+     * Ajoute des exercices sélectionnés à la séance courante.
+     * @param {string[]} ids Identifiants d'exercice.
+     * @returns {Promise<void>} Promesse résolue après sauvegarde.
+     */
+    A.addExercisesToCurrentSession = async function addExercisesToCurrentSession(ids) {
+        if (!Array.isArray(ids) || !ids.length) {
+            return;
+        }
+
+        const key = A.ymd(A.activeDate);
+        const session = (await db.getSession(key)) || { date: key, exercises: [] };
+        const existing = new Set((session.exercises || []).map((exercise) => exercise.exerciseId));
+
+        for (const id of ids) {
+            if (existing.has(id)) {
+                continue;
+            }
+            const exercise = await db.get('exercises', id);
+            if (!exercise) {
+                continue;
+            }
+            session.exercises.push({
+                pos: (session.exercises?.length || 0) + 1,
+                exerciseId: exercise.id,
+                exerciseName: exercise.name || 'Exercice',
+                sets: [{ pos: 1, reps: null, weight: null, rpe: null, rest: null, done: false }]
+            });
+        }
+
+        await db.saveSession(session);
+        await A.renderWeek();
+        await A.renderSession();
+    };
+
+    /**
+     * Ajoute une routine complète à la séance courante.
+     * @param {string} routineId Identifiant de routine.
+     * @returns {Promise<void>} Promesse résolue après sauvegarde.
+     */
+    A.addRoutineToSession = async function addRoutineToSession(routineId) {
+        const routine = await db.get('routines', routineId);
+        if (!routine) {
+            return;
+        }
+        const key = A.ymd(A.activeDate);
+        const session = (await db.getSession(key)) || { date: key, exercises: [] };
+
+        routine.moves.forEach((move) => {
+            if (session.exercises.some((exercise) => exercise.exerciseId === move.exerciseId)) {
+                return;
+            }
+            session.exercises.push({
+                pos: session.exercises.length + 1,
+                exerciseId: move.exerciseId,
+                exerciseName: move.exerciseName,
+                sets: move.sets.map((set) => ({
+                    pos: set.pos,
+                    reps: set.reps ?? null,
+                    weight: null,
+                    rpe: null,
+                    rest: set.rest ?? null,
+                    done: false
+                }))
+            });
+        });
+
+        await db.saveSession(session);
+        await A.populateRoutineSelect();
+        await A.renderWeek();
+        await A.renderSession();
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.btnAddExercises = document.getElementById('btnAddExercises');
+        refs.selectRoutine = document.getElementById('selectRoutine');
+        refs.todayLabel = document.getElementById('todayLabel');
+        refs.sessionList = document.getElementById('sessionList');
+        refsResolved = true;
+        return refs;
+    }
+
+    function assertRefs() {
+        ensureRefs();
+        const required = ['selectRoutine', 'todayLabel', 'sessionList'];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-session.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
+    }
+
+    function wireAddExercisesButton() {
+        const { btnAddExercises } = refs;
+        btnAddExercises?.addEventListener('click', () => {
+            A.openExercises({
+                mode: 'add',
+                callerScreen: 'screenSessions',
+                onAdd: async (ids) => {
+                    await A.addExercisesToCurrentSession(ids);
+                }
+            });
+        });
+    }
 })();

--- a/ui-week.js
+++ b/ui-week.js
@@ -1,53 +1,90 @@
 // ui-week.js — barre semaine (7 jours)
-(function(){
-  const A = window.App;
+(() => {
+    const A = window.App;
 
-  A.renderWeek = async function renderWeek() {
-    const wrap = A.el.weekStrip;
-    if (!wrap) return;
-    wrap.innerHTML = '';
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
 
-    const start = A.addDays(A.currentAnchor, -3); // 7 jours centrés
-    const sessDates = new Set((await db.listSessionDates()).map(x => x.date));
-    const tdy = A.today();
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', ensureRefs);
 
-    for (let i=0; i<7; i++) {
-      const d = A.addDays(start, i);
-      const key = A.ymd(d);
-      const isSelected = A.ymd(d) === A.ymd(A.activeDate);
-      const hasSession = sessDates.has(key);            // noir (passé ou futur)
-      const planned = await isPlannedDate(d);           // gris si futur
-      const isFuture = d >= tdy;
+    /* ACTIONS */
+    /**
+     * Rend la barre des sept jours centrée sur l'ancre courante.
+     * @returns {Promise<void>} Promesse résolue après mise à jour.
+     */
+    A.renderWeek = async function renderWeek() {
+        const { weekStrip } = assertRefs();
+        weekStrip.innerHTML = '';
 
-      const btn = document.createElement('button');
-      btn.className = 'day';
-      btn.textContent = d.toLocaleDateString('fr-FR', { weekday:'short', day:'numeric' }).replace('.', '');
+        const start = A.addDays(A.currentAnchor, -3);
+        const sessionDates = new Set((await db.listSessionDates()).map((item) => item.date));
+        const today = A.today();
 
-      if (hasSession) btn.classList.add('has-session');
-      else if (planned && isFuture) btn.classList.add('planned');
-      if (isSelected) btn.classList.add('selected');
+        for (let index = 0; index < 7; index += 1) {
+            const date = A.addDays(start, index);
+            const key = A.ymd(date);
+            const isSelected = A.ymd(date) === A.ymd(A.activeDate);
+            const hasSession = sessionDates.has(key);
+            const planned = await isPlannedDate(date);
+            const isFuture = date >= today;
 
-      btn.addEventListener('click', async () => {
-        A.activeDate = d;
-        await A.populateRoutineSelect();
-        await A.renderWeek();
-        await A.renderSession();
-      });
+            const button = document.createElement('button');
+            button.className = 'day';
+            button.textContent = date
+                .toLocaleDateString('fr-FR', { weekday: 'short', day: 'numeric' })
+                .replace('.', '');
 
-      wrap.appendChild(btn);
+            if (hasSession) {
+                button.classList.add('has-session');
+            } else if (planned && isFuture) {
+                button.classList.add('planned');
+            }
+            if (isSelected) {
+                button.classList.add('selected');
+            }
+
+            button.addEventListener('click', async () => {
+                A.activeDate = date;
+                await A.populateRoutineSelect();
+                await A.renderWeek();
+                await A.renderSession();
+            });
+
+            weekStrip.appendChild(button);
+        }
+
+        const selected = weekStrip.querySelector('.day.selected');
+        if (selected && typeof selected.scrollIntoView === 'function') {
+            selected.scrollIntoView({ inline: 'center', block: 'nearest' });
+        }
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.weekStrip = document.getElementById('weekStrip');
+        refsResolved = true;
+        return refs;
     }
 
-    // S'assurer que le jour sélectionné est visible
-    const sel = wrap.querySelector('.day.selected');
-    if (sel && typeof sel.scrollIntoView === 'function') {
-      sel.scrollIntoView({ inline: 'center', block: 'nearest' });
+    function assertRefs() {
+        ensureRefs();
+        if (!refs.weekStrip) {
+            throw new Error('ui-week.js: référence weekStrip manquante');
+        }
+        return refs;
     }
-  };
 
-  async function isPlannedDate(d){
-    const plan = await db.getActivePlan();
-    if (!plan) return false;
-    const wd = (d.getDay() + 6) % 7 + 1; // 1=lun..7=dim
-    return Boolean(plan.days[String(wd)]);
-  }
+    async function isPlannedDate(date) {
+        const plan = await db.getActivePlan();
+        if (!plan) {
+            return false;
+        }
+        const weekday = (date.getDay() + 6) % 7 + 1;
+        return Boolean(plan.days[String(weekday)]);
+    }
 })();


### PR DESCRIPTION
## Summary
- unify DOM wiring across initialization, calendar, week, session, read, edit, and execution modules with consistent ensureRefs/assertRefs scaffolding and JSDoc'd open APIs
- refresh the exercise library flow with reusable references, selection management, and option-driven callbacks alongside URL-safe placeholder handling
- migrate inline styling to reusable CSS classes for exercise cards, selection bars, and hero placeholders while keeping IndexedDB helpers documented

## Testing
- Not run (manual testing recommended)

------
https://chatgpt.com/codex/tasks/task_e_68d28b3eb04c833286f3b49e6732b8ff