### PR TITLE
feat: ouvrir lecture et édition d'exercice dans une modale

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,93 +157,99 @@
   </section>
   <!-- ==================== -->
  
-  <!-- ========== 3.1.2A Consulter un exercice ========== -->
-  <section id="screenExerciseRead" class="screen" hidden>
-    
-    <!-- En-tête -->
-    <header class="subheader">
-      <button class="btn" id="exReadBack">←</button>
-      <div class="title" id="exReadTitle">Exercice</div>
-      <button class="btn" id="exReadEdit">✏️ Editer</button>
-    </header>
+  <!-- ========== 3.1.2A/B Modale exercice (lecture / édition) ========== -->
+  <div id="exerciseModal" class="exercise-modal" hidden role="dialog" aria-modal="true" aria-labelledby="exReadTitle exEditTitle">
+    <div class="exercise-modal-backdrop"></div>
+    <div class="exercise-modal-wrapper">
+      <!-- ========== 3.1.2A Consulter un exercice ========== -->
+      <section id="screenExerciseRead" class="modal-screen" hidden>
+
+        <!-- En-tête -->
+        <header class="subheader">
+          <button class="btn" id="exReadBack">←</button>
+          <div class="title" id="exReadTitle">Exercice</div>
+          <button class="btn" id="exReadEdit">✏️ Editer</button>
+        </header>
 
 
-	<!-- Corps de l'écran Consulter un Exercice) -->
-	<main class="content">
+            <!-- Corps de l'écran Consulter un Exercice) -->
+            <main class="content">
 
-		<div class="panel" style="display:flex;flex-direction:column;gap:12px;">
-			<!-- Image / GIF -->
-			<img id="exReadHero" alt="aperçu exercice" class="image_big" />
+                    <div class="panel" style="display:flex;flex-direction:column;gap:12px;">
+                            <!-- Image / GIF -->
+                            <img id="exReadHero" alt="aperçu exercice" class="image_big" />
 
-			<!-- Lignes d’info -->
-			<div id="exReadMuscle"    class="element"></div>
-			<div id="exReadEquipment" class="details"></div>
+                            <!-- Lignes d’info -->
+                            <div id="exReadMuscle"    class="element"></div>
+                            <div id="exReadEquipment" class="details"></div>
 
-			<!-- Instructions -->
-			<div>
-				<div class="lbl">Instructions</div>
-				<ol id="exReadInstruc" class="listing"></ol>
-			</div>
-		</div>
- 
-	</main>  
-  </section>
-  <!-- ==================== -->
-  
-  <!-- ========== 3.1.2B Ajouter / Modifier un exercice ========== -->
-  <section id="screenExerciseEdit" class="screen" hidden>
-    
-    <!-- En-tête -->
-    <header class="subheader">
-      <button class="btn" id="exEditBack">←</button>
-      <div class="title" id="exEditTitle">Ajouter</div>
-      <button class="btn" id="exEditOk">OK</button>
-    </header>
+                            <!-- Instructions -->
+                            <div>
+                                    <div class="lbl">Instructions</div>
+                                    <ol id="exReadInstruc" class="listing"></ol>
+                            </div>
+                    </div>
+
+            </main>
+      </section>
+      <!-- ==================== -->
+
+      <!-- ========== 3.1.2B Ajouter / Modifier un exercice ========== -->
+      <section id="screenExerciseEdit" class="modal-screen" hidden>
+
+        <!-- En-tête -->
+        <header class="subheader">
+          <button class="btn" id="exEditBack">←</button>
+          <div class="title" id="exEditTitle">Ajouter</div>
+          <button class="btn" id="exEditOk">OK</button>
 
 
-	<!-- Corps de l'écran Ajouter / Modifier Exercices) -->
-	<main class="content">
+            <!-- Corps de l'écran Ajouter / Modifier Exercices) -->
+            <main class="content">
 
-		<!-- Cartouche haut -->
-		<div class="filters">   
-		
-			<!-- Zone suppression -->
-			<div class="row">
-				<button id="exEditDelete" class="btn danger full">🗑️ Supprimer</button>
-			</div>
-		</div>
-		
-		<!-- Cartouche bas : Formulaire -->
-		<div class="form">
-	  
-			<label class="lbl">Nom</label>
-			<input id="exName" class="input full" placeholder="Nom de l’exercice" />
-	 
-			<label class="lbl">Matériel</label>
-			<div id="exEquip" class="tags"></div>
-			
-			<label class="lbl">Muscle ciblé</label>
-			<select id="exTargetMuscle" class="input full">
-			  <option value="">Choisir…</option>
-			</select>
-			
-			<div id="exGroupInfo" class="hint"></div>
-			
-			<label class="lbl">Muscles secondaires</label>
-			<div id="exSecMuscles" class="tags"></div>
-	  
-			<label class="lbl">Image (URL)</label>
-			<input id="exImage" class="input full" type="url" placeholder="https://… ou ./data/media/xxx.gif" />
+                    <!-- Cartouche haut -->
+                    <div class="filters">
 
-			<label class="lbl">Instructions (1 par ligne)</label>
-			<textarea id="exInstr" class="input full" rows="8" placeholder="Étape 1…
+                            <!-- Zone suppression -->
+                            <div class="row">
+                                    <button id="exEditDelete" class="btn danger full">🗑️ Supprimer</button>
+                            </div>
+                    </div>
+
+                    <!-- Cartouche bas : Formulaire -->
+                    <div class="form">
+
+                            <label class="lbl">Nom</label>
+                            <input id="exName" class="input full" placeholder="Nom de l’exercice" />
+
+                            <label class="lbl">Matériel</label>
+                            <div id="exEquip" class="tags"></div>
+
+                            <label class="lbl">Muscle ciblé</label>
+                            <select id="exTargetMuscle" class="input full">
+                              <option value="">Choisir…</option>
+                            </select>
+
+                            <div id="exGroupInfo" class="hint"></div>
+
+                            <label class="lbl">Muscles secondaires</label>
+                            <div id="exSecMuscles" class="tags"></div>
+
+                            <label class="lbl">Image (URL)</label>
+                            <input id="exImage" class="input full" type="url" placeholder="https://… ou ./data/media/xxx.gif" />
+
+                            <label class="lbl">Instructions (1 par ligne)</label>
+                            <textarea id="exInstr" class="input full" rows="8" placeholder="Étape 1…
 Étape 2…"></textarea>
- 
-		</div>
 
-	   
-	</main>  
-  </section>
+                    </div>
+
+
+            </main>
+      </section>
+      <!-- ==================== -->
+    </div>
+  </div>
   <!-- ==================== -->
 
   <!-- Barre d’onglets fixe (icônes) -->

--- a/style.css
+++ b/style.css
@@ -238,6 +238,36 @@ image_big{
   text-overflow:ellipsis;
   white-space:nowrap;
 }
+.exercise-card-right{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  flex-shrink:0;
+  min-width:32px;
+}
+.exercise-card-checkbox{
+  width:20px;
+  height:20px;
+  accent-color: var(--emphase);
+  cursor:pointer;
+}
+.exercise-card-eye{
+  background:none;
+  border:none;
+  padding:4px;
+  border-radius:8px;
+  font-size:20px;
+  line-height:1;
+  cursor:pointer;
+  color: var(--darkGrayB);
+}
+.exercise-card-eye:focus-visible{
+  outline:2px solid var(--emphase);
+  outline-offset:2px;
+}
+.exercise-card-eye:hover{
+  color: var(--black);
+}
 .exercise-card-thumb{
   width:40px;
   height:40px;
@@ -271,6 +301,58 @@ image_big{
 }
 .exercise-selection-bar.hidden{ display:none; }
 .exercise-hero-placeholder{ object-fit:contain; background:var(--lightGray); }
+
+body.modal-open{ overflow:hidden; }
+
+.exercise-modal{
+  position:fixed;
+  inset:0;
+  z-index:50;
+  display:flex;
+  align-items:flex-start;
+  justify-content:center;
+  padding:5vh 0;
+}
+.exercise-modal[hidden]{ display:none; }
+.exercise-modal-backdrop{
+  position:absolute;
+  inset:0;
+  background:rgba(0,0,0,.45);
+}
+.exercise-modal-wrapper{
+  position:relative;
+  z-index:1;
+  width:95vw;
+  max-height:calc(100vh - 10vh);
+  background:var(--white);
+  border-radius:16px;
+  box-shadow:0 20px 40px rgba(0,0,0,.25);
+  overflow:hidden;
+  display:flex;
+  flex-direction:column;
+}
+.exercise-modal-wrapper .modal-screen{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  max-height:100%;
+}
+.exercise-modal-wrapper .content{
+  flex:1;
+  width:100%;
+  margin:0;
+  max-width:none;
+  border:none;
+  background:var(--whiteB);
+  padding-left:var(--pad-x);
+  padding-right:var(--pad-x);
+  padding-bottom:calc(env(safe-area-inset-bottom, 0) + 16px);
+  min-height:0;
+  overflow-y:auto;
+}
+.exercise-modal-wrapper .filters{
+  margin-top:var(--pad-y);
+}
 
 
 /* =========================================================


### PR DESCRIPTION
## Résumé
- affiche les écrans de lecture et d’édition d’un exercice dans une modale 95 % écran avec entête fixe
- adapte les cartes de la liste en réservant une zone à droite (case à cocher en mode ajout, icône œil en mode lecture) tout en préservant la sélection
- ajoute les styles et comportements utilitaires associés (masquage du fond, désactivation du scroll, rafraîchissement après édition/suppression)

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68d3013eb1f08332b6d2d0847109c42e