### PR TITLE
Ensure calendar modal has a consistent six-row layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -663,6 +663,15 @@ image_big{
   max-width:420px; width:90vw;
 }
 .modal::backdrop{ background: rgba(0,0,0,.25); }
+
+#dlgCalendar.modal{
+  margin:0;
+  position:fixed;
+  left:50%;
+  transform:translateX(-50%);
+  bottom: calc(var(--tabbar-h) + env(safe-area-inset-bottom, 0) + 12px);
+  width: min(420px, calc(100vw - 24px));
+}
 .modal-header{
   display:flex; justify-content:space-between; align-items:center;
   padding: var(--pad-y) var(--pad-x);
@@ -679,7 +688,13 @@ image_big{
 .day-cell:active{ transform: scale(.98); }
 .day-cell.planned{ background: var(--backGrayB); color:#333; border-color: var(--backGrayB); }
 .day-cell.has-session{ background: var(--black); color:#fff; border-color: var(--black); }
-.day-cell.selected{ background: var(--emphase); color:#fff; border-color: var(--emphase); }
+.day-cell.selected{ background: var(--black); color:#fff; border-color: var(--black); }
+.day-cell.placeholder{
+  background: transparent;
+  border-color: transparent;
+  cursor: default;
+  pointer-events: none;
+}
 
 /* =========================================================
    8) Séance du jour & séries

--- a/ui-calendar.js
+++ b/ui-calendar.js
@@ -46,7 +46,10 @@
         });
 
         for (let index = 0; index < startIndex; index += 1) {
-            grid.appendChild(document.createElement('div'));
+            const filler = document.createElement('div');
+            filler.className = 'day-cell placeholder';
+            filler.setAttribute('aria-hidden', 'true');
+            grid.appendChild(filler);
         }
 
         const lastDay = new Date(year, month + 1, 0).getDate();
@@ -81,6 +84,15 @@
             });
 
             grid.appendChild(cell);
+        }
+
+        const totalRendered = startIndex + lastDay;
+        const totalCells = 42;
+        for (let index = totalRendered; index < totalCells; index += 1) {
+            const filler = document.createElement('div');
+            filler.className = 'day-cell placeholder';
+            filler.setAttribute('aria-hidden', 'true');
+            grid.appendChild(filler);
         }
 
         bigCalendar.appendChild(grid);


### PR DESCRIPTION
## Summary
- render placeholder cells so the calendar grid always shows six rows
- pin the calendar modal to the bottom of the screen above the tab bar
- update calendar selection styling to use the black color scheme

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68df790248588332a2009114cdaf2ba1