### PR TITLE
Add 1RM / 1RMrpe / average RPE stats line to exercise cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -1650,6 +1650,12 @@ textarea:focus{
 .exercise-card--full-sets .exercise-card-title-row{
   padding-right: 52px;
 }
+.exercise-card-stats{
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--muted);
+  margin: -2px 0 4px;
+}
 .exercise-card--full-sets .exercise-card-name{
   padding: 0;
 }

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -966,6 +966,9 @@
         const titleRow = document.createElement('div');
         titleRow.className = 'exercise-card-title-row';
         titleRow.appendChild(name);
+        const statsLine = document.createElement('div');
+        statsLine.className = 'exercise-card-stats';
+        statsLine.textContent = formatExerciseStatsText(move.sets);
         const detailsButton = document.createElement('button');
         detailsButton.type = 'button';
         detailsButton.className = 'exercise-card-menu-button';
@@ -982,7 +985,7 @@
         const setsWrapper = document.createElement('div');
         setsWrapper.className = 'session-card-sets';
         renderRoutineCardSets(move, setsWrapper);
-        body.append(titleRow, setsWrapper);
+        body.append(titleRow, statsLine, setsWrapper);
 
         card.setAttribute('aria-label', move.exerciseName || 'Exercice');
         attachRoutineCardPressHandlers(card);
@@ -1071,8 +1074,12 @@
             return false;
         }
         const setsWrapper = card.querySelector('.session-card-sets');
+        const statsLine = card.querySelector('.exercise-card-stats');
         if (!setsWrapper) {
             return false;
+        }
+        if (statsLine) {
+            statsLine.textContent = formatExerciseStatsText(move?.sets);
         }
         renderRoutineCardSets(move, setsWrapper);
         return true;
@@ -1501,6 +1508,65 @@
 
     function formatSetRpe(value) {
         return `@${formatSynopsisRpe(value)}`;
+    }
+
+    function formatExerciseMetric(value, suffix = '') {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+            return '—';
+        }
+        return `${formatSynopsisNumber(numeric)}${suffix}`;
+    }
+
+    function computeExerciseStatsLine(sets) {
+        const eligibleSets = (Array.isArray(sets) ? sets : []).filter((set) => {
+            const rpe = Number(set?.rpe);
+            const reps = Number(set?.reps);
+            const weight = Number(set?.weight);
+            return Number.isFinite(rpe) && rpe >= 7 && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
+        });
+        if (!eligibleSets.length) {
+            return {
+                orm: null,
+                ormRpe: null,
+                rpeAvg: null
+            };
+        }
+        let ormSum = 0;
+        let ormCount = 0;
+        let ormRpeSum = 0;
+        let ormRpeCount = 0;
+        let rpeSum = 0;
+        let rpeCount = 0;
+        eligibleSets.forEach((set) => {
+            const reps = Number(set?.reps);
+            const weight = Number(set?.weight);
+            const rpe = Number(set?.rpe);
+            const orm = A.calculateOrm?.(weight, reps);
+            if (Number.isFinite(orm)) {
+                ormSum += orm;
+                ormCount += 1;
+            }
+            const ormRpe = A.calculateOrmWithRpe?.(weight, reps, rpe);
+            if (Number.isFinite(ormRpe)) {
+                ormRpeSum += ormRpe;
+                ormRpeCount += 1;
+            }
+            if (Number.isFinite(rpe)) {
+                rpeSum += rpe;
+                rpeCount += 1;
+            }
+        });
+        return {
+            orm: ormCount ? ormSum / ormCount : null,
+            ormRpe: ormRpeCount ? ormRpeSum / ormRpeCount : null,
+            rpeAvg: rpeCount ? rpeSum / rpeCount : null
+        };
+    }
+
+    function formatExerciseStatsText(sets) {
+        const stats = computeExerciseStatsLine(sets);
+        return `1RM ${formatExerciseMetric(stats.orm, 'kg')} · 1RMrpe ${formatExerciseMetric(stats.ormRpe, 'kg')} · RPE moyen ${formatExerciseMetric(stats.rpeAvg)}`;
     }
 
     function normalizeFocusField(field) {

--- a/ui-session.js
+++ b/ui-session.js
@@ -107,6 +107,65 @@
         return `@${formatSynopsisRpe(value)}`;
     }
 
+    function formatExerciseMetric(value, suffix = '') {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+            return '—';
+        }
+        return `${formatSynopsisNumber(numeric)}${suffix}`;
+    }
+
+    function computeExerciseStatsLine(sets) {
+        const eligibleSets = (Array.isArray(sets) ? sets : []).filter((set) => {
+            const rpe = Number(set?.rpe);
+            const reps = Number(set?.reps);
+            const weight = Number(set?.weight);
+            return Number.isFinite(rpe) && rpe >= 7 && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
+        });
+        if (!eligibleSets.length) {
+            return {
+                orm: null,
+                ormRpe: null,
+                rpeAvg: null
+            };
+        }
+        let ormSum = 0;
+        let ormCount = 0;
+        let ormRpeSum = 0;
+        let ormRpeCount = 0;
+        let rpeSum = 0;
+        let rpeCount = 0;
+        eligibleSets.forEach((set) => {
+            const reps = Number(set?.reps);
+            const weight = Number(set?.weight);
+            const rpe = Number(set?.rpe);
+            const orm = A.calculateOrm?.(weight, reps);
+            if (Number.isFinite(orm)) {
+                ormSum += orm;
+                ormCount += 1;
+            }
+            const ormRpe = A.calculateOrmWithRpe?.(weight, reps, rpe);
+            if (Number.isFinite(ormRpe)) {
+                ormRpeSum += ormRpe;
+                ormRpeCount += 1;
+            }
+            if (Number.isFinite(rpe)) {
+                rpeSum += rpe;
+                rpeCount += 1;
+            }
+        });
+        return {
+            orm: ormCount ? ormSum / ormCount : null,
+            ormRpe: ormRpeCount ? ormRpeSum / ormRpeCount : null,
+            rpeAvg: rpeCount ? rpeSum / rpeCount : null
+        };
+    }
+
+    function formatExerciseStatsText(sets) {
+        const stats = computeExerciseStatsLine(sets);
+        return `1RM ${formatExerciseMetric(stats.orm, 'kg')} · 1RMrpe ${formatExerciseMetric(stats.ormRpe, 'kg')} · RPE moyen ${formatExerciseMetric(stats.rpeAvg)}`;
+    }
+
     function normalizeFocusField(field) {
         if (field === 'weight' || field === 'rpe' || field === 'reps') {
             return field;
@@ -605,6 +664,9 @@
             const titleRow = document.createElement('div');
             titleRow.className = 'exercise-card-title-row';
             titleRow.appendChild(name);
+            const statsLine = document.createElement('div');
+            statsLine.className = 'exercise-card-stats';
+            statsLine.textContent = formatExerciseStatsText(exercise.sets);
             const detailsButton = document.createElement('button');
             detailsButton.type = 'button';
             detailsButton.className = 'exercise-card-menu-button';
@@ -624,7 +686,7 @@
             const setsWrapper = document.createElement('div');
             setsWrapper.className = 'session-card-sets';
             await renderSessionCardSets({ exercise, setsWrapper, dateKey: key });
-            body.append(titleRow, setsWrapper);
+            body.append(titleRow, statsLine, setsWrapper);
 
             card.setAttribute('aria-label', exerciseName);
             attachSessionCardPressHandlers(card);
@@ -735,8 +797,12 @@
             return false;
         }
         const setsWrapper = card.querySelector('.session-card-sets');
+        const statsLine = card.querySelector('.exercise-card-stats');
         if (!setsWrapper) {
             return false;
+        }
+        if (statsLine) {
+            statsLine.textContent = formatExerciseStatsText(exercise?.sets);
         }
         await renderSessionCardSets({ exercise, setsWrapper, dateKey });
         return true;


### PR DESCRIPTION
### Motivation
- Surface compact performance statistics on exercise cards in both session and routine screens to help quick assessment. 
- Compute metrics only from sets with `RPE >= 7` and include planned and done sets as requested. 
- Keep the visual display discreet and updateable when sets change.

### Description
- Add helpers `computeExerciseStatsLine`, `formatExerciseMetric` and `formatExerciseStatsText` in `ui-session.js` and `ui-routine-edit.js` to compute average `1RM`, `1RMrpe` and mean `RPE` from eligible sets. 
- Insert a new DOM node under the exercise name (`.exercise-card-stats`) in session and routine cards and refresh its content in `updateSessionExerciseCard` and `updateRoutineMoveCard`. 
- Add a small muted style for `.exercise-card-stats` in `style.css` and update the following files: `ui-session.js`, `ui-routine-edit.js`, `style.css`.

### Testing
- Validated JavaScript syntax for the modified files with `node -e "const fs=require('fs'); ['ui-session.js','ui-routine-edit.js'].forEach(f=>{new Function(fs.readFileSync(f,'utf8'));}); console.log('ok')"` which printed `ok`.
- No automated unit tests were added and no browser rendering screenshots were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f9c1bb1c8332a5eb1db6a5e354e0)