### PR TITLE
Add routine editing interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,77 @@
   </section>
 <!-- ==================== -->
 
+<!-- ========== Routine : édition template ========== -->
+<section id="screenRoutineEdit" class="screen" hidden>
+
+    <header class="header">
+        <div class="header-left"></div>
+        <div class="header-center">
+            <div class="title">Routine</div>
+        </div>
+        <div class="header-right"></div>
+    </header>
+
+    <main class="content">
+        <div class="bloque">
+            <div class="row">
+                <input id="routineName" class="input flex-1" placeholder="Nom de la routine" />
+                <select id="routineIcon" class="input" aria-label="Icône de routine"></select>
+            </div>
+        </div>
+
+        <section id="routineList" class="session-list" aria-label="Exercices de la routine"></section>
+
+        <div class="bloque">
+            <div class="row">
+                <button id="btnRoutineAddExercises" class="btn full">Ajouter exercice/s</button>
+            </div>
+        </div>
+    </main>
+
+</section>
+<!-- ==================== -->
+
+<!-- ========== Routine : édition des séries prévues ========== -->
+<section id="screenRoutineMoveEdit" class="screen" hidden>
+
+    <header class="header">
+        <div class="header-left">
+            <button id="routineMoveBack" class="btn ghost" title="Retour">◀︎</button>
+        </div>
+
+        <div class="header-center">
+            <div class="title" id="routineMoveTitle">Exercice</div>
+        </div>
+
+        <div class="header-right">
+            <button id="routineMoveDone" class="btn primary" title="Terminer">OK</button>
+        </div>
+    </header>
+
+    <main class="content">
+        <div class="bloque">
+            <button id="routineMoveDelete" class="btn danger full">🗑️ Retirer de la routine</button>
+        </div>
+
+        <div class="exec-grid exec-head">
+            <div>#</div>
+            <div>Reps</div>
+            <div>Poids</div>
+            <div>RPE</div>
+            <div></div>
+        </div>
+
+        <div id="routineMoveSets"></div>
+
+        <div class="add-actions">
+            <button id="routineMoveAddSet" class="btn primary full">Ajouter une série</button>
+        </div>
+    </main>
+
+</section>
+<!-- ==================== -->
+
 <!-- ========== 3.4.2 Modifier l’exécution (Colonne A uniquement) ========== -->
 <section id="screenExecEdit" class="screen" hidden>
 
@@ -287,6 +358,8 @@
 <script src="ui-exercise-read.js"></script>
 <script src="ui-exercise-edit.js"></script>
 <script src="ui-exercises_list.js"></script>
+<script src="ui-routine-edit.js"></script>
+<script src="ui-routine-move-edit.js"></script>
 <script src="ui-exec-edit.js"></script>
 <script src="init.js"></script>
 <script>

--- a/init.js
+++ b/init.js
@@ -38,7 +38,7 @@
     }
 
     function wireNavigation() {
-        const { tabLibraries, tabSessions, screenSessions, screenExercises, screenExerciseEdit } = refs;
+        const { tabLibraries, tabSessions, tabSettings, screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit } = refs;
 
         tabLibraries?.addEventListener('click', async () => {
             setActiveTab('tabLibraries');
@@ -54,9 +54,17 @@
             await A.renderSession();
         });
 
+        tabSettings?.addEventListener('click', async () => {
+            setActiveTab('tabSettings');
+            showOnly('routine');
+            await A.openRoutineEdit({ routineId: 'routine-test' });
+        });
+
         screenSessions?.setAttribute('data-screen', 'sessions');
         screenExercises?.setAttribute('data-screen', 'exercises');
         screenExerciseEdit?.setAttribute('data-screen', 'edit');
+        screenRoutineEdit?.setAttribute('data-screen', 'routine');
+        screenRoutineMoveEdit?.setAttribute('data-screen', 'routineMove');
     }
 
     function wireCalendar() {
@@ -105,9 +113,13 @@
         refs.calNext = document.getElementById('calNext');
         refs.tabLibraries = document.getElementById('tabLibraries');
         refs.tabSessions = document.getElementById('tabSessions');
+        refs.tabSettings = document.getElementById('tabSettings');
         refs.screenSessions = document.getElementById('screenSessions');
         refs.screenExercises = document.getElementById('screenExercises');
         refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenExecEdit = document.getElementById('screenExecEdit');
         refsResolved = true;
         return refs;
     }
@@ -122,7 +134,8 @@
             'dlgCalendar',
             'bigCalendar',
             'tabLibraries',
-            'tabSessions'
+            'tabSessions',
+            'tabSettings'
         ];
         const missing = required.filter((key) => !refs[key]);
         if (missing.length) {
@@ -140,7 +153,7 @@
     }
 
     function showOnly(which) {
-        const { screenSessions, screenExercises, screenExerciseEdit } = refs;
+        const { screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit, screenExecEdit } = refs;
         if (screenSessions) {
             screenSessions.hidden = which !== 'sessions';
         }
@@ -149,6 +162,15 @@
         }
         if (screenExerciseEdit) {
             screenExerciseEdit.hidden = which !== 'edit';
+        }
+        if (screenRoutineEdit) {
+            screenRoutineEdit.hidden = which !== 'routine';
+        }
+        if (screenRoutineMoveEdit) {
+            screenRoutineMoveEdit.hidden = which !== 'routineMove';
+        }
+        if (screenExecEdit) {
+            screenExecEdit.hidden = which !== 'exec';
         }
     }
 
@@ -183,6 +205,46 @@
             await ensureExercise('push_up', 'Pompes', 'chest', 'body weight');
             await ensureExercise('pull_up', 'Tractions', 'lats', 'body weight');
             await ensureExercise('squat', 'Squat', 'quads', 'barbell');
+            await db.put('routines', {
+                id: 'routine-test',
+                name: 'Routine test',
+                icon: '🏋️',
+                moves: [
+                    {
+                        id: 'move-push-test',
+                        pos: 1,
+                        exerciseId: 'push_up',
+                        exerciseName: 'Pompes',
+                        sets: [
+                            { pos: 1, reps: 12, weight: null, rpe: 7, rest: null },
+                            { pos: 2, reps: 12, weight: null, rpe: 8, rest: null },
+                            { pos: 3, reps: 12, weight: null, rpe: 9, rest: null }
+                        ]
+                    },
+                    {
+                        id: 'move-pull-test',
+                        pos: 2,
+                        exerciseId: 'pull_up',
+                        exerciseName: 'Tractions',
+                        sets: [
+                            { pos: 1, reps: 6, weight: null, rpe: 7, rest: null },
+                            { pos: 2, reps: 6, weight: null, rpe: 8, rest: null },
+                            { pos: 3, reps: 6, weight: null, rpe: 9, rest: null }
+                        ]
+                    },
+                    {
+                        id: 'move-squat-test',
+                        pos: 3,
+                        exerciseId: 'squat',
+                        exerciseName: 'Squat',
+                        sets: [
+                            { pos: 1, reps: 8, weight: 60, rpe: 7, rest: null },
+                            { pos: 2, reps: 8, weight: 60, rpe: 8, rest: null },
+                            { pos: 3, reps: 8, weight: 60, rpe: 9, rest: null }
+                        ]
+                    }
+                ]
+            });
         }
 
         if (!planCount) {

--- a/style.css
+++ b/style.css
@@ -580,6 +580,19 @@ image_big{
   font-weight: var(--fw-strong);
 }
 
+.routine-set-actions{
+  display:flex;
+  justify-content:flex-end;
+  gap:8px;
+}
+
+.btn-icon{
+  min-width:36px;
+  padding:8px;
+  font-size:18px;
+  line-height:1;
+}
+
 .exec-row.is-selected{
   background: var(--darkGray);
   color: var(--white);

--- a/ui-exec-edit.js
+++ b/ui-exec-edit.js
@@ -103,6 +103,8 @@
         refs.screenExerciseRead = document.getElementById('screenExerciseRead');
         refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
         refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
         refs.execTitle = document.getElementById('execTitle');
         refs.execDate = document.getElementById('execDate');
         refs.execExecuted = document.getElementById('execExecuted');
@@ -664,12 +666,15 @@
 
     function switchScreen(target) {
         const { screenSessions, screenExercises, screenExerciseEdit, screenExecEdit, screenExerciseRead } = assertRefs();
+        const { screenRoutineEdit, screenRoutineMoveEdit } = refs;
         const map = {
             screenSessions,
             screenExercises,
             screenExerciseEdit,
             screenExecEdit,
-            screenExerciseRead
+            screenExerciseRead,
+            screenRoutineEdit,
+            screenRoutineMoveEdit
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-exercise-edit.js
+++ b/ui-exercise-edit.js
@@ -72,6 +72,8 @@
         refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
         refs.screenSessions = document.getElementById('screenSessions');
         refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
         refs.exEditTitle = document.getElementById('exEditTitle');
         refs.exEditDelete = document.getElementById('exEditDelete');
         refs.exEditBack = document.getElementById('exEditBack');
@@ -251,7 +253,9 @@
             screenExerciseEdit,
             screenSessions,
             screenExecEdit,
-            screenExerciseRead: refs.screenExerciseRead
+            screenExerciseRead: refs.screenExerciseRead,
+            screenRoutineEdit: refs.screenRoutineEdit,
+            screenRoutineMoveEdit: refs.screenRoutineMoveEdit
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -55,6 +55,8 @@
         refs.screenSessions = document.getElementById('screenSessions');
         refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
         refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
         refs.exReadTitle = document.getElementById('exReadTitle');
         refs.exReadHero = document.getElementById('exReadHero');
         refs.exReadMuscle = document.getElementById('exReadMuscle');
@@ -150,12 +152,15 @@
 
     function switchScreen(target) {
         const { screenExerciseRead, screenExercises, screenSessions, screenExerciseEdit, screenExecEdit } = assertRefs();
+        const { screenRoutineEdit, screenRoutineMoveEdit } = refs;
         const map = {
             screenExerciseRead,
             screenExercises,
             screenSessions,
             screenExerciseEdit,
-            screenExecEdit
+            screenExecEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-exercises_list.js
+++ b/ui-exercises_list.js
@@ -135,6 +135,8 @@
         refs.screenExerciseRead = document.getElementById('screenExerciseRead');
         refs.screenSessions = document.getElementById('screenSessions');
         refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
         refs.content = document.querySelector('#screenExercises .content');
         refs.exSearch = document.getElementById('exSearch');
         refs.exFilterGroup = document.getElementById('exFilterGroup');
@@ -414,12 +416,15 @@
 
     function switchScreen(target) {
         const { screenExercises, screenExerciseEdit, screenExerciseRead, screenSessions, screenExecEdit } = assertRefs();
+        const { screenRoutineEdit, screenRoutineMoveEdit } = refs;
         const map = {
             screenExercises,
             screenExerciseEdit,
             screenExerciseRead,
             screenSessions,
-            screenExecEdit
+            screenExecEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -1,0 +1,564 @@
+// ui-routine-edit.js — édition d'une routine (liste + méta)
+(() => {
+    const A = window.App;
+
+    /* STATE */
+    const ICONS = ['🏋️', '💪', '🤸', '🏃', '🧘', '🚴', '🥊', '🏊', '🧗', '⚽'];
+    const refs = {};
+    let refsResolved = false;
+    const state = {
+        routineId: 'routine-test',
+        routine: null,
+        active: false,
+        pendingSave: null
+    };
+    const dragCtx = {
+        active: false,
+        card: null,
+        handle: null,
+        placeholder: null,
+        pointerId: null,
+        offsetY: 0,
+        initialOrder: []
+    };
+
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        wireInputs();
+        wireAddExercisesButton();
+    });
+
+    /* ACTIONS */
+    A.openRoutineEdit = async function openRoutineEdit(options = {}) {
+        const { routineId = 'routine-test' } = options;
+        state.routineId = routineId;
+        state.active = true;
+        await loadRoutine(true);
+        renderRoutine();
+        switchScreen('screenRoutineEdit');
+    };
+
+    A.refreshRoutineEdit = async function refreshRoutineEdit() {
+        if (!state.routineId) {
+            return;
+        }
+        ensureRefs();
+        state.active = !refs.screenRoutineEdit?.hidden;
+        await loadRoutine(true);
+        if (state.active) {
+            renderRoutine();
+        }
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.screenSessions = document.getElementById('screenSessions');
+        refs.screenExercises = document.getElementById('screenExercises');
+        refs.screenExerciseRead = document.getElementById('screenExerciseRead');
+        refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.routineName = document.getElementById('routineName');
+        refs.routineIcon = document.getElementById('routineIcon');
+        refs.routineList = document.getElementById('routineList');
+        refs.btnRoutineAddExercises = document.getElementById('btnRoutineAddExercises');
+        refsResolved = true;
+        return refs;
+    }
+
+    function assertRefs() {
+        ensureRefs();
+        const required = [
+            'screenRoutineEdit',
+            'routineName',
+            'routineIcon',
+            'routineList',
+            'btnRoutineAddExercises'
+        ];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-routine-edit.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
+    }
+
+    async function loadRoutine(force = false) {
+        if (!force && state.routine) {
+            return state.routine;
+        }
+        const routine = await db.get('routines', state.routineId);
+        state.routine = normalizeRoutine(routine || createEmptyRoutine(state.routineId));
+        return state.routine;
+    }
+
+    function createEmptyRoutine(id) {
+        return { id, name: 'Routine', icon: ICONS[0], moves: [] };
+    }
+
+    function normalizeRoutine(routine) {
+        if (!routine) {
+            return createEmptyRoutine(state.routineId);
+        }
+        const normalized = {
+            id: routine.id || state.routineId,
+            name: routine.name || 'Routine',
+            icon: routine.icon || ICONS[0],
+            moves: Array.isArray(routine.moves) ? [...routine.moves] : []
+        };
+        normalized.moves = normalized.moves.map((move, index) => ({
+            id: move.id || uid('move'),
+            pos: safeInt(move.pos, index + 1),
+            exerciseId: move.exerciseId,
+            exerciseName: move.exerciseName || 'Exercice',
+            sets: Array.isArray(move.sets)
+                ? move.sets.map((set, idx) => ({
+                    pos: safeInt(set.pos, idx + 1),
+                    reps: safeIntOrNull(set.reps),
+                    weight: safeFloatOrNull(set.weight),
+                    rpe: safeFloatOrNull(set.rpe),
+                    rest: safeIntOrNull(set.rest)
+                }))
+                : []
+        }));
+        normalized.moves.sort((a, b) => (a.pos ?? 0) - (b.pos ?? 0));
+        return normalized;
+    }
+
+    function wireInputs() {
+        const { routineName, routineIcon } = assertRefs();
+        routineName.addEventListener('input', () => {
+            if (!state.routine) {
+                return;
+            }
+            state.routine.name = routineName.value.trim() || 'Routine';
+            scheduleSave();
+        });
+        routineIcon.addEventListener('change', () => {
+            if (!state.routine) {
+                return;
+            }
+            state.routine.icon = routineIcon.value || ICONS[0];
+            scheduleSave();
+            renderIconPreview();
+        });
+    }
+
+    function wireAddExercisesButton() {
+        const { btnRoutineAddExercises } = assertRefs();
+        btnRoutineAddExercises.addEventListener('click', () => {
+            A.openExercises({
+                mode: 'add',
+                callerScreen: 'screenRoutineEdit',
+                onAdd: (ids) => {
+                    void addExercises(ids);
+                }
+            });
+        });
+    }
+
+    async function addExercises(ids) {
+        if (!state.routine || !Array.isArray(ids) || !ids.length) {
+            return;
+        }
+        const existingIds = new Set(state.routine.moves.map((move) => move.exerciseId));
+        for (const id of ids) {
+            if (existingIds.has(id)) {
+                continue;
+            }
+            const exercise = await db.get('exercises', id);
+            if (!exercise) {
+                continue;
+            }
+            state.routine.moves.push({
+                id: uid('move'),
+                pos: state.routine.moves.length + 1,
+                exerciseId: exercise.id,
+                exerciseName: exercise.name || 'Exercice',
+                sets: []
+            });
+            existingIds.add(exercise.id);
+        }
+        await persistRoutine();
+        renderRoutineList();
+    }
+
+    function renderRoutine() {
+        if (!state.routine) {
+            return;
+        }
+        populateIconSelect();
+        renderIconPreview();
+        const { routineName, routineIcon } = assertRefs();
+        routineName.value = state.routine.name || '';
+        routineIcon.value = state.routine.icon || ICONS[0];
+        renderRoutineList();
+    }
+
+    function renderIconPreview() {
+        const { routineIcon } = assertRefs();
+        Array.from(routineIcon.options).forEach((option) => {
+            option.selected = option.value === routineIcon.value;
+        });
+    }
+
+    function populateIconSelect() {
+        const { routineIcon } = assertRefs();
+        if (routineIcon.dataset.populated === '1') {
+            return;
+        }
+        routineIcon.innerHTML = '';
+        ICONS.forEach((icon) => {
+            const option = document.createElement('option');
+            option.value = icon;
+            option.textContent = icon;
+            routineIcon.appendChild(option);
+        });
+        routineIcon.dataset.populated = '1';
+    }
+
+    function renderRoutineList() {
+        const { routineList } = assertRefs();
+        routineList.innerHTML = '';
+        if (!state.routine?.moves?.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty';
+            empty.textContent = 'Aucun exercice dans la routine.';
+            routineList.appendChild(empty);
+            return;
+        }
+        const ordered = [...state.routine.moves].sort((a, b) => (a.pos ?? 0) - (b.pos ?? 0));
+        ordered.forEach((move) => {
+            routineList.appendChild(renderMoveCard(move));
+        });
+    }
+
+    function renderMoveCard(move) {
+        const card = document.createElement('article');
+        card.className = 'exercise-card clickable';
+        card.dataset.moveId = move.id;
+
+        const row = document.createElement('div');
+        row.className = 'exercise-card-row';
+
+        const left = document.createElement('div');
+        left.className = 'exercise-card-left';
+
+        const handle = document.createElement('button');
+        handle.type = 'button';
+        handle.className = 'session-card-handle';
+        handle.setAttribute('aria-label', 'Réordonner l\'exercice');
+        const grip = document.createElement('span');
+        grip.className = 'session-card-grip';
+        for (let index = 0; index < 3; index += 1) {
+            const dot = document.createElement('span');
+            dot.className = 'session-card-grip-dot';
+            grip.appendChild(dot);
+        }
+        handle.appendChild(grip);
+
+        const textWrapper = document.createElement('div');
+        textWrapper.className = 'exercise-card-text';
+        const name = document.createElement('div');
+        name.className = 'element';
+        name.textContent = move.exerciseName || 'Exercice';
+        const setsWrapper = document.createElement('div');
+        setsWrapper.className = 'session-card-sets';
+        const sets = Array.isArray(move.sets) ? [...move.sets].sort((a, b) => (a.pos ?? 0) - (b.pos ?? 0)) : [];
+        if (sets.length) {
+            sets.forEach((set) => {
+                const block = document.createElement('span');
+                block.className = 'session-card-set';
+                const reps = valueOrDash(set.reps);
+                const weight = set.weight != null && !Number.isNaN(set.weight)
+                    ? `${set.weight} kg`
+                    : '—';
+                const details = `${reps}×${weight}`;
+                const rpe = set.rpe != null && !Number.isNaN(set.rpe) ? `<sup>${set.rpe}</sup>` : '';
+                block.innerHTML = rpe ? `${details} ${rpe}` : details;
+                setsWrapper.appendChild(block);
+            });
+        } else {
+            const emptyBlock = document.createElement('span');
+            emptyBlock.className = 'session-card-set';
+            emptyBlock.textContent = 'Ajouter des séries';
+            setsWrapper.appendChild(emptyBlock);
+        }
+        textWrapper.append(name, setsWrapper);
+
+        left.append(handle, textWrapper);
+
+        const right = document.createElement('div');
+        right.className = 'exercise-card-right';
+        const pencil = document.createElement('span');
+        pencil.className = 'session-card-pencil';
+        pencil.setAttribute('aria-hidden', 'true');
+        pencil.textContent = '✏️';
+        right.appendChild(pencil);
+
+        row.append(left, right);
+        card.appendChild(row);
+
+        card.setAttribute('role', 'button');
+        card.setAttribute('aria-label', `${move.exerciseName || 'Exercice'} — éditer`);
+        card.addEventListener('click', () => {
+            A.openRoutineMoveEdit({
+                routineId: state.routineId,
+                moveId: move.id,
+                callerScreen: 'screenRoutineEdit'
+            });
+        });
+
+        makeRoutineCardInteractive(card, handle);
+        return card;
+    }
+
+    function makeRoutineCardInteractive(card, handle) {
+        handle.addEventListener('click', (event) => {
+            event.stopPropagation();
+        });
+        handle.addEventListener('pointerdown', (event) => startDrag(event, card, handle));
+    }
+
+    function startDrag(event, card, handle) {
+        if (dragCtx.active) {
+            return;
+        }
+        if (event.button !== 0 && event.pointerType !== 'touch') {
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+
+        const { routineList } = assertRefs();
+        dragCtx.active = true;
+        dragCtx.card = card;
+        dragCtx.handle = handle;
+        dragCtx.pointerId = event.pointerId;
+        dragCtx.initialOrder = getRoutineOrder(routineList);
+
+        const rect = card.getBoundingClientRect();
+        dragCtx.offsetY = event.clientY - rect.top;
+        const placeholder = document.createElement('div');
+        placeholder.className = 'session-card-placeholder';
+        placeholder.style.height = `${rect.height}px`;
+        placeholder.style.width = `${rect.width}px`;
+        dragCtx.placeholder = placeholder;
+
+        routineList.insertBefore(placeholder, card);
+        routineList.appendChild(card);
+
+        card.classList.add('session-card-dragging');
+        card.style.width = `${rect.width}px`;
+        card.style.height = `${rect.height}px`;
+        card.style.position = 'fixed';
+        card.style.left = `${rect.left}px`;
+        card.style.top = `${rect.top}px`;
+        card.style.zIndex = '1000';
+        card.style.pointerEvents = 'none';
+
+        if (handle.setPointerCapture) {
+            handle.setPointerCapture(event.pointerId);
+        }
+        handle.addEventListener('pointermove', onDragMove);
+        handle.addEventListener('pointerup', onDragEnd);
+        handle.addEventListener('pointercancel', onDragCancel);
+    }
+
+    function onDragMove(event) {
+        if (!dragCtx.active || event.pointerId !== dragCtx.pointerId) {
+            return;
+        }
+        event.preventDefault();
+
+        dragCtx.card.style.top = `${event.clientY - dragCtx.offsetY}px`;
+
+        const { routineList } = assertRefs();
+        const siblings = Array.from(routineList.children)
+            .filter((node) => node !== dragCtx.card && node !== dragCtx.placeholder);
+
+        for (const sibling of siblings) {
+            const rect = sibling.getBoundingClientRect();
+            const midpoint = rect.top + rect.height / 2;
+            if (event.clientY < midpoint) {
+                routineList.insertBefore(dragCtx.placeholder, sibling);
+                break;
+            }
+            const last = siblings[siblings.length - 1];
+            if (sibling === last) {
+                routineList.appendChild(dragCtx.placeholder);
+            }
+        }
+    }
+
+    function onDragEnd(event) {
+        if (!dragCtx.active || event.pointerId !== dragCtx.pointerId) {
+            return;
+        }
+        finalizeDrag();
+    }
+
+    function onDragCancel(event) {
+        if (!dragCtx.active || event.pointerId !== dragCtx.pointerId) {
+            return;
+        }
+        finalizeDrag(true);
+    }
+
+    async function finalizeDrag(cancelled = false) {
+        const { routineList } = assertRefs();
+        if (dragCtx.handle?.releasePointerCapture) {
+            try {
+                dragCtx.handle.releasePointerCapture(dragCtx.pointerId);
+            } catch (error) {
+                console.warn('releasePointerCapture ignoré:', error);
+            }
+        }
+        dragCtx.handle?.removeEventListener('pointermove', onDragMove);
+        dragCtx.handle?.removeEventListener('pointerup', onDragEnd);
+        dragCtx.handle?.removeEventListener('pointercancel', onDragCancel);
+
+        if (dragCtx.placeholder && dragCtx.placeholder.parentNode === routineList) {
+            routineList.insertBefore(dragCtx.card, dragCtx.placeholder);
+            routineList.removeChild(dragCtx.placeholder);
+        }
+        dragCtx.card.classList.remove('session-card-dragging');
+        Object.assign(dragCtx.card.style, { position: '', left: '', top: '', width: '', height: '', zIndex: '', pointerEvents: '' });
+
+        if (!cancelled) {
+            const order = getRoutineOrder(routineList);
+            if (!arraysEqual(order, dragCtx.initialOrder)) {
+                applyRoutineOrder(order);
+                await persistRoutine();
+                renderRoutineList();
+            }
+        }
+
+        dragCtx.active = false;
+        dragCtx.card = null;
+        dragCtx.handle = null;
+        dragCtx.placeholder = null;
+        dragCtx.pointerId = null;
+        dragCtx.offsetY = 0;
+        dragCtx.initialOrder = [];
+    }
+
+    function getRoutineOrder(container) {
+        return Array.from(container.children)
+            .filter((node) => node instanceof HTMLElement && node.dataset.moveId)
+            .map((node, index) => ({ moveId: node.dataset.moveId, pos: index + 1 }));
+    }
+
+    function applyRoutineOrder(order) {
+        if (!state.routine?.moves?.length) {
+            return;
+        }
+        const positionMap = new Map(order.map((entry) => [entry.moveId, entry.pos]));
+        state.routine.moves.forEach((move) => {
+            if (positionMap.has(move.id)) {
+                move.pos = positionMap.get(move.id);
+            }
+        });
+        state.routine.moves.sort((a, b) => (a.pos ?? 0) - (b.pos ?? 0));
+    }
+
+    async function persistRoutine() {
+        if (!state.routine) {
+            return;
+        }
+        await db.put('routines', serializeRoutine(state.routine));
+        void A.refreshRoutineEdit();
+    }
+
+    function scheduleSave() {
+        if (state.pendingSave) {
+            clearTimeout(state.pendingSave);
+        }
+        state.pendingSave = setTimeout(() => {
+            state.pendingSave = null;
+            void persistRoutine();
+        }, 300);
+    }
+
+    function serializeRoutine(routine) {
+        return {
+            id: routine.id,
+            name: routine.name,
+            icon: routine.icon,
+            moves: routine.moves.map((move, index) => ({
+                id: move.id,
+                pos: safeInt(move.pos, index + 1),
+                exerciseId: move.exerciseId,
+                exerciseName: move.exerciseName,
+                sets: Array.isArray(move.sets)
+                    ? move.sets.map((set, idx) => ({
+                        pos: safeInt(set.pos, idx + 1),
+                        reps: safeIntOrNull(set.reps),
+                        weight: safeFloatOrNull(set.weight),
+                        rpe: safeFloatOrNull(set.rpe),
+                        rest: safeIntOrNull(set.rest)
+                    }))
+                    : []
+            }))
+        };
+    }
+
+    function arraysEqual(a, b) {
+        if (a.length !== b.length) {
+            return false;
+        }
+        return a.every((entry, index) => {
+            const other = b[index];
+            return entry.moveId === other.moveId && entry.pos === other.pos;
+        });
+    }
+
+    function valueOrDash(value) {
+        if (value == null || Number.isNaN(value)) {
+            return '—';
+        }
+        return value;
+    }
+
+    function safeInt(value, fallback = null) {
+        const number = Number.parseInt(value, 10);
+        return Number.isFinite(number) ? number : fallback;
+    }
+
+    function safeFloatOrNull(value) {
+        const number = Number.parseFloat(value);
+        return Number.isFinite(number) ? number : null;
+    }
+
+    function safeIntOrNull(value) {
+        const number = Number.parseInt(value, 10);
+        return Number.isFinite(number) ? number : null;
+    }
+
+    function uid(prefix) {
+        return `${prefix}-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+    }
+
+    function switchScreen(target) {
+        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineEdit, screenRoutineMoveEdit } = assertRefs();
+        const map = {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit
+        };
+        Object.entries(map).forEach(([key, element]) => {
+            if (element) {
+                element.hidden = key !== target;
+            }
+        });
+        state.active = target === 'screenRoutineEdit';
+    }
+})();

--- a/ui-routine-move-edit.js
+++ b/ui-routine-move-edit.js
@@ -1,0 +1,416 @@
+// ui-routine-move-edit.js — édition des séries prévues d'un exercice de routine
+(() => {
+    const A = window.App;
+
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
+    const state = {
+        routineId: null,
+        moveId: null,
+        callerScreen: 'screenRoutineEdit',
+        routine: null,
+        pendingSave: null
+    };
+
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        wireNavigation();
+        wireActions();
+    });
+
+    /* ACTIONS */
+    A.openRoutineMoveEdit = async function openRoutineMoveEdit(options = {}) {
+        const { routineId, moveId, callerScreen = 'screenRoutineEdit' } = options;
+        if (!routineId || !moveId) {
+            return;
+        }
+        state.routineId = routineId;
+        state.moveId = moveId;
+        state.callerScreen = callerScreen;
+
+        const routine = await db.get('routines', routineId);
+        state.routine = normalizeRoutine(routine);
+        const move = findMove();
+        if (!move) {
+            alert('Exercice introuvable dans la routine.');
+            return;
+        }
+
+        const { routineMoveTitle } = assertRefs();
+        routineMoveTitle.textContent = move.exerciseName || 'Exercice';
+        renderSets();
+        switchScreen('screenRoutineMoveEdit');
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.screenSessions = document.getElementById('screenSessions');
+        refs.screenExercises = document.getElementById('screenExercises');
+        refs.screenExerciseRead = document.getElementById('screenExerciseRead');
+        refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.routineMoveTitle = document.getElementById('routineMoveTitle');
+        refs.routineMoveSets = document.getElementById('routineMoveSets');
+        refs.routineMoveBack = document.getElementById('routineMoveBack');
+        refs.routineMoveDone = document.getElementById('routineMoveDone');
+        refs.routineMoveAddSet = document.getElementById('routineMoveAddSet');
+        refs.routineMoveDelete = document.getElementById('routineMoveDelete');
+        refsResolved = true;
+        return refs;
+    }
+
+    function assertRefs() {
+        ensureRefs();
+        const required = [
+            'screenRoutineMoveEdit',
+            'routineMoveTitle',
+            'routineMoveSets',
+            'routineMoveBack',
+            'routineMoveDone',
+            'routineMoveAddSet',
+            'routineMoveDelete'
+        ];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-routine-move-edit.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
+    }
+
+    function wireNavigation() {
+        const { routineMoveBack, routineMoveDone } = assertRefs();
+        routineMoveBack.addEventListener('click', () => {
+            returnToCaller();
+        });
+        routineMoveDone.addEventListener('click', () => {
+            returnToCaller();
+        });
+    }
+
+    function wireActions() {
+        const { routineMoveAddSet, routineMoveDelete } = assertRefs();
+        routineMoveAddSet.addEventListener('click', () => {
+            addSet();
+        });
+        routineMoveDelete.addEventListener('click', () => {
+            removeMove();
+        });
+    }
+
+    function renderSets() {
+        const move = findMove();
+        const { routineMoveSets } = assertRefs();
+        routineMoveSets.innerHTML = '';
+        if (!move) {
+            return;
+        }
+        const sets = Array.isArray(move.sets) ? [...move.sets].sort((a, b) => (a.pos ?? 0) - (b.pos ?? 0)) : [];
+        if (!sets.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty';
+            empty.textContent = 'Aucune série prévue.';
+            routineMoveSets.appendChild(empty);
+            return;
+        }
+        sets.forEach((set, index) => {
+            routineMoveSets.appendChild(renderSetRow(set, index));
+        });
+    }
+
+    function renderSetRow(set, index) {
+        const row = document.createElement('div');
+        row.className = 'exec-grid exec-row routine-set-row';
+
+        const order = document.createElement('div');
+        order.textContent = index + 1;
+
+        const reps = document.createElement('input');
+        reps.type = 'number';
+        reps.inputMode = 'numeric';
+        reps.className = 'input';
+        reps.placeholder = 'Reps';
+        reps.value = set.reps ?? '';
+        reps.addEventListener('input', (event) => {
+            const value = readIntValue(event.currentTarget);
+            updateSetField(index, 'reps', value);
+        });
+
+        const weight = document.createElement('input');
+        weight.type = 'number';
+        weight.step = '0.5';
+        weight.inputMode = 'decimal';
+        weight.className = 'input';
+        weight.placeholder = 'Poids';
+        weight.value = set.weight ?? '';
+        weight.addEventListener('input', (event) => {
+            const value = readFloatValue(event.currentTarget);
+            updateSetField(index, 'weight', value);
+        });
+
+        const rpe = document.createElement('input');
+        rpe.type = 'number';
+        rpe.step = '0.5';
+        rpe.inputMode = 'decimal';
+        rpe.className = 'input';
+        rpe.placeholder = 'RPE';
+        rpe.value = set.rpe ?? '';
+        rpe.addEventListener('input', (event) => {
+            const value = readFloatValue(event.currentTarget);
+            updateSetField(index, 'rpe', value);
+        });
+
+        const actions = document.createElement('div');
+        actions.className = 'routine-set-actions';
+        actions.appendChild(createActionButton('↑', 'Monter', () => moveSet(index, -1)));
+        actions.appendChild(createActionButton('↓', 'Descendre', () => moveSet(index, 1)));
+        actions.appendChild(createActionButton('🗑️', 'Supprimer', () => removeSet(index)));
+
+        row.append(order, reps, weight, rpe, actions);
+        return row;
+    }
+
+    function createActionButton(symbol, title, handler) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn ghost btn-icon';
+        button.title = title;
+        button.textContent = symbol;
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            handler();
+        });
+        return button;
+    }
+
+    function addSet() {
+        const move = findMove();
+        if (!move) {
+            return;
+        }
+        const sets = Array.isArray(move.sets) ? move.sets : [];
+        sets.push({
+            pos: sets.length + 1,
+            reps: null,
+            weight: null,
+            rpe: null,
+            rest: null
+        });
+        move.sets = sets;
+        scheduleSave();
+        renderSets();
+    }
+
+    function updateSetField(index, field, value) {
+        const move = findMove();
+        if (!move) {
+            return;
+        }
+        if (!Array.isArray(move.sets) || !move.sets[index]) {
+            return;
+        }
+        move.sets[index] = {
+            ...move.sets[index],
+            [field]: value,
+            pos: index + 1
+        };
+        scheduleSave();
+    }
+
+    function moveSet(index, delta) {
+        const move = findMove();
+        if (!move) {
+            return;
+        }
+        const sets = move.sets || [];
+        const targetIndex = index + delta;
+        if (targetIndex < 0 || targetIndex >= sets.length) {
+            return;
+        }
+        const [item] = sets.splice(index, 1);
+        sets.splice(targetIndex, 0, item);
+        sets.forEach((set, idx) => {
+            set.pos = idx + 1;
+        });
+        move.sets = sets;
+        scheduleSave();
+        renderSets();
+    }
+
+    function removeSet(index) {
+        const move = findMove();
+        if (!move) {
+            return;
+        }
+        if (!Array.isArray(move.sets) || !move.sets[index]) {
+            return;
+        }
+        move.sets.splice(index, 1);
+        move.sets.forEach((set, idx) => {
+            set.pos = idx + 1;
+        });
+        scheduleSave();
+        renderSets();
+    }
+
+    async function removeMove() {
+        if (!state.routine) {
+            return;
+        }
+        if (!confirm('Supprimer cet exercice de la routine ?')) {
+            return;
+        }
+        const moves = state.routine.moves || [];
+        const index = moves.findIndex((move) => move.id === state.moveId);
+        if (index === -1) {
+            return;
+        }
+        moves.splice(index, 1);
+        moves.forEach((move, idx) => {
+            move.pos = idx + 1;
+        });
+        state.routine.moves = moves;
+        await persistRoutine();
+        returnToCaller();
+    }
+
+    function scheduleSave() {
+        if (state.pendingSave) {
+            clearTimeout(state.pendingSave);
+        }
+        state.pendingSave = setTimeout(() => {
+            state.pendingSave = null;
+            void persistRoutine();
+        }, 250);
+    }
+
+    async function persistRoutine() {
+        if (!state.routine) {
+            return;
+        }
+        await db.put('routines', serializeRoutine(state.routine));
+        await A.refreshRoutineEdit();
+    }
+
+    function normalizeRoutine(routine) {
+        if (!routine) {
+            return null;
+        }
+        return {
+            id: routine.id,
+            name: routine.name || 'Routine',
+            icon: routine.icon || '🏋️',
+            moves: Array.isArray(routine.moves)
+                ? routine.moves.map((move, index) => ({
+                    id: move.id || uid('move'),
+                    pos: safeInt(move.pos, index + 1),
+                    exerciseId: move.exerciseId,
+                    exerciseName: move.exerciseName || 'Exercice',
+                    sets: Array.isArray(move.sets)
+                        ? move.sets.map((set, idx) => ({
+                            pos: safeInt(set.pos, idx + 1),
+                            reps: safeIntOrNull(set.reps),
+                            weight: safeFloatOrNull(set.weight),
+                            rpe: safeFloatOrNull(set.rpe),
+                            rest: safeIntOrNull(set.rest)
+                        }))
+                        : []
+                }))
+                : []
+        };
+    }
+
+    function serializeRoutine(routine) {
+        return {
+            id: routine.id,
+            name: routine.name,
+            icon: routine.icon,
+            moves: Array.isArray(routine.moves)
+                ? routine.moves.map((move, index) => ({
+                    id: move.id || uid('move'),
+                    pos: safeInt(move.pos, index + 1),
+                    exerciseId: move.exerciseId,
+                    exerciseName: move.exerciseName,
+                    sets: Array.isArray(move.sets)
+                        ? move.sets.map((set, idx) => ({
+                            pos: safeInt(set.pos, idx + 1),
+                            reps: safeIntOrNull(set.reps),
+                            weight: safeFloatOrNull(set.weight),
+                            rpe: safeFloatOrNull(set.rpe),
+                            rest: safeIntOrNull(set.rest)
+                        }))
+                        : []
+                }))
+                : []
+        };
+    }
+
+    function findMove() {
+        if (!state.routine) {
+            return null;
+        }
+        return state.routine.moves?.find((move) => move.id === state.moveId) || null;
+    }
+
+    function returnToCaller() {
+        switchScreen(state.callerScreen || 'screenRoutineEdit');
+        void A.refreshRoutineEdit();
+    }
+
+    function switchScreen(target) {
+        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineEdit, screenRoutineMoveEdit } = assertRefs();
+        const map = {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit
+        };
+        Object.entries(map).forEach(([key, element]) => {
+            if (element) {
+                element.hidden = key !== target;
+            }
+        });
+    }
+
+    function safeInt(value, fallback = null) {
+        const number = Number.parseInt(value, 10);
+        return Number.isFinite(number) ? number : fallback;
+    }
+
+    function safeFloatOrNull(value) {
+        const number = Number.parseFloat(value);
+        return Number.isFinite(number) ? number : null;
+    }
+
+    function safeIntOrNull(value) {
+        const number = Number.parseInt(value, 10);
+        return Number.isFinite(number) ? number : null;
+    }
+
+    function readIntValue(input) {
+        if (!(input instanceof HTMLInputElement)) {
+            return null;
+        }
+        return safeIntOrNull(input.value);
+    }
+
+    function readFloatValue(input) {
+        if (!(input instanceof HTMLInputElement)) {
+            return null;
+        }
+        return safeFloatOrNull(input.value);
+    }
+
+    function uid(prefix) {
+        return `${prefix}-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+    }
+})();


### PR DESCRIPTION
## Summary
- add a routine editing screen with name/icon controls and a session-style list of exercises
- implement routine editing logic, drag-and-drop ordering, and a template set editor for planned series
- seed the default routine and update navigation/styles so the new screens integrate with existing flows

## Testing
- not run (UI only change)


------
https://chatgpt.com/codex/tasks/task_e_68d80562eb788332bf428c9300061637