### PR TITLE
Center set editor modal header

### DIFF
--- a/style.css
+++ b/style.css
@@ -757,13 +757,19 @@ image_big{
 .set-editor-header{
   display:flex;
   align-items:center;
-  justify-content:space-between;
   gap:12px;
+  flex-wrap:nowrap;
 }
 
 .set-editor-title{
   font-weight: var(--fw-strong);
   font-size: var(--fs-large);
+  flex:1;
+  min-width:0;
+  text-align:center;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 
 .set-editor-grid{
@@ -785,12 +791,17 @@ image_big{
 
 .set-editor-rest{
   grid-column: span 2;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
 }
 
 .set-editor-rest-grid{
   display:grid;
   gap:8px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  justify-items:center;
+  width:100%;
 }
 
 .set-editor-subfield{


### PR DESCRIPTION
## Summary
- keep the set editor modal header content on a single row while centering the title text
- align the rest label with the minute and second columns in the set editor modal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd827258f88332b2d41550ca3dc0de