### PR TITLE
Align weekly carousel to Monday and improve layout

### DIFF
--- a/init.js
+++ b/init.js
@@ -19,7 +19,7 @@
     /* ACTIONS */
     async function bootstrap() {
         A.activeDate = A.today();
-        A.currentAnchor = new Date(A.activeDate);
+        A.currentAnchor = A.startOfWeek(A.activeDate);
         A.calendarMonth = new Date(A.activeDate.getFullYear(), A.activeDate.getMonth(), 1);
 
         await db.init();

--- a/state.js
+++ b/state.js
@@ -54,5 +54,18 @@
         return next;
     };
 
+    /**
+     * Retourne le lundi de la semaine contenant la date fournie.
+     * @param {Date} date Date de base.
+     * @returns {Date} Lundi correspondant.
+     */
+    existing.startOfWeek = function startOfWeek(date) {
+        const base = new Date(date);
+        const day = base.getDay();
+        const diff = (day + 6) % 7;
+        base.setDate(base.getDate() - diff);
+        return new Date(base.toDateString());
+    };
+
     window.App = existing;
 })();

--- a/style.css
+++ b/style.css
@@ -469,13 +469,16 @@ image_big{
   -webkit-overflow-scrolling:touch;
 }
 .week-strip .week-page{
-  display:flex; gap:var(--gap);
-  flex:0 0 auto;
+  display:grid; grid-template-columns:repeat(7,minmax(0,1fr));
+  gap:var(--gap);
+  flex:0 0 100%; width:100%;
 }
 .week-strip .day{
   height: var(--control-h);
-  display:flex; align-items:center; justify-content:center;
-  padding: 0 var(--pad-x);
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  gap:4px;
+  padding:6px 4px;
+  text-align:center; white-space:normal; line-height:1.1;
   border:1px solid var(--whiteB);
   border-radius: var(--radius);
   background: var(--whiteB);
@@ -483,6 +486,9 @@ image_big{
   user-select:none; cursor:pointer;
   transition: transform .06s ease;
 }
+.week-strip .day span{ display:block; }
+.week-strip .day-weekday{ font-size: var(--fs-small); text-transform:capitalize; }
+.week-strip .day-number{ font-size:1.1em; }
 .week-strip .day:active{ transform: scale(.98); }
 
 /* Règles de priorité: selected > has-session > planned */

--- a/ui-calendar.js
+++ b/ui-calendar.js
@@ -73,7 +73,7 @@
 
             cell.addEventListener('click', async () => {
                 A.activeDate = date;
-                A.currentAnchor = date;
+                A.currentAnchor = A.startOfWeek(date);
                 await A.populateRoutineSelect();
                 await A.renderWeek();
                 await A.renderSession();


### PR DESCRIPTION
## Summary
- add a start-of-week helper and use it to align the weekly carousel on Monday-to-Sunday windows
- render week-day buttons with stacked labels and grid layout so seven days fill the strip width
- keep calendar selections in sync with the carousel anchor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da3b578fd48332aa5b8becddce28b7