### PR TITLE
Implement virtualized infinite week strip

### DIFF
--- a/style.css
+++ b/style.css
@@ -466,6 +466,10 @@ image_big{
   border-bottom:1px dashed var(--whiteB);
   -webkit-overflow-scrolling:touch;
 }
+.week-strip .week-page{
+  display:flex; gap:var(--gap);
+  flex:0 0 auto;
+}
 .week-strip .day{
   height: var(--control-h);
   display:flex; align-items:center; justify-content:center;

--- a/ui-week.js
+++ b/ui-week.js
@@ -5,6 +5,18 @@
     /* STATE */
     const refs = {};
     let refsResolved = false;
+    const DAYS_PER_PAGE = 7;
+    const HALF_WINDOW = Math.floor(DAYS_PER_PAGE / 2);
+    const VIRTUAL_PAGE_COUNT = 3;
+    const virtualState = {
+        pages: [],
+        adjusting: false,
+        centerStart: null,
+        sessionDates: new Set(),
+        plan: null,
+        today: null,
+        bound: false
+    };
 
     /* WIRE */
     document.addEventListener('DOMContentLoaded', ensureRefs);
@@ -16,49 +28,32 @@
      */
     A.renderWeek = async function renderWeek() {
         const { weekStrip } = assertRefs();
-        weekStrip.innerHTML = '';
+        const pages = ensureVirtualStrip();
 
-        const start = A.addDays(A.currentAnchor, -3);
-        const sessionDates = new Set((await db.listSessionDates()).map((item) => item.date));
-        const today = A.today();
+        const [sessionDates, plan] = await Promise.all([
+            db.listSessionDates(),
+            db.getActivePlan()
+        ]);
 
-        for (let index = 0; index < 7; index += 1) {
-            const date = A.addDays(start, index);
-            const key = A.ymd(date);
-            const isSelected = A.ymd(date) === A.ymd(A.activeDate);
-            const hasSession = sessionDates.has(key);
-            const planned = await isPlannedDate(date);
-            const isFuture = date >= today;
+        virtualState.sessionDates = new Set(sessionDates.map((item) => item.date));
+        virtualState.plan = plan;
+        virtualState.today = A.today();
 
-            const button = document.createElement('button');
-            button.className = 'day';
-            button.textContent = date
-                .toLocaleDateString('fr-FR', { weekday: 'short', day: 'numeric' })
-                .replace('.', '');
+        const anchor = A.currentAnchor || A.activeDate || virtualState.today || A.today();
+        const centerStart = A.addDays(anchor, -HALF_WINDOW);
+        virtualState.centerStart = centerStart;
 
-            if (hasSession) {
-                button.classList.add('has-session');
-            } else if (planned && isFuture) {
-                button.classList.add('planned');
-            }
-            if (isSelected) {
-                button.classList.add('selected');
-            }
+        renderPage(pages[0], A.addDays(centerStart, -DAYS_PER_PAGE));
+        renderPage(pages[1], centerStart);
+        renderPage(pages[2], A.addDays(centerStart, DAYS_PER_PAGE));
 
-            button.addEventListener('click', async () => {
-                A.activeDate = date;
-                await A.populateRoutineSelect();
-                await A.renderWeek();
-                await A.renderSession();
+        virtualState.adjusting = true;
+        requestAnimationFrame(() => {
+            weekStrip.scrollLeft = pages[1].offsetLeft;
+            requestAnimationFrame(() => {
+                virtualState.adjusting = false;
             });
-
-            weekStrip.appendChild(button);
-        }
-
-        const selected = weekStrip.querySelector('.day.selected');
-        if (selected && typeof selected.scrollIntoView === 'function') {
-            selected.scrollIntoView({ inline: 'center', block: 'nearest' });
-        }
+        });
     };
 
     /* UTILS */
@@ -79,12 +74,131 @@
         return refs;
     }
 
-    async function isPlannedDate(date) {
-        const plan = await db.getActivePlan();
+    function ensureVirtualStrip() {
+        const { weekStrip } = assertRefs();
+        if (!virtualState.pages.length) {
+            weekStrip.innerHTML = '';
+            for (let index = 0; index < VIRTUAL_PAGE_COUNT; index += 1) {
+                const page = document.createElement('div');
+                page.className = 'week-page';
+                virtualState.pages.push(page);
+                weekStrip.appendChild(page);
+            }
+        }
+        if (!virtualState.bound) {
+            weekStrip.addEventListener('scroll', handleScroll, { passive: true });
+            virtualState.bound = true;
+        }
+        return virtualState.pages;
+    }
+
+    function renderPage(container, startDate) {
+        if (!container) {
+            return;
+        }
+        container.innerHTML = '';
+
+        for (let index = 0; index < DAYS_PER_PAGE; index += 1) {
+            const date = A.addDays(startDate, index);
+            const key = A.ymd(date);
+            const isSelected = A.activeDate && A.ymd(date) === A.ymd(A.activeDate);
+            const hasSession = virtualState.sessionDates.has(key);
+            const planned = isPlannedDate(date, virtualState.plan);
+            const isFuture = virtualState.today && date >= virtualState.today;
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'day';
+            button.textContent = date
+                .toLocaleDateString('fr-FR', { weekday: 'short', day: 'numeric' })
+                .replace('.', '');
+
+            if (hasSession) {
+                button.classList.add('has-session');
+            } else if (planned && isFuture) {
+                button.classList.add('planned');
+            }
+            if (isSelected) {
+                button.classList.add('selected');
+            }
+
+            button.addEventListener('click', async () => {
+                A.activeDate = date;
+                A.currentAnchor = new Date(date);
+                await A.populateRoutineSelect();
+                await A.renderWeek();
+                await A.renderSession();
+            });
+
+            container.appendChild(button);
+        }
+    }
+
+    function handleScroll() {
+        if (virtualState.adjusting) {
+            return;
+        }
+        const { weekStrip } = assertRefs();
+        const pages = virtualState.pages;
+        if (pages.length < 3) {
+            return;
+        }
+
+        const scrollLeft = weekStrip.scrollLeft;
+        const tolerance = 4;
+        const prevOffset = pages[0].offsetLeft;
+        const nextOffset = pages[2].offsetLeft;
+
+        if (scrollLeft <= prevOffset + tolerance) {
+            shiftPages(-1);
+            return;
+        }
+        if (nextOffset && scrollLeft >= nextOffset - tolerance) {
+            shiftPages(1);
+        }
+    }
+
+    function shiftPages(direction) {
+        const { weekStrip } = assertRefs();
+        if (direction === 0 || !weekStrip) {
+            return;
+        }
+
+        virtualState.adjusting = true;
+
+        const baseAnchor = A.currentAnchor || virtualState.centerStart || virtualState.today || A.today();
+
+        if (direction > 0) {
+            const [prev, center, next] = virtualState.pages;
+            weekStrip.appendChild(prev);
+            virtualState.pages = [center, next, prev];
+            virtualState.centerStart = A.addDays(virtualState.centerStart || baseAnchor, DAYS_PER_PAGE);
+            A.currentAnchor = A.addDays(baseAnchor, DAYS_PER_PAGE);
+        } else {
+            const [prev, center, next] = virtualState.pages;
+            weekStrip.insertBefore(next, prev);
+            virtualState.pages = [next, prev, center];
+            virtualState.centerStart = A.addDays(virtualState.centerStart || baseAnchor, -DAYS_PER_PAGE);
+            A.currentAnchor = A.addDays(baseAnchor, -DAYS_PER_PAGE);
+        }
+
+        renderPage(virtualState.pages[0], A.addDays(virtualState.centerStart, -DAYS_PER_PAGE));
+        renderPage(virtualState.pages[1], virtualState.centerStart);
+        renderPage(virtualState.pages[2], A.addDays(virtualState.centerStart, DAYS_PER_PAGE));
+
+        requestAnimationFrame(() => {
+            weekStrip.scrollLeft = virtualState.pages[1].offsetLeft;
+            requestAnimationFrame(() => {
+                virtualState.adjusting = false;
+            });
+        });
+    }
+
+    function isPlannedDate(date, plan) {
         if (!plan) {
             return false;
         }
         const weekday = (date.getDay() + 6) % 7 + 1;
-        return Boolean(plan.days[String(weekday)]);
+        return Boolean(plan.days?.[String(weekday)]);
     }
 })();


### PR DESCRIPTION
## Summary
- virtualize the week strip with reusable week pages to simulate infinite scrolling while rendering only 21 days at a time
- keep session and planned indicators in sync when recycling pages and recentering on the selected day
- add styling for the new week page containers in the strip

## Testing
- no automated tests were run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d9839d48248332b9d5acf28e5c7d30