### PR TITLE
Adjust exec timer placement above tab bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,9 +143,9 @@ header .title{ font-weight: var(--fw-strong); }
    ========================================================= */
 /* Timer bas */
 .exec-timer{
-    z-index:15;
-    position:sticky; 
-    bottom:0; 
+    z-index:20;
+    position:sticky;
+    bottom: calc(var(--tabbar-h) + env(safe-area-inset-bottom, 0));
     
     display:grid; grid-template-columns: 1fr 2fr 1fr;
     align-items:center; gap:8px;


### PR DESCRIPTION
## Summary
- offset the sticky execution timer from the bottom by the tab bar height and safe-area inset
- raise the timer z-index so it reliably renders above the tab bar

## Testing
- Manual UI verification of timer position in browser

------
https://chatgpt.com/codex/tasks/task_e_68d7fd6848d88332b65087efecd9b696