### PR TITLE
Keep set editor fields on a single row

### DIFF
--- a/style.css
+++ b/style.css
@@ -754,8 +754,8 @@ image_big{
 
 .set-editor-grid{
   display:grid;
-  gap:12px;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap:8px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
 .set-editor-field{


### PR DESCRIPTION
## Summary
- reduce the spacing between set editor fields and force a five-column grid
- ensure the modal layout keeps all inputs on one line

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc1c6bfdd883328439ea730f8f3698