### PR TITLE
Highlight set rows when editing

### DIFF
--- a/style.css
+++ b/style.css
@@ -735,6 +735,24 @@ image_big{
   outline:none;
 }
 
+.set-editor-highlight{
+  background: var(--lightGray);
+  border-radius: var(--radius);
+  outline: 2px solid var(--emphase);
+  outline-offset: 0;
+}
+
+.set-editor-highlight .set-edit-button{
+  background: var(--lightGray);
+  outline: 2px solid var(--emphase);
+  outline-offset: 0;
+}
+
+.set-editor-highlight .set-edit-button:hover,
+.set-editor-highlight .set-edit-button:focus{
+  background: var(--lightGray);
+}
+
 .exec-rest-cell{
   font-variant-numeric: tabular-nums;
 }

--- a/ui-exec-edit.js
+++ b/ui-exec-edit.js
@@ -407,7 +407,8 @@
                 return;
             }
             const { minutes, seconds } = splitRest(value.rest);
-            SetEditor.open({
+            row.classList.add('set-editor-highlight');
+            const promise = SetEditor.open({
                 title,
                 values: {
                     reps: value.reps,
@@ -417,18 +418,27 @@
                     seconds
                 },
                 focus: focusField
-            }).then((result) => {
-                if (!result) {
-                    return;
-                }
-                value.reps = safePositiveInt(result.reps);
-                value.weight = sanitizeWeight(result.weight, true);
-                value.rpe = result.rpe != null ? clampInt(result.rpe, 5, 10) : null;
-                const totalRest = Math.max(0, Math.round((result.minutes ?? 0) * 60 + (result.seconds ?? 0)));
-                value.rest = totalRest;
-                updateButtons();
-                updateExecRestToggle();
             });
+            if (!promise || typeof promise.then !== 'function') {
+                row.classList.remove('set-editor-highlight');
+                return;
+            }
+            promise
+                .then((result) => {
+                    if (!result) {
+                        return;
+                    }
+                    value.reps = safePositiveInt(result.reps);
+                    value.weight = sanitizeWeight(result.weight, true);
+                    value.rpe = result.rpe != null ? clampInt(result.rpe, 5, 10) : null;
+                    const totalRest = Math.max(0, Math.round((result.minutes ?? 0) * 60 + (result.seconds ?? 0)));
+                    value.rest = totalRest;
+                    updateButtons();
+                    updateExecRestToggle();
+                })
+                .finally(() => {
+                    row.classList.remove('set-editor-highlight');
+                });
         };
 
         const createButton = (getText, focusField, extraClass = '') => {

--- a/ui-routine-move-edit.js
+++ b/ui-routine-move-edit.js
@@ -172,7 +172,7 @@
                 return;
             }
             const { minutes, seconds } = splitRest(value.rest);
-            row.classList.add('routine-set-row-active');
+            row.classList.add('routine-set-row-active', 'set-editor-highlight');
             SetEditor.open({
                 title,
                 values: {
@@ -200,7 +200,7 @@
                     applySetEditorResult(index, nextValues);
                 })
                 .finally(() => {
-                    row.classList.remove('routine-set-row-active');
+                    row.classList.remove('routine-set-row-active', 'set-editor-highlight');
                 });
         };
 


### PR DESCRIPTION
## Summary
- highlight rows opened in the set editor so their fields use the light gray background and emphase outline
- ensure execution and routine editors add and remove the highlight state around the modal lifecycle

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd874919d88332b96f6b341ad62648