### PR TITLE
Add user rest preference and time picker for routine sets

### DIFF
--- a/components/time-picker.js
+++ b/components/time-picker.js
@@ -1,0 +1,184 @@
+(() => {
+    const existing = window.App || {};
+    const components = existing.components || {};
+
+    class TimePicker {
+        constructor(options = {}) {
+            this.value = this.#sanitize(options.value ?? null);
+            this.onChange = typeof options.onChange === 'function' ? options.onChange : null;
+            this.label = options.label || 'Durée';
+            this.maxMinutes = Number.isFinite(options.maxMinutes) ? Math.max(0, Math.floor(options.maxMinutes)) : 59;
+            this.defaultValue = this.#sanitize(
+                options.defaultValue ?? existing.preferences?.getDefaultTimerDuration?.() ?? 0
+            );
+            this.container = document.createElement('div');
+            this.container.className = 'time-picker';
+            this.button = document.createElement('button');
+            this.button.type = 'button';
+            this.button.className = 'input time-picker-input';
+            this.button.setAttribute('aria-haspopup', 'dialog');
+            this.button.addEventListener('click', () => this.open());
+            this.container.appendChild(this.button);
+            this.#updateDisplay();
+        }
+
+        get element() {
+            return this.container;
+        }
+
+        get valueSeconds() {
+            return this.value;
+        }
+
+        setValue(seconds, notify = false) {
+            this.value = this.#sanitize(seconds);
+            this.#updateDisplay();
+            if (notify && this.onChange) {
+                this.onChange(this.value);
+            }
+        }
+
+        open() {
+            const dialog = this.#ensureDialog();
+            const totalSeconds = this.value ?? this.defaultValue ?? 0;
+            const currentMinutes = Math.floor(totalSeconds / 60);
+            const currentSeconds = Math.max(0, Math.round(totalSeconds - currentMinutes * 60));
+            this.minuteSelect.value = String(Math.min(currentMinutes, this.maxMinutes));
+            this.secondSelect.value = String(Math.min(currentSeconds, 59));
+            dialog.showModal();
+        }
+
+        #ensureDialog() {
+            if (this.dialog) {
+                return this.dialog;
+            }
+            const dialog = document.createElement('dialog');
+            dialog.className = 'time-picker-dialog';
+
+            const form = document.createElement('form');
+            form.method = 'dialog';
+            form.className = 'time-picker-form';
+
+            const title = document.createElement('div');
+            title.className = 'time-picker-title';
+            title.textContent = this.label;
+            form.appendChild(title);
+
+            const wheels = document.createElement('div');
+            wheels.className = 'time-picker-wheels';
+
+            const minutesWrap = document.createElement('label');
+            minutesWrap.className = 'time-picker-wheel';
+            minutesWrap.textContent = 'Minutes';
+            const minuteSelect = document.createElement('select');
+            minuteSelect.size = 5;
+            minuteSelect.className = 'time-picker-select';
+            for (let minute = 0; minute <= this.maxMinutes; minute += 1) {
+                const option = document.createElement('option');
+                option.value = String(minute);
+                option.textContent = minute.toString().padStart(2, '0');
+                minuteSelect.appendChild(option);
+            }
+            minutesWrap.appendChild(minuteSelect);
+
+            const secondsWrap = document.createElement('label');
+            secondsWrap.className = 'time-picker-wheel';
+            secondsWrap.textContent = 'Secondes';
+            const secondSelect = document.createElement('select');
+            secondSelect.size = 5;
+            secondSelect.className = 'time-picker-select';
+            for (let second = 0; second < 60; second += 1) {
+                const option = document.createElement('option');
+                option.value = String(second);
+                option.textContent = second.toString().padStart(2, '0');
+                secondSelect.appendChild(option);
+            }
+            secondsWrap.appendChild(secondSelect);
+
+            wheels.append(minutesWrap, secondsWrap);
+            form.appendChild(wheels);
+
+            const actions = document.createElement('div');
+            actions.className = 'time-picker-actions';
+            const cancelButton = document.createElement('button');
+            cancelButton.type = 'submit';
+            cancelButton.value = 'cancel';
+            cancelButton.className = 'btn ghost';
+            cancelButton.textContent = 'Annuler';
+            const okButton = document.createElement('button');
+            okButton.type = 'submit';
+            okButton.value = 'confirm';
+            okButton.className = 'btn primary';
+            okButton.textContent = 'Valider';
+            actions.append(cancelButton, okButton);
+            form.appendChild(actions);
+
+            form.addEventListener('submit', (event) => {
+                event.preventDefault();
+                const submitter = event.submitter;
+                if (submitter?.value === 'confirm') {
+                    dialog.close('confirm');
+                } else {
+                    dialog.close('cancel');
+                }
+            });
+
+            dialog.addEventListener('cancel', (event) => {
+                event.preventDefault();
+                dialog.close('cancel');
+            });
+
+            dialog.addEventListener('close', () => {
+                if (dialog.returnValue === 'confirm') {
+                    const selectedMinutes = Number.parseInt(this.minuteSelect.value, 10) || 0;
+                    const selectedSeconds = Number.parseInt(this.secondSelect.value, 10) || 0;
+                    const total = selectedMinutes * 60 + selectedSeconds;
+                    this.setValue(total, true);
+                }
+                this.button.focus();
+            });
+
+            document.body.appendChild(dialog);
+            this.dialog = dialog;
+            this.minuteSelect = minuteSelect;
+            this.secondSelect = secondSelect;
+            return dialog;
+        }
+
+        #sanitize(value) {
+            if (value === null || value === undefined || value === '') {
+                return null;
+            }
+            const number = Number(value);
+            if (!Number.isFinite(number) || number < 0) {
+                return null;
+            }
+            return Math.round(number);
+        }
+
+        #updateDisplay() {
+            const value = this.value;
+            const hasValue = Number.isFinite(value) && value !== null;
+            const displayValue = hasValue ? TimePicker.format(value) : '--:--';
+            this.button.textContent = displayValue;
+            if (hasValue) {
+                this.button.classList.add('has-value');
+            } else {
+                this.button.classList.remove('has-value');
+            }
+        }
+
+        static format(totalSeconds) {
+            const seconds = Math.max(0, Number.isFinite(totalSeconds) ? Math.round(totalSeconds) : 0);
+            const minutesPart = Math.floor(seconds / 60)
+                .toString()
+                .padStart(2, '0');
+            const secondsPart = (seconds % 60).toString().padStart(2, '0');
+            return `${minutesPart}:${secondsPart}`;
+        }
+    }
+
+    components.TimePicker = TimePicker;
+    existing.components = components;
+    window.App = existing;
+})();

--- a/index.html
+++ b/index.html
@@ -155,12 +155,11 @@
         </div>
 
         <div class="exec-grid exec-head routine-set-grid">
-            <div></div>
             <div>#</div>
             <div>Reps</div>
             <div>Poids</div>
-            <div>Temps de repos</div>
-            <div></div>
+            <div>Repos</div>
+            <div>Sup.</div>
         </div>
 
         <div id="routineMoveSets"></div>
@@ -384,9 +383,11 @@
 <!-- ==================== -->
   
 <!-- JS (ordre important) -->
-<script src="cfg.js"></script> 
+<script src="cfg.js"></script>
 <script src="db.js"></script>
 <script src="state.js"></script>
+<script src="preferences.js"></script>
+<script src="components/time-picker.js"></script>
 <script src="ui-week.js"></script>
 <script src="ui-calendar.js"></script>
 <script src="ui-session.js"></script>

--- a/preferences.js
+++ b/preferences.js
@@ -1,0 +1,81 @@
+(() => {
+    const existing = window.App || {};
+
+    /* STATE */
+    const STORAGE_KEY = 'a0.preferences';
+    const DEFAULTS = {
+        defaultTimerDuration: 90
+    };
+    let cache = null;
+
+    /* ACTIONS */
+    function ensureLoaded() {
+        if (cache) {
+            return cache;
+        }
+        let stored = null;
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            stored = raw ? JSON.parse(raw) : null;
+        } catch (error) {
+            console.warn('Préférences illisibles, réinitialisation.', error);
+        }
+        if (!stored || typeof stored !== 'object') {
+            stored = {};
+        }
+        cache = {
+            ...DEFAULTS,
+            ...stored
+        };
+        cache.defaultTimerDuration = sanitizeDuration(cache.defaultTimerDuration);
+        return cache;
+    }
+
+    function persist() {
+        if (!cache) {
+            return;
+        }
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+        } catch (error) {
+            console.warn('Impossible de sauvegarder les préférences.', error);
+        }
+    }
+
+    function sanitizeDuration(value) {
+        const number = Number(value);
+        if (!Number.isFinite(number) || number < 0) {
+            return DEFAULTS.defaultTimerDuration;
+        }
+        return Math.round(number);
+    }
+
+    /* EXPORT */
+    const preferences = existing.preferences || {};
+
+    preferences.getAll = function getAll() {
+        const data = ensureLoaded();
+        return { ...data };
+    };
+
+    preferences.getDefaultTimerDuration = function getDefaultTimerDuration() {
+        const data = ensureLoaded();
+        return sanitizeDuration(data.defaultTimerDuration);
+    };
+
+    preferences.setDefaultTimerDuration = function setDefaultTimerDuration(seconds) {
+        const data = ensureLoaded();
+        const sanitized = sanitizeDuration(seconds);
+        data.defaultTimerDuration = sanitized;
+        persist();
+        return sanitized;
+    };
+
+    preferences.reset = function reset() {
+        cache = { ...DEFAULTS };
+        persist();
+    };
+
+    existing.preferences = preferences;
+    window.App = existing;
+})();

--- a/style.css
+++ b/style.css
@@ -564,7 +564,7 @@ image_big{
   text-align:center; align-items:center;
 }
 .exec-grid.routine-set-grid{
-  grid-template-columns: auto 48px 1fr 1fr 1fr auto; /* Drag | # | Reps | Poids | Repos | Actions */
+  grid-template-columns: minmax(48px, 0.6fr) 1fr 1fr 1fr auto; /* # | Reps | Poids | Repos | Actions */
 }
 .exec-head{ font-weight: var(--fw-strong); }
 .exec-row .input{
@@ -616,34 +616,72 @@ image_big{
   gap:8px;
 }
 
-.routine-set-handle{
+.routine-set-order{
+  font-weight: var(--fw-strong);
+}
+
+.time-picker{
+  width:100%;
+}
+
+.time-picker-input{
   display:flex;
   align-items:center;
   justify-content:center;
-  cursor:grab;
-  font-size:20px;
-  color:var(--darkGrayB);
-  user-select:none;
-}
-.routine-set-row,
-.routine-set-row *,
-.routine-set-actions,
-.routine-set-actions *{
-  -webkit-user-select: none;
-  user-select: none;
+  gap:4px;
+  cursor:pointer;
 }
 
-.routine-set-row.routine-set-dragging{
-  opacity:0.95;
+.time-picker-dialog{
+  border:none;
+  border-radius:var(--radius);
+  padding:16px;
+  width:min(320px, 90vw);
 }
 
-.routine-set-placeholder{
-  border:1px dashed var(--whiteB);
+.time-picker-dialog::backdrop{
+  background:rgba(0,0,0,0.35);
+}
+
+.time-picker-form{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.time-picker-title{
+  font-weight: var(--fw-strong);
+  text-align:center;
+}
+
+.time-picker-wheels{
+  display:flex;
+  justify-content:center;
+  gap:16px;
+}
+
+.time-picker-wheel{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:8px;
+  font-weight: var(--fw-strong);
+  color: var(--darkGrayB);
+}
+
+.time-picker-select{
+  width:72px;
+  height:160px;
+  text-align:center;
+  font-size: var(--fs-base);
+  border:1px solid var(--whiteB);
   border-radius:var(--radius);
 }
 
-.routine-set-placeholder > *{
-  visibility:hidden;
+.time-picker-actions{
+  display:flex;
+  justify-content:flex-end;
+  gap:8px;
 }
 
 .btn-icon{


### PR DESCRIPTION
## Summary
- add a lightweight preferences module with a default 90s timer duration
- introduce a reusable mm:ss time picker component and use it for routine rest inputs
- align the routine template grid with consistent columns and carry previous set defaults when adding rows

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da4b50ebe4833280ce274b3982feb8