### PR TITLE
Add shared time picker modal for rest durations

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,32 @@
     <div id="bigCalendar" class="big-calendar"></div>
 </dialog>
 <!-- ==================== -->
-  
+
+<!-- ==========  Modale timepicker ========== -->
+<dialog id="dlgTimePicker" class="modal">
+    <form method="dialog" class="timepicker-form" data-role="timepicker-form">
+        <div id="dlgTimePickerLabel" class="timepicker-label" data-role="timepicker-label">Temps de repos</div>
+        <div class="timepicker-body">
+            <div class="vstepper">
+                <button type="button" class="btn" data-action="minutes-plus">+</button>
+                <input id="timePickerMinutes" class="input timepicker-value" type="number" min="0" max="59" inputmode="numeric" data-role="minutes" />
+                <button type="button" class="btn" data-action="minutes-minus">−</button>
+            </div>
+            <div class="timepicker-separator" aria-hidden="true">:</div>
+            <div class="vstepper">
+                <button type="button" class="btn" data-action="seconds-plus">+</button>
+                <input id="timePickerSeconds" class="input timepicker-value" type="number" min="0" max="59" inputmode="numeric" data-role="seconds" />
+                <button type="button" class="btn" data-action="seconds-minus">−</button>
+            </div>
+        </div>
+        <div class="timepicker-actions">
+            <button type="button" class="btn ghost" data-action="cancel">Retour</button>
+            <button type="submit" class="btn primary" data-action="confirm">OK</button>
+        </div>
+    </form>
+</dialog>
+<!-- ==================== -->
+
 <!-- JS (ordre important) -->
 <script src="cfg.js"></script>
 <script src="db.js"></script>

--- a/style.css
+++ b/style.css
@@ -650,6 +650,43 @@ image_big{
   cursor:pointer;
 }
 
+.timepicker-form{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  padding: var(--pad-y) var(--pad-x);
+}
+
+.timepicker-label{
+  text-align:center;
+  font-weight: var(--fw-strong);
+}
+
+.timepicker-body{
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:16px;
+}
+
+.timepicker-value{
+  text-align:center;
+  font-weight: var(--fw-strong);
+  min-width:72px;
+}
+
+.timepicker-separator{
+  font-size:32px;
+  line-height:1;
+  font-weight: var(--fw-strong);
+}
+
+.timepicker-actions{
+  display:flex;
+  justify-content:flex-end;
+  gap:8px;
+}
+
 .time-picker-dialog{
   border:none;
   border-radius:var(--radius);


### PR DESCRIPTION
## Summary
- add a shared time picker dialog to index.html with minute/second steppers and reusable styling
- rework the TimePicker component to drive the shared dialog and clamp values via plus/minus controls
- update the execution editor to use the component for rest inputs and adjust supporting styles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da6c59aa6483329c928aa80506c436