### PR TITLE
Ajuste la liste des exercices

### DIFF
--- a/style.css
+++ b/style.css
@@ -206,8 +206,14 @@ image_big{
   padding: var(--pad-y) var(--pad-x);
 }
 .exercise-card-row{ display:flex; align-items:center; justify-content:space-between; gap:var(--gap); }
-.exercise-card-left{ display:flex; align-items:center; gap:10px; }
-.exercise-card-text{ display:flex; flex-direction:column; gap:2px; }
+.exercise-card-left{ display:flex; align-items:center; gap:10px; flex:1; min-width:0; }
+.exercise-card-text{ display:flex; flex-direction:column; gap:2px; min-width:0; }
+.exercise-card-text .element,
+.exercise-card-text .details{
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
 .exercise-card-thumb{
   width:40px;
   height:40px;
@@ -217,8 +223,8 @@ image_big{
   flex-shrink:0;
 }
 .exercise-card.selected{
-  border-color: var(--emphase);
-  box-shadow:0 0 0 2px rgba(0,128,255,0.2);
+  border-color: var(--darkGrayB);
+  background: var(--darkGray);
 }
 .exercise-card.clickable{ cursor:pointer; user-select:none; }
 .exercise-thumb-placeholder{ object-fit:contain; }

--- a/ui-exercises_list.js
+++ b/ui-exercises_list.js
@@ -171,8 +171,9 @@
 
         const button = document.createElement('button');
         button.id = 'btnAddSelected';
-        button.className = 'btn primary full';
-        button.textContent = 'Ajouter les exercices';
+        button.className = 'btn full';
+        button.disabled = true;
+        button.textContent = 'Ajouter 0 exercice(s)';
         button.addEventListener('click', () => {
             if (!state.selection.size) {
                 return;
@@ -191,17 +192,19 @@
     }
 
     function updateSelectionBar() {
-        if (state.listMode !== 'add' || !refs.exSelectBar) {
-            refs.exSelectBar?.classList.add('hidden');
+        if (!refs.exSelectBar) {
             return;
         }
-        const hasSelection = state.selection.size > 0;
-        refs.exSelectBar.classList.toggle('hidden', !hasSelection);
-        if (refs.btnAddSelected) {
-            refs.btnAddSelected.textContent = hasSelection
-                ? `Ajouter les exercices (${state.selection.size})`
-                : 'Ajouter les exercices';
+        const isAddMode = state.listMode === 'add';
+        refs.exSelectBar.classList.toggle('hidden', !isAddMode);
+        if (!isAddMode || !refs.btnAddSelected) {
+            return;
         }
+
+        const count = state.selection.size;
+        refs.btnAddSelected.disabled = count === 0;
+        refs.btnAddSelected.classList.toggle('primary', count > 0);
+        refs.btnAddSelected.textContent = `Ajouter ${count} exercice(s)`;
     }
 
     function renderItem(exercise) {
@@ -263,6 +266,7 @@
             });
             row.append(left);
         } else {
+            card.classList.add('clickable');
             card.addEventListener('click', () => {
                 A.openExerciseRead({ currentId: exercise.id, callerScreen: 'screenExercises' });
             });


### PR DESCRIPTION
## Summary
- tronque le nom et les détails des exercices dans la liste pour éviter les débordements
- ajuste le style des cartes selon le mode (sélection en ajout, pointer et non-sélectionnable en vue)
- rend le bouton d'ajout toujours visible avec gestion de l'état désactivé et du compteur

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2ac18f0ec8332a2512d834cd5325f