### PR TITLE
Align time picker trigger before opening dialog

### DIFF
--- a/components/time-picker.js
+++ b/components/time-picker.js
@@ -52,6 +52,29 @@
             const minutesValue = Math.min(currentMinutes, this.maxMinutes);
             const secondsValue = Math.min(currentSeconds, 59);
 
+            const button = this.button;
+            if (button) {
+                const content = button.closest?.('.content');
+                const scroller =
+                    (content instanceof HTMLElement && content) ||
+                    document.scrollingElement ||
+                    document.documentElement ||
+                    document.body;
+
+                if (scroller && scroller instanceof HTMLElement && scroller !== document.body) {
+                    const scrollerRect = scroller.getBoundingClientRect();
+                    const buttonRect = button.getBoundingClientRect();
+                    const targetTop = buttonRect.top - scrollerRect.top + scroller.scrollTop;
+                    if (typeof scroller.scrollTo === 'function') {
+                        scroller.scrollTo({ top: targetTop, behavior: 'smooth' });
+                    } else {
+                        scroller.scrollTop = targetTop;
+                    }
+                } else if (button.scrollIntoView) {
+                    button.scrollIntoView({ block: 'start', behavior: 'smooth' });
+                }
+            }
+
             if (shared.label) {
                 shared.label.textContent = this.label;
             }


### PR DESCRIPTION
## Summary
- scroll the time picker button into view before opening the shared dialog
- support scrolling within the closest `.content` container or fall back to the document scroller

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daa5edd6bc8332adddbfe67d1b383b