### PR TITLE
Add exercise statistics overview with charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,65 @@
 </section>
 <!-- ==================== -->
 
+<!-- ========== Statistiques : liste ========== -->
+<section id="screenStatsList" class="screen" hidden>
+
+    <header class="header">
+        <div class="header-left"></div>
+        <div class="header-center">
+            <div class="title">Statistiques</div>
+        </div>
+        <div class="header-right"></div>
+    </header>
+
+    <main class="content">
+        <section id="statsExerciseList" class="session-list" aria-label="Exercices suivis"></section>
+    </main>
+
+</section>
+<!-- ==================== -->
+
+<!-- ========== Statistiques : détail exercice ========== -->
+<section id="screenStatsDetail" class="screen" hidden>
+
+    <header class="header">
+        <div class="header-left">
+            <button id="statsBack" class="btn ghost" title="Retour">◀︎</button>
+        </div>
+        <div class="header-center">
+            <div class="title" id="statsExerciseTitle">Exercice</div>
+        </div>
+        <div class="header-right"></div>
+    </header>
+
+    <main class="content">
+        <div class="bloque stats-header">
+            <div class="stats-subtitle" id="statsExerciseSubtitle"></div>
+        </div>
+
+        <div class="stats-chart-card">
+            <div id="statsChart" class="stats-chart" role="img" aria-label="Évolution dans le temps"></div>
+            <div id="statsChartEmpty" class="stats-chart-empty" hidden>Aucune donnée enregistrée.</div>
+        </div>
+
+        <div class="bloque">
+            <label class="sr-only" for="statsMetricSelector">Choisir la statistique</label>
+            <select id="statsMetricSelector" class="input full">
+                <option value="reps">Répétitions totales</option>
+                <option value="weight">Poids maximum</option>
+                <option value="orm">1RM estimé</option>
+            </select>
+        </div>
+
+        <section>
+            <h2 class="stats-section-title">Historique</h2>
+            <ul id="statsTimeline" class="stats-timeline" aria-live="polite"></ul>
+        </section>
+    </main>
+
+</section>
+<!-- ==================== -->
+
 <!-- ========== 3.4.2 Modifier l’exécution (Colonne A uniquement) ========== -->
 <section id="screenExecEdit" class="screen" hidden>
 
@@ -426,6 +485,7 @@
 <script src="ui-routine-list.js"></script>
 <script src="ui-routine-edit.js"></script>
 <script src="ui-routine-move-edit.js"></script>
+<script src="ui-stats.js"></script>
 <script src="ui-exec-edit.js"></script>
 <script src="init.js"></script>
 <script>

--- a/init.js
+++ b/init.js
@@ -38,7 +38,20 @@
     }
 
     function wireNavigation() {
-        const { tabLibraries, tabSessions, tabSettings, tabStats, screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit, screenRoutineList } = refs;
+        const {
+            tabLibraries,
+            tabSessions,
+            tabSettings,
+            tabStats,
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit,
+            screenRoutineList,
+            screenStatsList,
+            screenStatsDetail
+        } = refs;
 
         tabLibraries?.addEventListener('click', async () => {
             setActiveTab('tabLibraries');
@@ -56,8 +69,7 @@
 
         tabStats?.addEventListener('click', async () => {
             setActiveTab('tabStats');
-            showOnly('routineList');
-            await A.openRoutineList();
+            await A.openStatsList();
         });
 
         tabSettings?.addEventListener('click', async () => {
@@ -72,6 +84,8 @@
         screenRoutineEdit?.setAttribute('data-screen', 'routine');
         screenRoutineMoveEdit?.setAttribute('data-screen', 'routineMove');
         screenRoutineList?.setAttribute('data-screen', 'routineList');
+        screenStatsList?.setAttribute('data-screen', 'statsList');
+        screenStatsDetail?.setAttribute('data-screen', 'statsDetail');
     }
 
     function wireCalendar() {
@@ -129,6 +143,8 @@
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
         refs.screenRoutineList = document.getElementById('screenRoutineList');
         refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refsResolved = true;
         return refs;
     }
@@ -163,7 +179,17 @@
     }
 
     function showOnly(which) {
-        const { screenSessions, screenExercises, screenExerciseEdit, screenRoutineEdit, screenRoutineMoveEdit, screenExecEdit, screenRoutineList } = refs;
+        const {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit,
+            screenExecEdit,
+            screenRoutineList,
+            screenStatsList,
+            screenStatsDetail
+        } = refs;
         if (screenSessions) {
             screenSessions.hidden = which !== 'sessions';
         }
@@ -184,6 +210,12 @@
         }
         if (screenRoutineList) {
             screenRoutineList.hidden = which !== 'routineList';
+        }
+        if (screenStatsList) {
+            screenStatsList.hidden = which !== 'statsList';
+        }
+        if (screenStatsDetail) {
+            screenStatsDetail.hidden = which !== 'statsDetail';
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -199,6 +199,82 @@ textarea:focus{
   font-weight: var(--fw-strong);
 }
 
+/* =========================================================
+   Statistiques
+   ========================================================= */
+.stats-header {
+    margin-bottom: 16px;
+}
+
+.stats-subtitle {
+    color: var(--darkGrayB);
+}
+
+.stats-chart-card {
+    margin-bottom: 16px;
+    padding: 16px;
+    background: var(--white);
+    border: 1px solid var(--lightGrayB);
+    border-radius: var(--radius);
+}
+
+.stats-chart {
+    width: 100%;
+    min-height: 220px;
+}
+
+.stats-chart-svg {
+    width: 100%;
+    height: 200px;
+    display: block;
+}
+
+.stats-chart-empty {
+    padding: 24px 0;
+    text-align: center;
+    color: var(--darkGrayB);
+}
+
+.stats-section-title {
+    margin: 24px 0 12px;
+    font-weight: var(--fw-strong);
+}
+
+.stats-timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.stats-timeline-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 12px 16px;
+    background: var(--white);
+    border: 1px solid var(--lightGrayB);
+    border-radius: var(--radius);
+}
+
+.stats-timeline-date {
+    font-weight: var(--fw-strong);
+}
+
+.stats-timeline-value {
+    color: var(--black);
+    font-weight: var(--fw-strong);
+}
+
+.stats-timeline-empty {
+    padding: 16px;
+    text-align: center;
+    color: var(--darkGrayB);
+    background: transparent;
+}
+
 /* Grosse image pour l'exécution */
 image_big{
 	 width:100%;

--- a/ui-exec-edit.js
+++ b/ui-exec-edit.js
@@ -105,6 +105,8 @@
         refs.screenExecEdit = document.getElementById('screenExecEdit');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.execTitle = document.getElementById('execTitle');
         refs.execDate = document.getElementById('execDate');
         refs.execExecuted = document.getElementById('execExecuted');
@@ -725,7 +727,7 @@
 
     function switchScreen(target) {
         const { screenSessions, screenExercises, screenExerciseEdit, screenExecEdit, screenExerciseRead } = assertRefs();
-        const { screenRoutineEdit, screenRoutineMoveEdit } = refs;
+        const { screenRoutineEdit, screenRoutineMoveEdit, screenStatsList, screenStatsDetail } = refs;
         const map = {
             screenSessions,
             screenExercises,
@@ -733,7 +735,9 @@
             screenExecEdit,
             screenExerciseRead,
             screenRoutineEdit,
-            screenRoutineMoveEdit
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-exercise-edit.js
+++ b/ui-exercise-edit.js
@@ -74,6 +74,8 @@
         refs.screenExecEdit = document.getElementById('screenExecEdit');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.exEditTitle = document.getElementById('exEditTitle');
         refs.exEditDelete = document.getElementById('exEditDelete');
         refs.exEditBack = document.getElementById('exEditBack');
@@ -255,7 +257,9 @@
             screenExecEdit,
             screenExerciseRead: refs.screenExerciseRead,
             screenRoutineEdit: refs.screenRoutineEdit,
-            screenRoutineMoveEdit: refs.screenRoutineMoveEdit
+            screenRoutineMoveEdit: refs.screenRoutineMoveEdit,
+            screenStatsList: refs.screenStatsList,
+            screenStatsDetail: refs.screenStatsDetail
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -57,6 +57,8 @@
         refs.screenExecEdit = document.getElementById('screenExecEdit');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.exReadTitle = document.getElementById('exReadTitle');
         refs.exReadHero = document.getElementById('exReadHero');
         refs.exReadMuscle = document.getElementById('exReadMuscle');
@@ -152,7 +154,7 @@
 
     function switchScreen(target) {
         const { screenExerciseRead, screenExercises, screenSessions, screenExerciseEdit, screenExecEdit } = assertRefs();
-        const { screenRoutineEdit, screenRoutineMoveEdit } = refs;
+        const { screenRoutineEdit, screenRoutineMoveEdit, screenStatsList, screenStatsDetail } = refs;
         const map = {
             screenExerciseRead,
             screenExercises,
@@ -160,7 +162,9 @@
             screenExerciseEdit,
             screenExecEdit,
             screenRoutineEdit,
-            screenRoutineMoveEdit
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-exercises_list.js
+++ b/ui-exercises_list.js
@@ -137,6 +137,8 @@
         refs.screenExecEdit = document.getElementById('screenExecEdit');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.content = document.querySelector('#screenExercises .content');
         refs.exSearch = document.getElementById('exSearch');
         refs.exFilterGroup = document.getElementById('exFilterGroup');
@@ -416,7 +418,7 @@
 
     function switchScreen(target) {
         const { screenExercises, screenExerciseEdit, screenExerciseRead, screenSessions, screenExecEdit } = assertRefs();
-        const { screenRoutineEdit, screenRoutineMoveEdit } = refs;
+        const { screenRoutineEdit, screenRoutineMoveEdit, screenStatsList, screenStatsDetail } = refs;
         const map = {
             screenExercises,
             screenExerciseEdit,
@@ -424,7 +426,9 @@
             screenSessions,
             screenExecEdit,
             screenRoutineEdit,
-            screenRoutineMoveEdit
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -65,6 +65,8 @@
         refs.screenRoutineList = document.getElementById('screenRoutineList');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.routineName = document.getElementById('routineName');
         refs.routineIcon = document.getElementById('routineIcon');
         refs.routineList = document.getElementById('routineList');
@@ -566,7 +568,17 @@
     }
 
     function switchScreen(target) {
-        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineEdit, screenRoutineMoveEdit, screenRoutineList } = assertRefs();
+        const {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit,
+            screenRoutineList
+        } = assertRefs();
+        const { screenStatsList, screenStatsDetail } = refs;
         const map = {
             screenSessions,
             screenExercises,
@@ -575,7 +587,9 @@
             screenExecEdit,
             screenRoutineEdit,
             screenRoutineList,
-            screenRoutineMoveEdit
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-routine-list.js
+++ b/ui-routine-list.js
@@ -47,6 +47,8 @@
         refs.screenRoutineList = document.getElementById('screenRoutineList');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.routineCatalog = document.getElementById('routineCatalog');
         refs.btnRoutineCreate = document.getElementById('btnRoutineCreate');
         refs.tabStats = document.getElementById('tabStats');
@@ -195,8 +197,7 @@
     }
 
     function switchScreen(target) {
-        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineList, screenRoutineEdit, screenRoutineMoveEdit } = assertRefs();
-        const map = {
+        const {
             screenSessions,
             screenExercises,
             screenExerciseEdit,
@@ -205,6 +206,19 @@
             screenRoutineList,
             screenRoutineEdit,
             screenRoutineMoveEdit
+        } = assertRefs();
+        const { screenStatsList, screenStatsDetail } = refs;
+        const map = {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineList,
+            screenRoutineEdit,
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-routine-move-edit.js
+++ b/ui-routine-move-edit.js
@@ -56,6 +56,8 @@
         refs.screenExecEdit = document.getElementById('screenExecEdit');
         refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
         refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.routineMoveTitle = document.getElementById('routineMoveTitle');
         refs.routineMoveSets = document.getElementById('routineMoveSets');
         refs.routineMoveBack = document.getElementById('routineMoveBack');
@@ -372,8 +374,7 @@
     }
 
     function switchScreen(target) {
-        const { screenSessions, screenExercises, screenExerciseEdit, screenExerciseRead, screenExecEdit, screenRoutineEdit, screenRoutineMoveEdit } = assertRefs();
-        const map = {
+        const {
             screenSessions,
             screenExercises,
             screenExerciseEdit,
@@ -381,6 +382,18 @@
             screenExecEdit,
             screenRoutineEdit,
             screenRoutineMoveEdit
+        } = assertRefs();
+        const { screenStatsList, screenStatsDetail } = refs;
+        const map = {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineEdit,
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
         };
         Object.entries(map).forEach(([key, element]) => {
             if (element) {

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -1,0 +1,516 @@
+// ui-stats.js — écrans de statistiques des exercices
+(() => {
+    const A = window.App;
+
+    /* STATE */
+    const refs = {};
+    let refsResolved = false;
+    const state = {
+        activeMetric: 'reps',
+        exercises: [],
+        usageByExercise: new Map(),
+        activeExercise: null
+    };
+
+    const METRIC_LABELS = {
+        reps: 'Répétitions totales',
+        weight: 'Poids maximum',
+        orm: '1RM estimé'
+    };
+
+    /* WIRE */
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureRefs();
+        wireEvents();
+    });
+
+    /* ACTIONS */
+    A.openStatsList = async function openStatsList() {
+        ensureRefs();
+        highlightStatsTab();
+        await loadData(true);
+        state.activeExercise = null;
+        renderExerciseList();
+        switchScreen('screenStatsList');
+    };
+
+    A.openExerciseStats = async function openExerciseStats(exerciseId) {
+        ensureRefs();
+        highlightStatsTab();
+        await loadData(true);
+        const exercise = state.exercises.find((item) => item.id === exerciseId) || (await db.get('exercises', exerciseId));
+        state.activeExercise = exercise || null;
+        renderExerciseDetail();
+        switchScreen('screenStatsDetail');
+    };
+
+    A.invalidateStatsCache = function invalidateStatsCache() {
+        state.exercises = [];
+        state.usageByExercise.clear();
+    };
+
+    /* UTILS */
+    function ensureRefs() {
+        if (refsResolved) {
+            return refs;
+        }
+        refs.screenSessions = document.getElementById('screenSessions');
+        refs.screenExercises = document.getElementById('screenExercises');
+        refs.screenExerciseEdit = document.getElementById('screenExerciseEdit');
+        refs.screenExerciseRead = document.getElementById('screenExerciseRead');
+        refs.screenExecEdit = document.getElementById('screenExecEdit');
+        refs.screenRoutineList = document.getElementById('screenRoutineList');
+        refs.screenRoutineEdit = document.getElementById('screenRoutineEdit');
+        refs.screenRoutineMoveEdit = document.getElementById('screenRoutineMoveEdit');
+        refs.screenStatsList = document.getElementById('screenStatsList');
+        refs.screenStatsDetail = document.getElementById('screenStatsDetail');
+        refs.statsExerciseList = document.getElementById('statsExerciseList');
+        refs.statsExerciseTitle = document.getElementById('statsExerciseTitle');
+        refs.statsExerciseSubtitle = document.getElementById('statsExerciseSubtitle');
+        refs.statsChart = document.getElementById('statsChart');
+        refs.statsChartEmpty = document.getElementById('statsChartEmpty');
+        refs.statsMetricSelector = document.getElementById('statsMetricSelector');
+        refs.statsTimeline = document.getElementById('statsTimeline');
+        refs.statsBack = document.getElementById('statsBack');
+        refs.tabStats = document.getElementById('tabStats');
+        refsResolved = true;
+        return refs;
+    }
+
+    function assertStatsRefs() {
+        ensureRefs();
+        const required = [
+            'screenStatsList',
+            'statsExerciseList',
+            'screenStatsDetail',
+            'statsExerciseTitle',
+            'statsExerciseSubtitle',
+            'statsChart',
+            'statsChartEmpty',
+            'statsMetricSelector',
+            'statsTimeline',
+            'statsBack'
+        ];
+        const missing = required.filter((key) => !refs[key]);
+        if (missing.length) {
+            throw new Error(`ui-stats.js: références manquantes (${missing.join(', ')})`);
+        }
+        return refs;
+    }
+
+    function wireEvents() {
+        const { statsBack, statsMetricSelector } = assertStatsRefs();
+        statsBack.addEventListener('click', () => {
+            highlightStatsTab();
+            state.activeExercise = null;
+            renderExerciseList();
+            switchScreen('screenStatsList');
+        });
+        statsMetricSelector.addEventListener('change', () => {
+            state.activeMetric = statsMetricSelector.value;
+            renderExerciseDetail();
+        });
+    }
+
+    async function loadData(force = false) {
+        if (!force && state.exercises.length) {
+            return;
+        }
+        const [exercisesRaw, sessionsRaw] = await Promise.all([db.getAll('exercises'), db.getAll('sessions')]);
+        const exercises = Array.isArray(exercisesRaw) ? exercisesRaw : [];
+        const sessions = Array.isArray(sessionsRaw) ? sessionsRaw : [];
+
+        const usageMap = new Map();
+        sessions.forEach((session) => {
+            const { date, exercises: executed } = session || {};
+            if (!date || !Array.isArray(executed)) {
+                return;
+            }
+            const dateObj = parseDate(date);
+            executed.forEach((item) => {
+                const sets = Array.isArray(item?.sets) ? item.sets : [];
+                if (!sets.length) {
+                    return;
+                }
+                const metrics = computeMetrics(sets);
+                if (!metrics.hasData) {
+                    return;
+                }
+                const entry = {
+                    date,
+                    dateObj,
+                    metrics
+                };
+                const key = item?.exerciseId;
+                if (!key) {
+                    return;
+                }
+                if (!usageMap.has(key)) {
+                    usageMap.set(key, []);
+                }
+                usageMap.get(key).push(entry);
+            });
+        });
+
+        usageMap.forEach((list) => {
+            list.sort((a, b) => a.date.localeCompare(b.date));
+        });
+
+        const enriched = exercises.map((exercise) => {
+            const usage = usageMap.get(exercise.id) || [];
+            const usageCount = usage.length;
+            const latest = usageCount ? usage[usageCount - 1] : null;
+            return {
+                ...exercise,
+                usageCount,
+                latestDate: latest ? latest.dateObj : null,
+                latestTimestamp: latest ? latest.dateObj.getTime() : 0
+            };
+        });
+
+        enriched.sort((a, b) => {
+            const aHas = a.usageCount > 0;
+            const bHas = b.usageCount > 0;
+            if (aHas !== bHas) {
+                return aHas ? -1 : 1;
+            }
+            if (aHas && bHas && a.latestTimestamp !== b.latestTimestamp) {
+                return b.latestTimestamp - a.latestTimestamp;
+            }
+            const nameA = (a?.name || '').toLocaleLowerCase('fr-FR');
+            const nameB = (b?.name || '').toLocaleLowerCase('fr-FR');
+            return nameA.localeCompare(nameB);
+        });
+
+        state.exercises = enriched;
+        state.usageByExercise = usageMap;
+    }
+
+    function renderExerciseList() {
+        const { statsExerciseList } = assertStatsRefs();
+        statsExerciseList.innerHTML = '';
+        if (!state.exercises.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty';
+            empty.textContent = 'Aucun exercice disponible.';
+            statsExerciseList.appendChild(empty);
+            return;
+        }
+        state.exercises.forEach((exercise) => {
+            statsExerciseList.appendChild(renderExerciseCard(exercise));
+        });
+    }
+
+    function renderExerciseCard(exercise) {
+        const card = document.createElement('article');
+        card.className = 'exercise-card clickable';
+        card.setAttribute('role', 'button');
+        card.setAttribute('aria-label', `${exercise?.name || 'Exercice'} — voir les statistiques`);
+
+        const row = document.createElement('div');
+        row.className = 'exercise-card-row';
+
+        const left = document.createElement('div');
+        left.className = 'exercise-card-left';
+        left.appendChild(renderGrip());
+
+        const textWrapper = document.createElement('div');
+        textWrapper.className = 'exercise-card-text';
+
+        const title = document.createElement('div');
+        title.className = 'element';
+        title.textContent = exercise?.name || 'Exercice';
+
+        const details = document.createElement('div');
+        details.className = 'details';
+        details.textContent = buildExerciseDetails(exercise);
+
+        textWrapper.append(title, details);
+        left.appendChild(textWrapper);
+
+        const right = document.createElement('div');
+        right.className = 'exercise-card-right';
+        const chevron = document.createElement('span');
+        chevron.className = 'session-card-pencil';
+        chevron.setAttribute('aria-hidden', 'true');
+        chevron.textContent = '▶︎';
+        right.appendChild(chevron);
+
+        row.append(left, right);
+        card.appendChild(row);
+
+        card.addEventListener('click', () => {
+            A.openExerciseStats(exercise?.id);
+        });
+
+        return card;
+    }
+
+    function buildExerciseDetails(exercise) {
+        if (!exercise?.usageCount) {
+            return 'Jamais réalisé pour le moment.';
+        }
+        const count = exercise.usageCount;
+        const usage = state.usageByExercise.get(exercise.id) || [];
+        const last = usage[usage.length - 1];
+        const sessionLabel = count > 1 ? 'séances' : 'séance';
+        const lastLabel = last?.dateObj ? A.fmtUI(last.dateObj) : '—';
+        return `${count} ${sessionLabel} • Dernière : ${lastLabel}`;
+    }
+
+    function renderExerciseDetail() {
+        const { statsExerciseTitle, statsExerciseSubtitle, statsMetricSelector } = assertStatsRefs();
+        const exercise = state.activeExercise;
+        statsExerciseTitle.textContent = exercise?.name || 'Exercice';
+        statsMetricSelector.value = state.activeMetric;
+        updateExerciseSummary(statsExerciseSubtitle);
+        renderChart();
+        renderTimeline();
+    }
+
+    function updateExerciseSummary(element) {
+        const exercise = state.activeExercise;
+        if (!exercise) {
+            element.textContent = '';
+            return;
+        }
+        const usage = state.usageByExercise.get(exercise.id) || [];
+        if (!usage.length) {
+            element.textContent = 'Aucune séance enregistrée pour cet exercice.';
+            return;
+        }
+        const last = usage[usage.length - 1];
+        const metricValue = last?.metrics ? last.metrics[state.activeMetric] || 0 : 0;
+        const metricText = formatMetricValue(metricValue, state.activeMetric);
+        const count = usage.length;
+        const sessionLabel = count > 1 ? 'séances' : 'séance';
+        const lastLabel = last?.dateObj ? A.fmtUI(last.dateObj) : '—';
+        element.textContent = `${count} ${sessionLabel} • Dernière : ${lastLabel} • ${metricText}`;
+    }
+
+    function renderChart() {
+        const { statsChart, statsChartEmpty } = assertStatsRefs();
+        statsChart.innerHTML = '';
+        statsChart.removeAttribute('aria-label');
+        const exercise = state.activeExercise;
+        if (!exercise) {
+            statsChartEmpty.hidden = false;
+            return;
+        }
+        const usage = state.usageByExercise.get(exercise.id) || [];
+        if (!usage.length) {
+            statsChartEmpty.hidden = false;
+            return;
+        }
+        statsChartEmpty.hidden = true;
+        const data = usage.map((entry) => ({
+            date: entry.dateObj,
+            value: entry.metrics[state.activeMetric] || 0
+        }));
+        const maxValue = Math.max(...data.map((item) => item.value), 0);
+        const width = 320;
+        const height = 200;
+        const padding = 16;
+        const points = data.map((item, index) => {
+            const x = data.length === 1 ? width / 2 : (index / (data.length - 1)) * (width - padding * 2) + padding;
+            const ratio = maxValue > 0 ? item.value / maxValue : 0;
+            const y = height - padding - ratio * (height - padding * 2);
+            return { x, y, value: item.value, date: item.date };
+        });
+        const pathData = points
+            .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+            .join(' ');
+
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+        svg.setAttribute('preserveAspectRatio', 'none');
+        svg.setAttribute('role', 'presentation');
+        svg.classList.add('stats-chart-svg');
+
+        const axis = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        axis.setAttribute('x1', String(padding));
+        axis.setAttribute('y1', String(height - padding));
+        axis.setAttribute('x2', String(width - padding));
+        axis.setAttribute('y2', String(height - padding));
+        axis.setAttribute('stroke', '#d4d4d4');
+        axis.setAttribute('stroke-width', '2');
+        svg.appendChild(axis);
+
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', pathData);
+        path.setAttribute('fill', 'none');
+        path.setAttribute('stroke', A.EMPHASIS || '#0f62fe');
+        path.setAttribute('stroke-width', '3');
+        path.setAttribute('stroke-linecap', 'round');
+        path.setAttribute('stroke-linejoin', 'round');
+        svg.appendChild(path);
+
+        points.forEach((point) => {
+            const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            circle.setAttribute('cx', point.x.toFixed(2));
+            circle.setAttribute('cy', point.y.toFixed(2));
+            circle.setAttribute('r', '5');
+            circle.setAttribute('fill', '#ffffff');
+            circle.setAttribute('stroke', A.EMPHASIS || '#0f62fe');
+            circle.setAttribute('stroke-width', '2');
+            svg.appendChild(circle);
+        });
+
+        statsChart.setAttribute(
+            'aria-label',
+            `Évolution — ${METRIC_LABELS[state.activeMetric] || 'Statistique'} sur ${data.length} point${data.length > 1 ? 's' : ''}`
+        );
+        statsChart.appendChild(svg);
+    }
+
+    function renderTimeline() {
+        const { statsTimeline } = assertStatsRefs();
+        statsTimeline.innerHTML = '';
+        const exercise = state.activeExercise;
+        if (!exercise) {
+            statsTimeline.appendChild(buildTimelineEmpty());
+            return;
+        }
+        const usage = state.usageByExercise.get(exercise.id) || [];
+        if (!usage.length) {
+            statsTimeline.appendChild(buildTimelineEmpty());
+            return;
+        }
+        const ordered = [...usage].sort((a, b) => b.date.localeCompare(a.date));
+        ordered.forEach((entry) => {
+            statsTimeline.appendChild(renderTimelineItem(entry));
+        });
+    }
+
+    function buildTimelineEmpty() {
+        const empty = document.createElement('li');
+        empty.className = 'stats-timeline-empty';
+        empty.textContent = 'Aucune séance enregistrée.';
+        return empty;
+    }
+
+    function renderTimelineItem(entry) {
+        const item = document.createElement('li');
+        item.className = 'stats-timeline-item';
+
+        const date = document.createElement('span');
+        date.className = 'stats-timeline-date';
+        date.textContent = entry?.dateObj ? A.fmtUI(entry.dateObj) : '—';
+
+        const value = document.createElement('span');
+        value.className = 'stats-timeline-value';
+        const metricValue = entry?.metrics ? entry.metrics[state.activeMetric] || 0 : 0;
+        value.textContent = formatMetricValue(metricValue, state.activeMetric);
+
+        item.append(date, value);
+        return item;
+    }
+
+    function renderGrip() {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'session-card-handle';
+        wrapper.setAttribute('aria-hidden', 'true');
+        const grip = document.createElement('span');
+        grip.className = 'session-card-grip';
+        for (let index = 0; index < 3; index += 1) {
+            const dot = document.createElement('span');
+            dot.className = 'session-card-grip-dot';
+            grip.appendChild(dot);
+        }
+        wrapper.appendChild(grip);
+        return wrapper;
+    }
+
+    function computeMetrics(sets) {
+        let totalReps = 0;
+        let maxWeight = 0;
+        let maxOrm = 0;
+        let hasData = false;
+        sets.forEach((set) => {
+            const reps = parseNumber(set?.reps);
+            const weight = parseNumber(set?.weight);
+            if (Number.isFinite(reps) && reps > 0) {
+                totalReps += reps;
+                hasData = true;
+            }
+            if (Number.isFinite(weight) && weight > maxWeight) {
+                maxWeight = weight;
+                hasData = true;
+            }
+            if (Number.isFinite(weight) && weight > 0 && Number.isFinite(reps) && reps > 0) {
+                const estimated = weight * (1 + reps / 30);
+                if (estimated > maxOrm) {
+                    maxOrm = estimated;
+                }
+                hasData = true;
+            }
+        });
+        return {
+            reps: totalReps,
+            weight: maxWeight,
+            orm: maxOrm,
+            hasData
+        };
+    }
+
+    function parseNumber(value) {
+        const number = Number.parseFloat(value);
+        return Number.isFinite(number) ? number : NaN;
+    }
+
+    function parseDate(key) {
+        const iso = `${key}T00:00:00`;
+        const parsed = new Date(iso);
+        if (Number.isNaN(parsed.getTime())) {
+            return new Date();
+        }
+        return parsed;
+    }
+
+    function formatMetricValue(value, metric) {
+        const rounded = metric === 'reps' ? Math.round(value) : Math.round(value * 10) / 10;
+        if (metric === 'reps') {
+            return `${rounded} répétition${rounded > 1 ? 's' : ''}`;
+        }
+        return `${rounded} kg`;
+    }
+
+    function highlightStatsTab() {
+        document.querySelectorAll('.tabbar .tab').forEach((button) => button.classList.remove('active'));
+        if (refs.tabStats) {
+            refs.tabStats.classList.add('active');
+        }
+    }
+
+    function switchScreen(target) {
+        const {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineList,
+            screenRoutineEdit,
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
+        } = ensureRefs();
+        const map = {
+            screenSessions,
+            screenExercises,
+            screenExerciseEdit,
+            screenExerciseRead,
+            screenExecEdit,
+            screenRoutineList,
+            screenRoutineEdit,
+            screenRoutineMoveEdit,
+            screenStatsList,
+            screenStatsDetail
+        };
+        Object.entries(map).forEach(([key, element]) => {
+            if (element) {
+                element.hidden = key !== target;
+            }
+        });
+    }
+})();


### PR DESCRIPTION
## Summary
- add dedicated statistics list and detail screens for exercises
- compute reps, max weight, and estimated 1RM per session to feed the new chart and timeline selector
- update navigation and styles so stats views integrate cleanly with existing screens

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc0bd14f908332a9c8e786071cb650