### PR TITLE
Refactor exec edit screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,6 @@
 <!-- ========== 3.4.2 Modifier l’exécution (Colonne A uniquement) ========== -->
 <section id="screenExecEdit" class="screen" hidden>
 
-    <!-- En-tête -->
     <header class="header">
         <div class="header-left">
             <button id="execBack" class="btn ghost" title="Retour">◀︎</button>
@@ -268,43 +267,37 @@
 
         <div class="header-center">
             <div class="title" id="execTitle">Exercice</div>
-       </div>
+        </div>
 
         <div class="header-right">
-            <button id="execOk" class="btn primary" title="Valider">OK︎</button>
+            <button id="execOk" class="btn primary" title="Terminer">OK</button>
         </div>
     </header>
-  
+
     <main class="content">
-      <div class="details" id="execDate">—</div>
-  
-      <!-- Entête colonnes -->
-      <div class="exec-grid exec-head routine-set-grid">
-        <div>#</div>
-        <div>Reps</div>
-        <div>Poids</div>
-        <div>RPE</div>
-        <div class="routine-set-head-rest">Repos</div>
-        <div>Sup.</div>
-      </div>
-  
-      <!-- Séries exécutées (lecture seule) -->
-      <div id="execExecuted"></div>
-  
-      <!-- Zone série en cours (1 seule ligne éditable quand des prévues existent),
-           sinon une ligne “Nouvelle série” -->
-      <div id="execEditable"></div>
-  
-      <div class="add-actions">
-        <button id="execRestToggle" class="btn primary full">Repos</button>
-      </div>
-  
-      <!-- (Colonnes B/C réservées pour plus tard) -->
+        <div class="details" id="execDate">—</div>
 
+        <div class="bloque">
+            <button id="execDelete" class="btn danger full">🗑️ Retirer de la séance</button>
+        </div>
 
+        <div class="exec-grid exec-head routine-set-grid routine-set-head">
+            <div class="set-editor-label">#</div>
+            <div class="set-editor-label">Reps</div>
+            <div class="set-editor-label">Poids</div>
+            <div class="set-editor-label">RPE</div>
+            <div class="routine-set-head-rest set-editor-label">Repos</div>
+            <div class="set-editor-label">Sup.</div>
+        </div>
+
+        <div id="execSets"></div>
+
+        <div class="add-actions">
+            <button id="execAddSet" class="btn primary full">Ajouter une série</button>
+        </div>
     </main>
-    
-  </section>
+
+</section>
 <!-- ==================== -->
  
 <!-- ========== 3.1.1 Bibliothèque d’exercices (liste) ========== -->

--- a/style.css
+++ b/style.css
@@ -758,37 +758,6 @@ image_big{
   font-size: var(--fs-base);
 }
 
-.exec-row.exec-executed{
-  color: var(--black);
-  font-weight: var(--fw-base);
-}
-
-.exec-row.exec-planned,
-.exec-row.exec-new{
-  color: var(--darkGrayB);
-  font-weight: var(--fw-base);
-}
-
-.exec-row.exec-executed .details,
-.exec-row.exec-planned .details,
-.exec-row.exec-new .details{
-  color: inherit;
-  font-size: var(--fs-base);
-  font-weight: inherit;
-}
-
-.exec-edit-row{
-  color: var(--black);
-  font-weight: var(--fw-strong);
-}
-
-.exec-edit-row .input,
-.exec-edit-row select{
-  color: var(--black);
-  font-size: var(--fs-base);
-  font-weight: var(--fw-strong);
-}
-
 .routine-set-actions{
   display:flex;
   justify-content:flex-end;
@@ -808,7 +777,7 @@ image_big{
   font-weight: var(--fw-strong);
 }
 
-.set-edit-button{ 
+.set-edit-button{
   width:100%;
   min-height: var(--control-h);
   font-weight: var(--fw-strong);
@@ -819,6 +788,49 @@ image_big{
 }
 .routine-set-grid .set-edit-button{
   color: var(--black);
+}
+
+.exec-set-row{
+  color: var(--black);
+}
+
+.exec-set-row .set-edit-button{
+  color: inherit;
+}
+
+.exec-set-row .set-edit-button:hover,
+.exec-set-row .set-edit-button:focus{
+  color: inherit;
+}
+
+.exec-set-planned{
+  color: var(--lightGrayB);
+}
+
+.exec-set-planned .set-edit-button{
+  border-color: var(--lightGrayB);
+  color: var(--lightGrayB);
+}
+
+.exec-set-planned .routine-set-order{
+  color: var(--lightGrayB);
+}
+
+.exec-set-planned .routine-set-actions .btn{
+  border-color: var(--lightGrayB);
+  color: var(--lightGrayB);
+}
+
+.exec-set-planned .rpe-chip{
+  background: transparent;
+  border: 1px solid var(--lightGrayB);
+  color: var(--lightGrayB);
+}
+
+.rpe-chip-muted{
+  background: transparent;
+  border: 1px solid currentColor;
+  color: inherit;
 }
 
 .set-edit-button:hover,


### PR DESCRIPTION
## Summary
- rebuild the execution editor screen layout using the routine set editor structure with delete and add actions
- update styling so planned sets appear in light gray, including RPE chips and action controls
- rewrite execution editing logic to manage planned/executed sets and the shared rest timer directly on session data

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68df8d10f824833295d6e09f3a35886b