### PR TITLE
Align history tab set fields into fixed columns

### DIFF
--- a/style.css
+++ b/style.css
@@ -1454,6 +1454,21 @@ textarea:focus{
     border-radius: var(--radius);
     background: var(--panelBack);
 }
+.exercise-history-set-line{
+    display:grid;
+    grid-template-columns: 3ch 6ch 4.5ch auto auto auto auto;
+    column-gap: .35rem;
+    align-items: baseline;
+}
+.exercise-history-set-line__reps,
+.exercise-history-set-line__weight,
+.exercise-history-set-line__rpe{
+    text-align: right;
+}
+.exercise-history-set-line__sep,
+.exercise-history-set-line__slash{
+    text-align: center;
+}
 
 /* =========================================================
    8) Boutons

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -570,9 +570,7 @@
                 wrapper.appendChild(emptyLine);
             } else {
                 sets.forEach((set) => {
-                    const line = document.createElement('div');
-                    line.className = 'details';
-                    line.textContent = formatSetLine(set, weightUnit);
+                    const line = buildHistorySetLine(set, weightUnit);
                     wrapper.appendChild(line);
                 });
             }
@@ -617,6 +615,38 @@
         const line = parts.length ? parts.join(' ') : '—';
         const ormSummary = formatOrmSummary(orm, ormRpe, weightUnit);
         return ormSummary ? `${line} ${ormSummary}` : line;
+    }
+
+    function buildHistorySetLine(set, weightUnit) {
+        const line = document.createElement('div');
+        line.className = 'details exercise-history-set-line';
+
+        const reps = Number.isFinite(set?.reps) ? `${set.reps}x` : '—';
+        const weight = set?.weight != null && !Number.isNaN(Number(set.weight))
+            ? `${formatNumber(Number(set.weight))}${weightUnit}`
+            : '—';
+        const rpe = set?.rpe != null && set?.rpe !== '' ? `@${formatRpeValue(set.rpe)}` : '—';
+        const orm = Number.isFinite(set?.orm) ? `${formatOrmValue(set.orm)}${weightUnit}` : `—${weightUnit}`;
+        const ormRpe = Number.isFinite(set?.ormRpe) ? `${formatOrmValue(set.ormRpe)}${weightUnit}` : `—${weightUnit}`;
+
+        line.append(
+            createHistoryPart('exercise-history-set-line__reps', reps),
+            createHistoryPart('exercise-history-set-line__weight', weight),
+            createHistoryPart('exercise-history-set-line__rpe', rpe),
+            createHistoryPart('exercise-history-set-line__sep', '='),
+            createHistoryPart('exercise-history-set-line__orm', orm),
+            createHistoryPart('exercise-history-set-line__slash', '/'),
+            createHistoryPart('exercise-history-set-line__orm-rpe', ormRpe)
+        );
+
+        return line;
+    }
+
+    function createHistoryPart(className, text) {
+        const part = document.createElement('span');
+        part.className = className;
+        part.textContent = text;
+        return part;
     }
 
     function formatRpeValue(value) {


### PR DESCRIPTION
### Motivation
- Improve readability of the "Historique" tab by aligning per-set values (reps, weight, RPE, ORM) into consistent vertical columns so items like `12x`, `40kg` and `@RPE` line up across rows.

### Description
- Replace plain-text history set rows with a structured DOM row created by `buildHistorySetLine(set, weightUnit)` in `ui-exercise-read.js` that emits multiple span parts for reps, weight, RPE, separators and ORM values.
- Add helper `createHistoryPart(className, text)` in `ui-exercise-read.js` to build the individual parts and keep `formatSetLine` intact for other usages.
- Add CSS rules in `style.css` (`.exercise-history-set-line` and related part classes) to render the row as a fixed-column grid and to right/center align the appropriate columns.

### Testing
- Ran `node --check ui-exercise-read.js` which completed successfully. 
- Verified file modifications are present for `ui-exercise-read.js` and `style.css` (no runtime errors reported by the static check).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a8e07cd08332bbe2301921fd32ed)