### PR TITLE
Improve time picker interactions

### DIFF
--- a/components/time-picker.js
+++ b/components/time-picker.js
@@ -194,10 +194,10 @@
                 TimePicker.#adjustInput(refs.minutesInput, -1, max);
             });
             refs.secondsPlus?.addEventListener('click', () => {
-                TimePicker.#adjustInput(refs.secondsInput, 1, 59);
+                TimePicker.#adjustInput(refs.secondsInput, 10, 59);
             });
             refs.secondsMinus?.addEventListener('click', () => {
-                TimePicker.#adjustInput(refs.secondsInput, -1, 59);
+                TimePicker.#adjustInput(refs.secondsInput, -10, 59);
             });
 
             refs.minutesInput?.addEventListener('input', () => {
@@ -207,6 +207,9 @@
             refs.secondsInput?.addEventListener('input', () => {
                 TimePicker.#sanitizeInputValue(refs.secondsInput, 59);
             });
+
+            refs.minutesInput?.addEventListener('focus', TimePicker.#selectInputOnFocus);
+            refs.secondsInput?.addEventListener('focus', TimePicker.#selectInputOnFocus);
 
             this.#sharedDialog = refs;
             return refs;
@@ -234,6 +237,16 @@
             const next = Math.max(0, Math.min(max, safe + delta));
             input.value = String(next);
             return next;
+        }
+
+        static #selectInputOnFocus(event) {
+            const target = event?.target;
+            if (!target?.select) {
+                return;
+            }
+            window.requestAnimationFrame(() => {
+                target.select();
+            });
         }
 
         static #sharedDialog = null;

--- a/style.css
+++ b/style.css
@@ -683,8 +683,12 @@ image_big{
 
 .timepicker-actions{
   display:flex;
-  justify-content:flex-end;
   gap:8px;
+  width:100%;
+}
+
+.timepicker-actions .btn{
+  flex:1 1 0%;
 }
 
 .time-picker-dialog{


### PR DESCRIPTION
## Summary
- increment and decrement seconds values in steps of 10 seconds
- automatically select time fields when focused for easier editing
- stretch the dialog action buttons so Retour and OK share the available width

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da7255d29c8332b4f1f07bb0e95ce5