### PR TITLE
Harmoniser la modale de saisie des séries

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,10 +509,7 @@
                 </div>
             </div>
         </div>
-        <div class="set-editor-actions">
-            <button type="button" class="btn ghost" data-action="close">Fermer</button>
-            <button type="submit" class="btn primary" data-action="submit">Valider</button>
-        </div>
+        <div class="set-editor-actions" data-role="set-editor-actions"></div>
     </form>
 </dialog>
 <!-- ==================== -->

--- a/style.css
+++ b/style.css
@@ -949,6 +949,15 @@ image_big{
   min-width:0;
 }
 
+.set-editor-actions-vertical{
+  flex-direction:column;
+}
+
+.set-editor-actions-vertical .btn{
+  flex:0 0 auto;
+  width:100%;
+}
+
 .set-editor-form.set-editor-tone-black .set-editor-field .vstepper .input,
 .set-editor-form.set-editor-tone-black .set-editor-field .vstepper .btn,
 .set-editor-form.set-editor-tone-black .set-editor-actions .btn.ghost{

--- a/ui-exec-edit.js
+++ b/ui-exec-edit.js
@@ -271,16 +271,34 @@
                     seconds
                 },
                 focus: focusField,
-                tone: set.done === true ? 'black' : 'muted',
+                tone: 'black',
+                actionsLayout: 'vertical',
+                actions: [
+                    {
+                        id: 'plan',
+                        label: 'Planifier',
+                        variant: 'ghost',
+                        full: true
+                    },
+                    {
+                        id: 'save',
+                        label: 'Enregistrer',
+                        variant: 'primary',
+                        full: true
+                    }
+                ],
                 onChange: updatePreview
             })
                 .then(async (result) => {
-                    if (!result) {
+                    if (!result || !result.values) {
                         return;
                     }
-                    const sanitized = sanitizeEditorResult(result, value.rest);
-                    await applySetEditorResult(index, sanitized);
-                    startTimer(sanitized.rest);
+                    const sanitized = sanitizeEditorResult(result.values, value.rest);
+                    const markDone = result.action === 'save';
+                    await applySetEditorResult(index, sanitized, { done: markDone });
+                    if (markDone) {
+                        startTimer(sanitized.rest);
+                    }
                 })
                 .finally(() => {
                     row.classList.remove('routine-set-row-active', 'set-editor-highlight');
@@ -368,7 +386,7 @@
         await persistSession();
     }
 
-    async function applySetEditorResult(index, values) {
+    async function applySetEditorResult(index, values, options = {}) {
         const exercise = getExercise();
         if (!exercise) {
             return;
@@ -377,6 +395,7 @@
         if (!sets[index]) {
             return;
         }
+        const nextDone = options.done ?? sets[index].done ?? false;
         sets[index] = {
             ...sets[index],
             pos: index + 1,
@@ -384,7 +403,7 @@
             weight: sanitizeWeight(values.weight),
             rpe: values.rpe != null && values.rpe !== '' ? clampInt(values.rpe, 5, 10) : null,
             rest: Math.max(0, safeInt(values.rest, getDefaultRest())),
-            done: true
+            done: nextDone
         };
         exercise.sets = sets;
         await persistSession();

--- a/ui-routine-move-edit.js
+++ b/ui-routine-move-edit.js
@@ -184,19 +184,29 @@
                 },
                 focus: focusField,
                 tone: 'black',
+                actionsLayout: 'vertical',
+                actions: [
+                    {
+                        id: 'plan',
+                        label: 'Planifier',
+                        variant: 'ghost',
+                        full: true
+                    }
+                ],
                 onChange: (next) => {
                     updatePreview(next);
                 }
             })
                 .then((result) => {
-                    if (!result) {
+                    if (!result || result.action !== 'plan' || !result.values) {
                         return;
                     }
+                    const payload = result.values;
                     const nextValues = {
-                        reps: safePositiveInt(result.reps),
-                        weight: sanitizeWeight(result.weight),
-                        rpe: result.rpe != null ? clampRpe(result.rpe) : null,
-                        rest: Math.max(0, Math.round((result.minutes ?? 0) * 60 + (result.seconds ?? 0)))
+                        reps: safePositiveInt(payload.reps),
+                        weight: sanitizeWeight(payload.weight),
+                        rpe: payload.rpe != null ? clampRpe(payload.rpe) : null,
+                        rest: Math.max(0, Math.round((payload.minutes ?? 0) * 60 + (payload.seconds ?? 0)))
                     };
                     applySetEditorResult(index, nextValues);
                 })


### PR DESCRIPTION
## Summary
- unifier la modale de saisie des séries en générant dynamiquement les boutons d'action et en harmonisant la présentation
- adapter les écrans routine et exécution pour utiliser les mêmes options de modale tout en conservant leurs actions spécifiques
- ajouter une variante verticale pour les boutons de la modale afin d'obtenir des boutons pleine largeur

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df94fb97948332834c060c44d907b2