### PR TITLE
Ajoute filtres temporels et métriques aux statistiques d’exercice

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,9 @@
         <div class="header-center">
             <div class="title" id="statsExerciseTitle">Exercice</div>
         </div>
-        <div class="header-right"></div>
+        <div class="header-right">
+            <button id="statsGoal" class="btn ghost" type="button" title="Objectif">objectif</button>
+        </div>
     </header>
 
     <main class="content">
@@ -213,18 +215,37 @@
             <div class="stats-subtitle" id="statsExerciseSubtitle"></div>
         </div>
 
+        <div class="bloque stats-tags-group">
+            <div
+                id="statsMetricTags"
+                class="tags mono"
+                role="group"
+                aria-label="Choisir la statistique"
+            >
+                <button type="button" class="tag" data-metric="orm">1RM</button>
+                <button type="button" class="tag" data-metric="tenrm">10RM</button>
+                <button type="button" class="tag" data-metric="reps">Répétitions</button>
+                <button type="button" class="tag" data-metric="weight">Charge max</button>
+            </div>
+        </div>
+
         <div class="stats-chart-card">
             <div id="statsChart" class="stats-chart" role="img" aria-label="Évolution dans le temps"></div>
             <div id="statsChartEmpty" class="stats-chart-empty" hidden>Aucune donnée enregistrée.</div>
         </div>
 
-        <div class="bloque">
-            <label class="sr-only" for="statsMetricSelector">Choisir la statistique</label>
-            <select id="statsMetricSelector" class="input full">
-                <option value="reps">Répétitions totales</option>
-                <option value="weight">Poids maximum</option>
-                <option value="orm">1RM estimé</option>
-            </select>
+        <div class="bloque stats-tags-group">
+            <div
+                id="statsRangeTags"
+                class="tags mono"
+                role="group"
+                aria-label="Choisir la période"
+            >
+                <button type="button" class="tag" data-range="1M">1M</button>
+                <button type="button" class="tag" data-range="3M">3M</button>
+                <button type="button" class="tag" data-range="6M">6M</button>
+                <button type="button" class="tag" data-range="12M">12M</button>
+            </div>
         </div>
 
         <section>

--- a/style.css
+++ b/style.css
@@ -218,6 +218,15 @@ textarea:focus{
     border-radius: var(--radius);
 }
 
+#statsMetricTags,
+#statsRangeTags {
+    --tag-columns: 4;
+}
+
+.stats-tags-group {
+    gap: 6px;
+}
+
 .stats-chart {
     width: 100%;
     min-height: 220px;
@@ -225,8 +234,13 @@ textarea:focus{
 
 .stats-chart-svg {
     width: 100%;
-    height: 200px;
+    height: 220px;
     display: block;
+}
+
+.stats-chart-svg .stats-axis-label {
+    font-size: 10px;
+    fill: var(--darkGrayB);
 }
 
 .stats-chart-empty {
@@ -458,6 +472,10 @@ image_big{
   --tag-width: calc((100% - (var(--tag-columns, 1) - 1) * var(--tag-gap, 1px)) / var(--tag-columns, 1));
   display:flex; flex-wrap:wrap;
   gap: var(--tag-gap);
+}
+.tags.mono .tag{
+  font-family: "SFMono-Regular","Roboto Mono","Menlo","Courier New",monospace;
+  font-weight: var(--fw-base);
 }
 .tag{
   height: var(--control-h);


### PR DESCRIPTION
## Summary
- add an objectif button and tag-based selectors for metrics and periods on the exercise statistics header
- compute daily points with new 10RM metric support and render the chart with labelled axes over the selected time range
- style the stats screen with monospace tags and axis label styling for the updated controls

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68de1edcc04083329e4d3803864e26bb