### PR TITLE
Add navigation controls to week date carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,11 @@
     <main class="content">
   
         <!-- Calendrier 1 semaine défilable -->
-        <section class="week-strip" id="weekStrip" aria-label="Calendrier 1 semaine"></section>
+        <div class="week-strip-wrapper">
+            <button id="weekPrev" class="week-strip-nav" type="button" title="Semaine précédente" aria-label="Afficher les jours précédents">◀︎</button>
+            <section class="week-strip" id="weekStrip" aria-label="Calendrier 1 semaine"></section>
+            <button id="weekNext" class="week-strip-nav" type="button" title="Semaine suivante" aria-label="Afficher les jours suivants">▶︎</button>
+        </div>
   
         <!-- Liste des exercices de la séance -->
         <section id="sessionList" class="session-list" aria-label="Séance du jour"></section>

--- a/style.css
+++ b/style.css
@@ -462,12 +462,30 @@ image_big{
 /* =========================================================
    7) Semaine & calendrier
    ========================================================= */
+.week-strip-wrapper{
+  display:flex; align-items:center; gap:var(--gap);
+  margin-bottom:12px;
+}
 .week-strip{
   display:flex; gap:var(--gap); overflow-x:auto;
-  padding-bottom:8px; margin-bottom:12px;
+  padding-bottom:8px; margin-bottom:0;
   border-bottom:1px dashed var(--whiteB);
   -webkit-overflow-scrolling:touch;
+  scrollbar-width:none;
 }
+.week-strip::-webkit-scrollbar{ display:none; }
+.week-strip-nav{
+  display:flex; align-items:center; justify-content:center;
+  width: var(--control-h); height: var(--control-h);
+  border-radius: var(--radius);
+  border:1px solid var(--whiteB);
+  background: var(--whiteB);
+  font-size:1.2rem;
+  cursor:pointer;
+  user-select:none;
+}
+.week-strip-nav:active{ transform: scale(.97); }
+.week-strip-wrapper .week-strip{ flex:1; }
 .week-strip .week-page{
   display:grid; grid-template-columns:repeat(7,minmax(0,1fr));
   gap:var(--gap);

--- a/ui-week.js
+++ b/ui-week.js
@@ -14,7 +14,8 @@
         sessionDates: new Set(),
         plan: null,
         today: null,
-        bound: false
+        bound: false,
+        controlsBound: false
     };
 
     /* WIRE */
@@ -62,6 +63,13 @@
             return refs;
         }
         refs.weekStrip = document.getElementById('weekStrip');
+        refs.weekPrev = document.getElementById('weekPrev');
+        refs.weekNext = document.getElementById('weekNext');
+        if (!virtualState.controlsBound) {
+            refs.weekPrev?.addEventListener('click', () => handleNavClick(-1));
+            refs.weekNext?.addEventListener('click', () => handleNavClick(1));
+            virtualState.controlsBound = true;
+        }
         refsResolved = true;
         return refs;
     }
@@ -90,6 +98,13 @@
             virtualState.bound = true;
         }
         return virtualState.pages;
+    }
+
+    function handleNavClick(direction) {
+        if (virtualState.adjusting) {
+            return;
+        }
+        shiftPages(direction);
     }
 
     function renderPage(container, startDate) {


### PR DESCRIPTION
## Summary
- hide the horizontal scrollbar in the week carousel
- add left/right navigation buttons around the date strip with updated styling
- connect the new controls to the existing week carousel paging logic

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68da53ac1408833280345548edf1b24f