### PR TITLE
Connect settings tab to routine list and adjust set editor grid

### DIFF
--- a/init.js
+++ b/init.js
@@ -74,8 +74,7 @@
 
         tabSettings?.addEventListener('click', async () => {
             setActiveTab('tabSettings');
-            showOnly('routine');
-            await A.openRoutineEdit({ routineId: 'routine-test' });
+            await A.openRoutineList();
         });
 
         screenSessions?.setAttribute('data-screen', 'sessions');

--- a/style.css
+++ b/style.css
@@ -755,7 +755,7 @@ image_big{
 .set-editor-grid{
   display:grid;
   gap:12px;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
 
 .set-editor-field{

--- a/ui-routine-list.js
+++ b/ui-routine-list.js
@@ -19,7 +19,7 @@
     /* ACTIONS */
     A.openRoutineList = async function openRoutineList() {
         ensureRefs();
-        highlightStatsTab();
+        highlightSettingsTab();
         await loadRoutines(true);
         renderList();
         switchScreen('screenRoutineList');
@@ -51,7 +51,7 @@
         refs.screenStatsDetail = document.getElementById('screenStatsDetail');
         refs.routineCatalog = document.getElementById('routineCatalog');
         refs.btnRoutineCreate = document.getElementById('btnRoutineCreate');
-        refs.tabStats = document.getElementById('tabStats');
+        refs.tabSettings = document.getElementById('tabSettings');
         refsResolved = true;
         return refs;
     }
@@ -73,7 +73,7 @@
         }
         btnRoutineCreate.addEventListener('click', () => {
             const id = createRoutineId();
-            highlightStatsTab();
+            highlightSettingsTab();
             A.openRoutineEdit({ routineId: id });
         });
     }
@@ -145,7 +145,7 @@
         card.appendChild(row);
 
         card.addEventListener('click', () => {
-            highlightStatsTab();
+            highlightSettingsTab();
             A.openRoutineEdit({ routineId: routine?.id });
         });
 
@@ -189,10 +189,10 @@
         return `routine-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`;
     }
 
-    function highlightStatsTab() {
+    function highlightSettingsTab() {
         document.querySelectorAll('.tabbar .tab').forEach((button) => button.classList.remove('active'));
-        if (refs.tabStats) {
-            refs.tabStats.classList.add('active');
+        if (refs.tabSettings) {
+            refs.tabSettings.classList.add('active');
         }
     }
 


### PR DESCRIPTION
## Summary
- open the routine list when the settings tab is selected and keep the tab highlighted while editing
- ensure the statistics tab opens the new statistics interface via the main navigation
- reduce the set editor grid column minimum size so all fields fit within the dialog on small screens

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc1750413c8332b8622b872eaddc83