### PR TITLE
Préremplir le groupe musculaire lors du remplacement d’exercice

### DIFF
--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -201,7 +201,7 @@
             removeMove();
         });
         routineMoveReplace.addEventListener('click', () => {
-            replaceMoveExercise();
+            void replaceMoveExercise();
         });
         routineMoveUp.addEventListener('click', () => {
             void moveRoutineExercise(-1);
@@ -875,7 +875,7 @@
         A.ensureRoutineMoveInView?.(copy.id);
     }
 
-    function replaceMoveExercise() {
+    async function replaceMoveExercise() {
         const move = findMove();
         if (!move) {
             return;
@@ -885,10 +885,21 @@
         } else {
             refs.dlgRoutineMoveEditor?.close();
         }
+        const sourceExercise = move.exerciseId ? await db.get('exercises', move.exerciseId) : null;
+        const defaultMuscleGroup = (
+            move.muscleGroup2
+            || move.muscle
+            || move.muscleGroup3
+            || sourceExercise?.muscleGroup2
+            || sourceExercise?.muscle
+            || sourceExercise?.muscleGroup3
+            || ''
+        ).toString().trim();
         A.openExercises({
             mode: 'add',
             callerScreen: state.replaceCallerScreen || 'screenRoutineMoveEdit',
             selectionLimit: 1,
+            presetGroupFilter: defaultMuscleGroup,
             onAdd: (ids) => {
                 const [nextId] = ids;
                 if (nextId) {

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -2143,10 +2143,14 @@
         } else {
             refs.dlgExecMoveEditor?.close();
         }
+        const sourceExercise = exercise.exercise_id ? await db.get('exercises', exercise.exercise_id) : null;
         const defaultMuscleGroup = (
             exercise.muscleGroup2
             || exercise.muscle
             || exercise.muscleGroup3
+            || sourceExercise?.muscleGroup2
+            || sourceExercise?.muscle
+            || sourceExercise?.muscleGroup3
             || ''
         ).toString().trim();
         A.openExercises({


### PR DESCRIPTION
### Motivation
- Accélérer le flux de remplacement d’un exercice en préremplissant le filtre « groupe musculaire » dans l’écran de recherche d’exercices en se basant sur l’exercice source (local puis fiche en base). 

### Description
- `ui-session-execution-edit.js`: `replaceExercise` charge maintenant la fiche source via `db.get` et calcule `defaultMuscleGroup` en prenant d’abord les données locales puis les champs de la fiche en base, puis transmet `presetGroupFilter` à `A.openExercises`.
- `ui-routine-execution-edit.js`: `replaceMoveExercise` est devenu `async`, récupère la fiche source avec `db.get`, calcule `defaultMuscleGroup` par fallback et passe `presetGroupFilter` à `A.openExercises`.
- Le handler du bouton « Remplacer » dans l’éditeur de routine utilise maintenant `void replaceMoveExercise()` pour appeler proprement la nouvelle fonction asynchrone.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check ui-session-execution-edit.js && node --check ui-routine-execution-edit.js`, qui a réussi. 
- Aucun autre test automatisé ajouté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d29139c6b48332b586b6f03b22f961)