### PR TITLE
Add close control to workout timer bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,13 +428,14 @@
 <!-- ✅ Barre de timer collante en bas -->
 <footer id="execTimerBar" class="exec-timer" hidden>
     <!-- pause/play -->
-    <button id="tmrToggle" class="btn ghost">⏸</button>
+    <button id="tmrToggle" class="btn ghost" aria-label="Mettre en pause ou reprendre le timer">⏸</button>
     <!-- timer avec - [temps] + -->
     <div class="tmr-center">
-        <button id="tmrMinus" class="btn ghost">−10s</button>
+        <button id="tmrMinus" class="btn ghost" aria-label="Retirer 10 secondes">−10s</button>
         <div id="tmrDisplay" class="tmr-display">0:00</div>
-        <button id="tmrPlus" class="btn ghost">+10s</button>
+        <button id="tmrPlus" class="btn ghost" aria-label="Ajouter 10 secondes">+10s</button>
     </div>
+    <button id="tmrClose" class="btn ghost tmr-close" aria-label="Fermer et réinitialiser le timer">✕</button>
 </footer>
  <!-- ==================== -->
  

--- a/style.css
+++ b/style.css
@@ -144,11 +144,11 @@ header .title{ font-weight: var(--fw-strong); }
    4) Timer
    ========================================================= */
 /* Timer bas */
-.exec-timer{
+.exec-timer{ 
     z-index:20;
     position:sticky;
     bottom: calc(var(--tabbar-h) + env(safe-area-inset-bottom, 0));
-    
+
     display:grid; grid-template-columns: 1fr 2fr 1fr;
     align-items:center; gap:8px;
     padding:10px 12px;
@@ -156,6 +156,7 @@ header .title{ font-weight: var(--fw-strong); }
     border-top:1px solid var(--whiteB);
 }
 .exec-timer .tmr-center{ display:flex; align-items:center; justify-content:center; gap:10px; }
+.exec-timer .tmr-close{ justify-self:end; }
 .tmr-display{ font-weight: var(--fw-strong); min-width:76px; text-align:center; }
 .exec-timer .btn.ghost{ border:1px solid var(--whiteB); }
 

--- a/ui-exec-edit.js
+++ b/ui-exec-edit.js
@@ -111,6 +111,7 @@
         refs.timerToggle = document.getElementById('tmrToggle');
         refs.timerMinus = document.getElementById('tmrMinus');
         refs.timerPlus = document.getElementById('tmrPlus');
+        refs.timerClose = document.getElementById('tmrClose');
         refsResolved = true;
         return refs;
     }
@@ -130,7 +131,8 @@
             'timerDisplay',
             'timerToggle',
             'timerMinus',
-            'timerPlus'
+            'timerPlus',
+            'timerClose'
         ];
         const missing = required.filter((key) => !refs[key]);
         if (missing.length) {
@@ -160,7 +162,7 @@
     }
 
     function wireTimerControls() {
-        const { timerToggle, timerMinus, timerPlus } = assertRefs();
+        const { timerToggle, timerMinus, timerPlus, timerClose } = assertRefs();
         timerToggle.addEventListener('click', () => {
             const timer = ensureSharedTimer();
             if (timer.running) {
@@ -174,6 +176,9 @@
         });
         timerPlus.addEventListener('click', () => {
             void adjustTimer(10);
+        });
+        timerClose.addEventListener('click', () => {
+            resetTimerState();
         });
     }
 
@@ -593,9 +598,10 @@
     }
 
     function resetTimerState() {
-        stopTimer();
         const timer = ensureSharedTimer();
-        Object.assign(timer, defaultTimerState());
+        const currentExerciseKey = timer.exerciseKey;
+        stopTimer();
+        Object.assign(timer, defaultTimerState(), { exerciseKey: currentExerciseKey });
         updateTimerUI();
     }
 


### PR DESCRIPTION
## Summary
- add an accessible close button to the execution timer bar to dismiss and reset it
- wire the new control into the shared timer state without losing the current exercise association
- adjust timer bar layout styling so the new button aligns to the right edge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9a9fd7688332bb83d08e1ff2465b