### PR TITLE
Ajoute RPE / 1RM / 1RMrpe en tête des blocs historique exercice

### DIFF
--- a/style.css
+++ b/style.css
@@ -1469,6 +1469,9 @@ textarea:focus{
 .exercise-history-set-line__slash{
     text-align: center;
 }
+.exercise-history-stats-line{
+    color: var(--mutedText);
+}
 
 /* =========================================================
    8) Boutons

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -572,6 +572,9 @@
             dateLabel.textContent = formatSessionDate(session);
             wrapper.appendChild(dateLabel);
 
+            const statsLine = buildHistoryStatsLine(sets, weightUnit);
+            wrapper.appendChild(statsLine);
+
             if (!sets.length) {
                 const emptyLine = document.createElement('div');
                 emptyLine.className = 'details';
@@ -649,6 +652,65 @@
         );
 
         return line;
+    }
+
+    function buildHistoryStatsLine(sets, weightUnit) {
+        const line = document.createElement('div');
+        line.className = 'details exercise-history-set-line exercise-history-stats-line';
+        const stats = computeHistorySessionStats(sets);
+        const rpeAvg = Number.isFinite(stats?.rpeAvg) ? formatRpeValue(stats.rpeAvg) : '—';
+        const orm = Number.isFinite(stats?.orm) ? `${formatOrmValue(stats.orm)}${weightUnit}` : `—${weightUnit}`;
+        const ormRpe = Number.isFinite(stats?.ormRpe) ? `${formatOrmValue(stats.ormRpe)}${weightUnit}` : `—${weightUnit}`;
+
+        line.append(
+            createHistoryPart('exercise-history-set-line__reps', ''),
+            createHistoryPart('exercise-history-set-line__weight', ''),
+            createHistoryPart('exercise-history-set-line__rpe', rpeAvg),
+            createHistoryPart('exercise-history-set-line__sep', ''),
+            createHistoryPart('exercise-history-set-line__orm', orm),
+            createHistoryPart('exercise-history-set-line__slash', ''),
+            createHistoryPart('exercise-history-set-line__orm-rpe', ormRpe)
+        );
+        return line;
+    }
+
+    function computeHistorySessionStats(sets) {
+        const eligibleSets = (Array.isArray(sets) ? sets : []).filter((set) => {
+            const rpe = Number(set?.rpe);
+            const reps = Number(set?.reps);
+            const weight = Number(set?.weight);
+            return Number.isFinite(rpe) && rpe >= 7 && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
+        });
+        if (!eligibleSets.length) {
+            return { rpeAvg: null, orm: null, ormRpe: null };
+        }
+
+        let rpeSum = 0;
+        let ormSum = 0;
+        let ormCount = 0;
+        let ormRpeSum = 0;
+        let ormRpeCount = 0;
+        eligibleSets.forEach((set) => {
+            const rpe = Number(set?.rpe);
+            const reps = Number(set?.reps);
+            const weight = Number(set?.weight);
+            rpeSum += rpe;
+            const orm = A.calculateOrm?.(weight, reps);
+            if (Number.isFinite(orm)) {
+                ormSum += orm;
+                ormCount += 1;
+            }
+            const ormRpe = A.calculateOrmWithRpe?.(weight, reps, rpe);
+            if (Number.isFinite(ormRpe)) {
+                ormRpeSum += ormRpe;
+                ormRpeCount += 1;
+            }
+        });
+        return {
+            rpeAvg: rpeSum / eligibleSets.length,
+            orm: ormCount ? ormSum / ormCount : null,
+            ormRpe: ormRpeCount ? ormRpeSum / ormRpeCount : null
+        };
     }
 
     function createHistoryPart(className, text) {


### PR DESCRIPTION
### Motivation
- Afficher pour chaque séance de l’onglet « Histo » une ligne de synthèse contenant les 3 valeurs (RPE moyen, 1RM, 1RMrpe) calculées uniquement sur les séries à RPE >= 7 et alignées horizontalement avec les colonnes des lignes de séries.

### Description
- Ajout de l’appel à `buildHistoryStatsLine(sets, weightUnit)` juste après l’étiquette de date dans `ui-exercise-read.js` pour insérer la ligne de métriques au début de chaque bloc séance.
- Ajout des fonctions `buildHistoryStatsLine` et `computeHistorySessionStats` dans `ui-exercise-read.js` ; le calcul filtre les séries `rpe >= 7` et moyenne `rpe`, `1RM` (via `A.calculateOrm`) et `1RMrpe` (via `A.calculateOrmWithRpe`) en réutilisant les fonctions de formatage existantes.
- Modification de `style.css` pour ajouter la classe `.exercise-history-stats-line` (style atténué) et réutiliser la grille existante `.exercise-history-set-line` afin d’aligner les valeurs avec les colonnes RPE / 1RM / 1RMrpe.
- L’affichage rend uniquement les valeurs (pas de labels) et laisse vides les colonnes `reps` et `weight` pour garantir l’alignement.

### Testing
- `node --check ui-exercise-read.js` — réussi.
- `node --check ui-session.js` — réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b347726c8332b0b8f3dd55923cef)