### PR TITLE
Harmonize routine template set editing styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,13 +158,13 @@
             <button id="routineMoveDelete" class="btn danger full">🗑️ Retirer de la routine</button>
         </div>
 
-        <div class="exec-grid exec-head routine-set-grid">
-            <div>#</div>
-            <div>Reps</div>
-            <div>Poids</div>
-            <div>RPE</div>
-            <div class="routine-set-head-rest">Repos</div>
-            <div>Sup.</div>
+        <div class="exec-grid exec-head routine-set-grid routine-set-head">
+            <div class="set-editor-label">#</div>
+            <div class="set-editor-label">Reps</div>
+            <div class="set-editor-label">Poids</div>
+            <div class="set-editor-label">RPE</div>
+            <div class="routine-set-head-rest set-editor-label">Repos</div>
+            <div class="set-editor-label">Sup.</div>
         </div>
 
         <div id="routineMoveSets"></div>

--- a/style.css
+++ b/style.css
@@ -739,6 +739,13 @@ image_big{
 .routine-set-grid > *{ min-width:0; }
 .exec-head{ font-weight: var(--fw-strong); }
 .exec-head > *{ display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; }
+.routine-set-head{
+  font-size: var(--fs-small);
+  color: var(--darkGrayB);
+}
+.routine-set-head .set-editor-label{
+  font-weight: var(--fw-strong);
+}
 .exec-row .input{
   height: var(--control-h); width:100%;
   text-align:center; margin:0; padding:0 8px;
@@ -801,7 +808,7 @@ image_big{
   font-weight: var(--fw-strong);
 }
 
-.set-edit-button{
+.set-edit-button{ 
   width:100%;
   min-height: var(--control-h);
   font-weight: var(--fw-strong);
@@ -809,6 +816,9 @@ image_big{
   color: var(--black);
   background: var(--whiteB);
   border-color: var(--black);
+}
+.routine-set-grid .set-edit-button{
+  color: var(--black);
 }
 
 .set-edit-button:hover,


### PR DESCRIPTION
## Summary
- align the routine template set list header styling with the set editor modal labels
- ensure routine template set values render in black for better readability

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df89b68b0083329407f45cae4568f0