### PR TITLE
Improve stats chart layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -212,7 +212,7 @@ textarea:focus{
 
 .stats-chart-card {
     margin-bottom: 16px;
-    padding: 16px;
+    padding: 0;
     background: var(--white);
     border: 1px solid var(--lightGrayB);
     border-radius: var(--radius);
@@ -244,7 +244,7 @@ textarea:focus{
 }
 
 .stats-chart-svg .stats-axis-tick {
-    font-size: 10px;
+    font-size: 12px;
     fill: var(--darkGrayB);
 }
 


### PR DESCRIPTION
## Summary
- widen the stats chart display by removing surrounding padding and increasing tick readability
- update the chart rendering to drop the vertical axis line, recolor the horizontal axis, and hide unit labels
- generate four evenly spaced date ticks on the horizontal axis regardless of the number of data points

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68df7196ec448332a88ff115e77b218e