### PR TITLE
Constrain exercise set chips to two rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -392,9 +392,14 @@ image_big{
 }
 .session-card-sets{
   display:flex;
-  flex-wrap:wrap;
+  flex-direction:column;
   gap:4px;
   margin-top:4px;
+}
+.session-card-sets-row{
+  display:flex;
+  flex-wrap:nowrap;
+  gap:4px;
 }
 .session-card-sets:empty{
   display:none;
@@ -409,6 +414,10 @@ image_big{
   border:1px solid var(--lightGrayB);
   font-size:var(--fs-small);
   line-height:1.1;
+}
+.session-card-set--ellipsis{
+  justify-content:center;
+  font-weight:600;
 }
 .session-card-set sup{
   font-size:.7em;

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -286,9 +286,18 @@
         name.textContent = move.exerciseName || 'Exercice';
         const setsWrapper = document.createElement('div');
         setsWrapper.className = 'session-card-sets';
-        const sets = Array.isArray(move.sets) ? [...move.sets].sort((a, b) => (a.pos ?? 0) - (b.pos ?? 0)) : [];
+        const sets = Array.isArray(move.sets)
+            ? [...move.sets].sort((a, b) => (a.pos ?? 0) - (b.pos ?? 0))
+            : [];
+        const MAX_LINES = 2;
+        const BLOCKS_PER_LINE = 3;
+        const MAX_BLOCKS = MAX_LINES * BLOCKS_PER_LINE;
         if (sets.length) {
-            sets.forEach((set) => {
+            const hasOverflow = sets.length > MAX_BLOCKS;
+            const displayedSets = hasOverflow
+                ? sets.slice(0, MAX_BLOCKS - 1)
+                : sets.slice(0, MAX_BLOCKS);
+            const blocks = displayedSets.map((set) => {
                 const block = document.createElement('span');
                 block.className = 'session-card-set';
                 const reps = valueOrDash(set.reps);
@@ -298,13 +307,36 @@
                 const details = `${reps}×${weight}`;
                 const rpe = set.rpe != null && !Number.isNaN(set.rpe) ? `<sup>${set.rpe}</sup>` : '';
                 block.innerHTML = rpe ? `${details} ${rpe}` : details;
-                setsWrapper.appendChild(block);
+                return block;
             });
+            if (hasOverflow) {
+                const ellipsis = document.createElement('span');
+                ellipsis.className = 'session-card-set session-card-set--ellipsis';
+                ellipsis.textContent = '…';
+                ellipsis.setAttribute('title', 'Autres séries');
+                blocks.push(ellipsis);
+            }
+            for (let lineIndex = 0; lineIndex < MAX_LINES; lineIndex += 1) {
+                const start = lineIndex * BLOCKS_PER_LINE;
+                const lineBlocks = blocks.slice(start, start + BLOCKS_PER_LINE);
+                if (!lineBlocks.length) {
+                    break;
+                }
+                const line = document.createElement('div');
+                line.className = 'session-card-sets-row';
+                lineBlocks.forEach((block) => {
+                    line.appendChild(block);
+                });
+                setsWrapper.appendChild(line);
+            }
         } else {
+            const line = document.createElement('div');
+            line.className = 'session-card-sets-row';
             const emptyBlock = document.createElement('span');
             emptyBlock.className = 'session-card-set';
             emptyBlock.textContent = 'Ajouter des séries';
-            setsWrapper.appendChild(emptyBlock);
+            line.appendChild(emptyBlock);
+            setsWrapper.appendChild(line);
         }
         textWrapper.append(name, setsWrapper);
 

--- a/ui-session.js
+++ b/ui-session.js
@@ -113,16 +113,45 @@
             const setsWrapper = document.createElement('div');
             setsWrapper.className = 'session-card-sets';
             const sets = Array.isArray(exercise.sets) ? exercise.sets : [];
-            sets.forEach((set) => {
-                const block = document.createElement('span');
-                block.className = 'session-card-set';
-                const reps = set.reps ?? 0;
-                const weight = set.weight ?? 0;
-                const rpeSmall = set.rpe ? `<sup>${set.rpe}</sup>` : '';
-                const details = `${reps}×${weight} kg`;
-                block.innerHTML = rpeSmall ? `${details} ${rpeSmall}` : details;
-                setsWrapper.appendChild(block);
-            });
+            const MAX_LINES = 2;
+            const BLOCKS_PER_LINE = 3;
+            const MAX_BLOCKS = MAX_LINES * BLOCKS_PER_LINE;
+            if (sets.length) {
+                const hasOverflow = sets.length > MAX_BLOCKS;
+                const displayedSets = hasOverflow
+                    ? sets.slice(0, MAX_BLOCKS - 1)
+                    : sets.slice(0, MAX_BLOCKS);
+                const blocks = displayedSets.map((set) => {
+                    const block = document.createElement('span');
+                    block.className = 'session-card-set';
+                    const reps = set.reps ?? 0;
+                    const weight = set.weight ?? 0;
+                    const rpeSmall = set.rpe ? `<sup>${set.rpe}</sup>` : '';
+                    const details = `${reps}×${weight} kg`;
+                    block.innerHTML = rpeSmall ? `${details} ${rpeSmall}` : details;
+                    return block;
+                });
+                if (hasOverflow) {
+                    const ellipsis = document.createElement('span');
+                    ellipsis.className = 'session-card-set session-card-set--ellipsis';
+                    ellipsis.textContent = '…';
+                    ellipsis.setAttribute('title', 'Autres séries');
+                    blocks.push(ellipsis);
+                }
+                for (let lineIndex = 0; lineIndex < MAX_LINES; lineIndex += 1) {
+                    const start = lineIndex * BLOCKS_PER_LINE;
+                    const lineBlocks = blocks.slice(start, start + BLOCKS_PER_LINE);
+                    if (!lineBlocks.length) {
+                        break;
+                    }
+                    const line = document.createElement('div');
+                    line.className = 'session-card-sets-row';
+                    lineBlocks.forEach((block) => {
+                        line.appendChild(block);
+                    });
+                    setsWrapper.appendChild(line);
+                }
+            }
             textWrapper.append(name, setsWrapper);
 
             left.append(handle, textWrapper);


### PR DESCRIPTION
## Summary
- limit exercise cards on the session and routine screens to two lines of three set chips
- add an ellipsis chip when additional sets exist beyond the displayed ones
- adjust the card styling to support row layouts and the new ellipsis indicator

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68df732a701c833293ad7f85d12cf98d