### PR TITLE
Add routine list screen accessible from stats tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,15 +67,49 @@
   </section>
 <!-- ==================== -->
 
+<!-- ========== Routine : liste ========== -->
+<section id="screenRoutineList" class="screen" hidden>
+
+    <header class="header">
+        <div class="header-left">
+            <button class="btn ghost" title="Retour">◀︎</button>
+        </div>
+
+        <div class="header-center">
+            <div class="title">Routines</div>
+        </div>
+
+        <div class="header-right">
+            <button class="btn primary" title="OK">OK</button>
+        </div>
+    </header>
+
+    <main class="content">
+        <section id="routineCatalog" class="session-list" aria-label="Routines enregistrées"></section>
+
+        <div class="bloque">
+            <div class="row">
+                <button id="btnRoutineCreate" class="btn full">Créer une nouvelle routine</button>
+            </div>
+        </div>
+    </main>
+
+</section>
+<!-- ==================== -->
+
 <!-- ========== Routine : édition template ========== -->
 <section id="screenRoutineEdit" class="screen" hidden>
 
     <header class="header">
-        <div class="header-left"></div>
+        <div class="header-left">
+            <button id="routineEditBack" class="btn ghost" title="Retour">◀︎</button>
+        </div>
         <div class="header-center">
             <div class="title">Routine</div>
         </div>
-        <div class="header-right"></div>
+        <div class="header-right">
+            <button id="routineEditOk" class="btn primary" title="Valider">OK</button>
+        </div>
     </header>
 
     <main class="content">
@@ -359,6 +393,7 @@
 <script src="ui-exercise-read.js"></script>
 <script src="ui-exercise-edit.js"></script>
 <script src="ui-exercises_list.js"></script>
+<script src="ui-routine-list.js"></script>
 <script src="ui-routine-edit.js"></script>
 <script src="ui-routine-move-edit.js"></script>
 <script src="ui-exec-edit.js"></script>

--- a/init.js
+++ b/init.js
@@ -38,7 +38,7 @@
     }
 
     function wireNavigation() {
-        const { tabLibraries, tabSessions, tabSettings, screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit } = refs;
+        const { tabLibraries, tabSessions, tabSettings, tabStats, screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit, screenRoutineList } = refs;
 
         tabLibraries?.addEventListener('click', async () => {
             setActiveTab('tabLibraries');
@@ -54,6 +54,12 @@
             await A.renderSession();
         });
 
+        tabStats?.addEventListener('click', async () => {
+            setActiveTab('tabStats');
+            showOnly('routineList');
+            await A.openRoutineList();
+        });
+
         tabSettings?.addEventListener('click', async () => {
             setActiveTab('tabSettings');
             showOnly('routine');
@@ -65,6 +71,7 @@
         screenExerciseEdit?.setAttribute('data-screen', 'edit');
         screenRoutineEdit?.setAttribute('data-screen', 'routine');
         screenRoutineMoveEdit?.setAttribute('data-screen', 'routineMove');
+        screenRoutineList?.setAttribute('data-screen', 'routineList');
     }
 
     function wireCalendar() {
@@ -113,12 +120,14 @@
         refs.calNext = document.getElementById('calNext');
         refs.tabLibraries = document.getElementById('tabLibraries');
         refs.tabSessions = document.getElementById('tabSessions');
+        refs.tabStats = document.getElementById('tabStats');
         refs.tabSettings = document.getElementById('tabSettings');
         refs.screenSessions = document.getElementById('screenSessions');
         refs.screenExercises = document.getElementById('screenExercises');
         refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenRoutineList = document.getElementById('screenRoutineList');
         refs.screenExecEdit = document.getElementById('screenExecEdit');
         refsResolved = true;
         return refs;
@@ -135,6 +144,7 @@
             'bigCalendar',
             'tabLibraries',
             'tabSessions',
+            'tabStats',
             'tabSettings'
         ];
         const missing = required.filter((key) => !refs[key]);
@@ -153,7 +163,7 @@
     }
 
     function showOnly(which) {
-        const { screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit, screenExecEdit } = refs;
+        const { screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit, screenExecEdit, screenRoutineList } = refs;
         if (screenSessions) {
             screenSessions.hidden = which !== 'sessions';
         }
@@ -171,6 +181,9 @@
         }
         if (screenExecEdit) {
             screenExecEdit.hidden = which !== 'exec';
+        }
+        if (screenRoutineList) {
+            screenRoutineList.hidden = which !== 'routineList';
         }
     }
 

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -27,6 +27,7 @@
         ensureRefs();
         wireInputs();
         wireAddExercisesButton();
+        wireHeaderButtons();
     });
 
     /* ACTIONS */
@@ -61,12 +62,15 @@
         refs.screenExerciseRead = document.getElementById('screenExerciseRead');
         refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
         refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineList = document.getElementById('screenRoutineList');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
         refs.routineName = document.getElementById('routineName');
         refs.routineIcon = document.getElementById('routineIcon');
         refs.routineList = document.getElementById('routineList');
         refs.btnRoutineAddExercises = document.getElementById('btnRoutineAddExercises');
+        refs.routineEditBack = document.getElementById('routineEditBack');
+        refs.routineEditOk = document.getElementById('routineEditOk');
         refsResolved = true;
         return refs;
     }
@@ -78,13 +82,25 @@
             'routineName',
             'routineIcon',
             'routineList',
-            'btnRoutineAddExercises'
+            'btnRoutineAddExercises',
+            'routineEditBack',
+            'routineEditOk'
         ];
         const missing = required.filter((key) => !refs[key]);
         if (missing.length) {
             throw new Error(`ui-routine-edit.js: références manquantes (${missing.join(', ')})`);
         }
         return refs;
+    }
+
+    function wireHeaderButtons() {
+        const { routineEditBack, routineEditOk } = assertRefs();
+        routineEditBack.addEventListener('click', () => {
+            void A.openRoutineList();
+        });
+        routineEditOk.addEventListener('click', () => {
+            void A.openRoutineList();
+        });
     }
 
     async function loadRoutine(force = false) {
@@ -472,6 +488,12 @@
         }
         await db.put('routines', serializeRoutine(state.routine));
         void A.refreshRoutineEdit();
+        if (typeof A.refreshRoutineList === 'function') {
+            void A.refreshRoutineList();
+        }
+        if (typeof A.populateRoutineSelect === 'function') {
+            void A.populateRoutineSelect();
+        }
     }
 
     function scheduleSave() {
@@ -544,7 +566,7 @@
     }
 
     function switchScreen(target) {
-        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineEdit, screenRoutineMoveEdit } = assertRefs();
+        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineEdit, screenRoutineMoveEdit, screenRoutineList } = assertRefs();
         const map = {
             screenSessions,
             screenExercises,
@@ -552,6 +574,7 @@
             screenExerciseRead,
             screenExecEdit,
             screenRoutineEdit,
+            screenRoutineList,
             screenRoutineMoveEdit
         };
         Object.entries(map).forEach(([key, element]) => {

--- a/ui-routine-list.js
+++ b/ui-routine-list.js
@@ -1,0 +1,216 @@
+// ui-routine-list.js — liste des routines
+(() => {
+    const A = window.App;
+
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
+    const state = {
+        routines: [],
+        active: false
+    };
+
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        wireCreateButton();
+    });
+
+    /* ACTIONS */
+    A.openRoutineList = async function openRoutineList() {
+        ensureRefs();
+        highlightStatsTab();
+        await loadRoutines(true);
+        renderList();
+        switchScreen('screenRoutineList');
+    };
+
+    A.refreshRoutineList = async function refreshRoutineList() {
+        ensureRefs();
+        await loadRoutines(true);
+        state.active = refs.screenRoutineList ? !refs.screenRoutineList.hidden : state.active;
+        if (state.active) {
+            renderList();
+        }
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.screenSessions = document.getElementById('screenSessions');
+        refs.screenExercises = document.getElementById('screenExercises');
+        refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refs.screenExerciseRead = document.getElementById('screenExerciseRead');
+        refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineList = document.getElementById('screenRoutineList');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.routineCatalog = document.getElementById('routineCatalog');
+        refs.btnRoutineCreate = document.getElementById('btnRoutineCreate');
+        refs.tabStats = document.getElementById('tabStats');
+        refsResolved = true;
+        return refs;
+    }
+
+    function assertRefs() {
+        ensureRefs();
+        const required = ['screenRoutineList', 'routineCatalog'];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-routine-list.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
+    }
+
+    function wireCreateButton() {
+        const { btnRoutineCreate } = ensureRefs();
+        if (!btnRoutineCreate) {
+            return;
+        }
+        btnRoutineCreate.addEventListener('click', () => {
+            const id = createRoutineId();
+            highlightStatsTab();
+            A.openRoutineEdit({ routineId: id });
+        });
+    }
+
+    async function loadRoutines(force = false) {
+        if (!force && state.routines.length) {
+            return state.routines;
+        }
+        const raw = await db.getAll('routines');
+        state.routines = Array.isArray(raw) ? raw.slice() : [];
+        return state.routines;
+    }
+
+    function renderList() {
+        const { routineCatalog } = assertRefs();
+        routineCatalog.innerHTML = '';
+        if (!state.routines.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty';
+            empty.textContent = 'Aucune routine enregistrée.';
+            routineCatalog.appendChild(empty);
+            return;
+        }
+        const sorted = [...state.routines].sort((a, b) => {
+            const nameA = (a?.name || '').toLocaleLowerCase('fr-FR');
+            const nameB = (b?.name || '').toLocaleLowerCase('fr-FR');
+            return nameA.localeCompare(nameB);
+        });
+        sorted.forEach((routine) => {
+            routineCatalog.appendChild(renderRoutineCard(routine));
+        });
+    }
+
+    function renderRoutineCard(routine) {
+        const card = document.createElement('article');
+        card.className = 'exercise-card clickable';
+        card.setAttribute('role', 'button');
+        card.setAttribute('aria-label', `${routine?.name || 'Routine'} — éditer`);
+
+        const row = document.createElement('div');
+        row.className = 'exercise-card-row';
+
+        const left = document.createElement('div');
+        left.className = 'exercise-card-left';
+        left.appendChild(renderGrip());
+
+        const textWrapper = document.createElement('div');
+        textWrapper.className = 'exercise-card-text';
+        const title = document.createElement('div');
+        title.className = 'element';
+        title.textContent = routine?.name || 'Routine';
+
+        const details = document.createElement('div');
+        details.className = 'details';
+        details.textContent = buildDetails(routine);
+
+        textWrapper.append(title, details);
+        left.appendChild(textWrapper);
+
+        const right = document.createElement('div');
+        right.className = 'exercise-card-right';
+        const pencil = document.createElement('span');
+        pencil.className = 'session-card-pencil';
+        pencil.setAttribute('aria-hidden', 'true');
+        pencil.textContent = '✏️';
+        right.appendChild(pencil);
+
+        row.append(left, right);
+        card.appendChild(row);
+
+        card.addEventListener('click', () => {
+            highlightStatsTab();
+            A.openRoutineEdit({ routineId: routine?.id });
+        });
+
+        return card;
+    }
+
+    function renderGrip() {
+        const gripWrapper = document.createElement('div');
+        gripWrapper.className = 'session-card-handle';
+        gripWrapper.setAttribute('aria-hidden', 'true');
+        const grip = document.createElement('span');
+        grip.className = 'session-card-grip';
+        for (let index = 0; index < 3; index += 1) {
+            const dot = document.createElement('span');
+            dot.className = 'session-card-grip-dot';
+            grip.appendChild(dot);
+        }
+        gripWrapper.appendChild(grip);
+        return gripWrapper;
+    }
+
+    function buildDetails(routine) {
+        const moves = Array.isArray(routine?.moves) ? routine.moves : [];
+        const exerciseCount = moves.length;
+        const reps = moves.reduce((total, move) => {
+            const sets = Array.isArray(move?.sets) ? move.sets : [];
+            return (
+                total +
+                sets.reduce((subtotal, set) => {
+                    const repsValue = Number.parseInt(set?.reps, 10);
+                    return Number.isFinite(repsValue) ? subtotal + repsValue : subtotal;
+                }, 0)
+            );
+        }, 0);
+        const exerciseLabel = exerciseCount > 1 ? 'exercices' : 'exercice';
+        const repsLabel = reps > 1 ? 'répétitions' : 'répétition';
+        return `${exerciseCount} ${exerciseLabel} • ${reps} ${repsLabel}`;
+    }
+
+    function createRoutineId() {
+        return `routine-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`;
+    }
+
+    function highlightStatsTab() {
+        document.querySelectorAll('.tabbar .tab').forEach((button) => button.classList.remove('active'));
+        if (refs.tabStats) {
+            refs.tabStats.classList.add('active');
+        }
+    }
+
+    function switchScreen(target) {
+        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineList, screenRoutineEdit, screenRoutineMoveEdit } = assertRefs();
+        const map = {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineList,
+            screenRoutineEdit,
+            screenRoutineMoveEdit
+        };
+        Object.entries(map).forEach(([key, element]) => {
+            if (element) {
+                element.hidden = key !== target;
+            }
+        });
+        state.active = target === 'screenRoutineList';
+    }
+})();


### PR DESCRIPTION
## Summary
- add a dedicated routine list screen reachable from the statistics tab with a creation entry point
- update the routine editor header to include return/validation buttons that reopen the list
- refresh navigation wiring and persistence hooks so routine data stays in sync across screens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d966ebb6c08332b9aa11995b3be031