### PR TITLE
Adjust set editor modal presentation

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -306,8 +306,16 @@
             if (!refs) {
                 return;
             }
-            const { title = 'Série', values = {} } = options;
-            refs.title.textContent = title;
+            const { title = 'Série', values = {}, tone = 'black' } = options;
+            if (refs.title) {
+                refs.title.textContent = title;
+                refs.title.hidden = !title;
+            }
+            if (refs.form) {
+                refs.form.classList.remove('set-editor-tone-black', 'set-editor-tone-muted');
+                const toneClass = tone === 'muted' ? 'set-editor-tone-muted' : 'set-editor-tone-black';
+                refs.form.classList.add(toneClass);
+            }
             const repsValue = SetEditor.#parseInt(values.reps, 0);
             refs.repsInput.value = String(Math.max(0, repsValue ?? 0));
             const hasWeight = values.weight != null && values.weight !== '';

--- a/index.html
+++ b/index.html
@@ -471,10 +471,6 @@
 <!-- ==========  Modale série ========== -->
 <dialog id="dlgSetEditor" class="modal">
     <form method="dialog" class="set-editor-form" data-role="set-editor-form">
-        <div class="set-editor-header">
-            <div id="setEditorTitle" class="set-editor-title" data-role="set-editor-title">Série</div>
-            <button type="button" class="btn ghost" data-action="close">Fermer</button>
-        </div>
         <div class="set-editor-grid">
             <label class="set-editor-field">
                 <span class="set-editor-label">Reps</span>
@@ -521,6 +517,7 @@
             </div>
         </div>
         <div class="set-editor-actions">
+            <button type="button" class="btn ghost" data-action="close">Fermer</button>
             <button type="submit" class="btn primary" data-action="submit">Valider</button>
         </div>
     </form>

--- a/style.css
+++ b/style.css
@@ -828,26 +828,8 @@ image_big{
 .set-editor-form{
   display:flex;
   flex-direction:column;
-  gap:16px;
+  gap:14px;
   min-width:280px;
-}
-
-.set-editor-header{
-  display:flex;
-  align-items:center;
-  gap:12px;
-  flex-wrap:nowrap;
-}
-
-.set-editor-title{
-  font-weight: var(--fw-strong);
-  font-size: var(--fs-large);
-  flex:1;
-  min-width:0;
-  text-align:center;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
 }
 
 .set-editor-grid{
@@ -859,11 +841,14 @@ image_big{
 .set-editor-field{
   display:flex;
   flex-direction:column;
-  gap:6px;
+  gap:2px;
 }
 
 .set-editor-label{
   font-weight: var(--fw-strong);
+  font-size: var(--fs-small);
+  line-height:1.1;
+  color: var(--darkGrayB);
   text-align:center;
 }
 
@@ -889,20 +874,52 @@ image_big{
 }
 
 .set-editor-rest-grid .vstepper{
-  width:72px;
+  width:54px;
+}
+
+.set-editor-rest-grid .vstepper .btn{
+  height: calc(var(--control-h) * 0.75);
+  min-height: calc(var(--control-h) * 0.75);
+  font-size: calc(var(--fs-base) * 0.75);
+  padding-inline: 0;
 }
 
 .set-editor-rest-grid .vstepper .input{
+  height: calc(var(--control-h) * 0.75);
   text-align:center;
+  font-size: calc(var(--fs-base) * 0.75);
 }
 
 .set-editor-actions{
   display:flex;
-  justify-content:flex-end;
+  gap:8px;
 }
 
 .set-editor-actions .btn{
-  min-width:120px;
+  flex:1 1 0;
+  min-width:0;
+}
+
+.set-editor-form.set-editor-tone-black .set-editor-field .vstepper .input,
+.set-editor-form.set-editor-tone-black .set-editor-field .vstepper .btn,
+.set-editor-form.set-editor-tone-black .set-editor-actions .btn.ghost{
+  color: var(--black);
+  border-color: var(--black);
+}
+
+.set-editor-form.set-editor-tone-black .set-editor-field .vstepper .input{
+  font-weight: var(--fw-strong);
+}
+
+.set-editor-form.set-editor-tone-muted .set-editor-field .vstepper .input,
+.set-editor-form.set-editor-tone-muted .set-editor-field .vstepper .btn,
+.set-editor-form.set-editor-tone-muted .set-editor-actions .btn.ghost{
+  color: var(--darkGrayB);
+  border-color: var(--darkGrayB);
+}
+
+.set-editor-form.set-editor-tone-muted .set-editor-field .vstepper .input{
+  font-weight: var(--fw-base);
 }
 
 .set-editor-form .vstepper{

--- a/ui-exec-edit.js
+++ b/ui-exec-edit.js
@@ -408,6 +408,7 @@
             }
             const { minutes, seconds } = splitRest(value.rest);
             row.classList.add('set-editor-highlight');
+            const tone = set.done === true ? 'black' : 'muted';
             const promise = SetEditor.open({
                 title,
                 values: {
@@ -417,7 +418,8 @@
                     minutes,
                     seconds
                 },
-                focus: focusField
+                focus: focusField,
+                tone
             });
             if (!promise || typeof promise.then !== 'function') {
                 row.classList.remove('set-editor-highlight');

--- a/ui-routine-move-edit.js
+++ b/ui-routine-move-edit.js
@@ -183,6 +183,7 @@
                     seconds
                 },
                 focus: focusField,
+                tone: 'black',
                 onChange: (next) => {
                     updatePreview(next);
                 }


### PR DESCRIPTION
## Summary
- remove the series title bar from the set editor modal and place the close button alongside validation actions
- refine the column header styling and shrink the rest controls to better match the desired proportions
- add tone handling to the set editor so routine templates stay black while planned execution sets render muted

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df6c4619848332b5a93ffd37834696