### PR TITLE
Fix visible text selection for set-entry cells (including rest minutes/seconds)

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -884,7 +884,8 @@
                     && target.selectionEnd > target.selectionStart;
                 const colonIndex = current.indexOf(':') >= 0 ? current.indexOf(':') : normalized.minutesText.length;
                 const cursor = typeof target?.selectionStart === 'number' ? target.selectionStart : current.length;
-                const minuteSide = hasSelection ? true : cursor <= colonIndex;
+                const selectionStart = typeof target?.selectionStart === 'number' ? target.selectionStart : cursor;
+                const minuteSide = hasSelection ? selectionStart <= colonIndex : cursor <= colonIndex;
 
                 if (key === ':') {
                     if (minuteSide) {

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -571,7 +571,13 @@
                 getValue: () => input.value,
                 onChange: (next, meta = {}) => {
                     input.value = next;
-                    if (typeof meta?.caretPosition === 'number') {
+                    if (field === 'rest' && typeof meta?.caretPosition === 'number') {
+                        const colonIndex = String(next).indexOf(':');
+                        const onMinutes = colonIndex < 0 || meta.caretPosition <= colonIndex;
+                        requestAnimationFrame(() => {
+                            selectInput(input, 'rest', { restPart: onMinutes ? 'minutes' : 'seconds' });
+                        });
+                    } else if (typeof meta?.caretPosition === 'number') {
                         const position = Math.max(0, Math.min(String(next).length, meta.caretPosition));
                         requestAnimationFrame(() => {
                             input.setSelectionRange(position, position);
@@ -592,6 +598,32 @@
             });
         };
 
+        const selectInput = (input, field, options = {}) => {
+            if (!input) {
+                return;
+            }
+            requestAnimationFrame(() => {
+                input.focus({ preventScroll: true });
+                if (field !== 'rest') {
+                    input.select();
+                    return;
+                }
+                const restPart = options.restPart === 'seconds' ? 'seconds' : 'minutes';
+                const valueText = String(input.value ?? '');
+                const colonIndex = valueText.indexOf(':');
+                if (colonIndex < 0) {
+                    input.select();
+                    return;
+                }
+                if (restPart === 'seconds') {
+                    const start = colonIndex + 1;
+                    input.setSelectionRange(start, valueText.length);
+                    return;
+                }
+                input.setSelectionRange(0, colonIndex);
+            });
+        };
+
         const createInput = (getValue, field, extraClass = '', options = {}) => {
             const input = document.createElement('input');
             const { inputMode = inlineKeyboard ? 'none' : 'numeric', type = 'text' } = options;
@@ -609,7 +641,7 @@
             input._update = update;
             update();
             input.addEventListener('focus', () => {
-                input.select();
+                selectInput(input, field);
             });
             const commit = () => {
                 if (field === 'rpe') {
@@ -627,6 +659,7 @@
             input.addEventListener('click', () => {
                 openEditor(field);
                 attachInlineKeyboard(input, field);
+                selectInput(input, field, field === 'rest' ? { restPart: 'minutes' } : {});
             });
             return input;
         };
@@ -640,11 +673,6 @@
         );
         const rpeInput = createInput(() => (value.rpe == null ? '' : String(value.rpe)), 'rpe', 'exec-rpe-cell');
         const restInput = createInput(() => formatRestDisplay(value.rest), 'rest', 'exec-rest-cell');
-        restInput.addEventListener('focus', () => {
-            const colon = restInput.value.indexOf(':');
-            const end = colon >= 0 ? colon : restInput.value.length;
-            restInput.setSelectionRange(0, end);
-        });
         collectInputs(repsInput, weightInput, rpeInput, restInput);
         syncRowTone();
         const selectField = (field) => {
@@ -659,6 +687,7 @@
                 return;
             }
             attachInlineKeyboard(target, field);
+            selectInput(target, field, field === 'rest' ? { restPart: 'minutes' } : {});
         };
 
         row.append(order, repsInput, weightInput, rpeInput, restInput);

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1280,7 +1280,13 @@
                 getValue: () => input.value,
                 onChange: (next, meta = {}) => {
                     input.value = next;
-                    if (typeof meta?.caretPosition === 'number') {
+                    if (field === 'rest' && typeof meta?.caretPosition === 'number') {
+                        const colonIndex = String(next).indexOf(':');
+                        const onMinutes = colonIndex < 0 || meta.caretPosition <= colonIndex;
+                        requestAnimationFrame(() => {
+                            selectInput(input, 'rest', { restPart: onMinutes ? 'minutes' : 'seconds' });
+                        });
+                    } else if (typeof meta?.caretPosition === 'number') {
                         const position = Math.max(0, Math.min(String(next).length, meta.caretPosition));
                         requestAnimationFrame(() => {
                             input.setSelectionRange(position, position);
@@ -1301,6 +1307,32 @@
             });
         };
 
+        const selectInput = (input, field, options = {}) => {
+            if (!input) {
+                return;
+            }
+            requestAnimationFrame(() => {
+                input.focus({ preventScroll: true });
+                if (field !== 'rest') {
+                    input.select();
+                    return;
+                }
+                const restPart = options.restPart === 'seconds' ? 'seconds' : 'minutes';
+                const valueText = String(input.value ?? '');
+                const colonIndex = valueText.indexOf(':');
+                if (colonIndex < 0) {
+                    input.select();
+                    return;
+                }
+                if (restPart === 'seconds') {
+                    const start = colonIndex + 1;
+                    input.setSelectionRange(start, valueText.length);
+                    return;
+                }
+                input.setSelectionRange(0, colonIndex);
+            });
+        };
+
         const createInput = (getValue, field, extraClass = '', options = {}) => {
             const input = document.createElement('input');
             const { inputMode = inlineKeyboard ? 'none' : 'numeric', type = 'text', html = false } = options;
@@ -1318,7 +1350,7 @@
             input._update = update;
             update();
             input.addEventListener('focus', () => {
-                input.select();
+                selectInput(input, field);
             });
             const commit = () => {
                 if (field === 'rpe') {
@@ -1336,6 +1368,7 @@
             input.addEventListener('click', () => {
                 openEditor(field);
                 attachInlineKeyboard(input, field);
+                selectInput(input, field, field === 'rest' ? { restPart: 'minutes' } : {});
             });
             return input;
         };
@@ -1349,11 +1382,6 @@
         );
         const rpeInput = createInput(() => (value.rpe == null ? '' : String(value.rpe)), 'rpe', 'exec-rpe-cell');
         const restInput = createInput(() => formatRestDisplay(value.rest), 'rest', 'exec-rest-cell');
-        restInput.addEventListener('focus', () => {
-            const colon = restInput.value.indexOf(':');
-            const end = colon >= 0 ? colon : restInput.value.length;
-            restInput.setSelectionRange(0, end);
-        });
         collectInputs(repsInput, weightInput, rpeInput, restInput);
         syncRowTone();
         selectField = (field) => {
@@ -1368,6 +1396,7 @@
                 return;
             }
             attachInlineKeyboard(target, field);
+            selectInput(target, field, field === 'rest' ? { restPart: 'minutes' } : {});
         };
 
         const metaCell = buildMetaCell(set, index, meta);


### PR DESCRIPTION
### Motivation
- Make text selection visible and consistent when focusing/clicking set-entry cells in both session edit and routine template editors. 
- Ensure the rest time cell selects only the active segment (minutes or seconds) while defaulting to minutes on open.
- Align inline time-keyboard behavior with actual caret/selection position so minute/second editing works reliably.

### Description
- Restored explicit native selection behavior by adding a `selectInput` helper and using it on `focus`/`click` for inputs in `ui-session-execution-edit.js` and `ui-routine-execution-edit.js` so selection is visible on native background. 
- Changed inline keyboard `onChange` handling to detect `field === 'rest'` and map `caretPosition` to selecting the `minutes` or `seconds` segment instead of always manipulating caret directly. 
- Removed the previous ad-hoc `restInput` focus handler and replaced it with `selectInput` which focuses and selects the appropriate segment (default `minutes`) when opening the rest cell. 
- Fixed time-layout selection logic in `components/set-editor.js` so the active side (minutes/seconds) is derived from `selectionStart` when a selection exists instead of assuming minutes, preventing incorrect segment targeting while typing with selections.

### Testing
- Ran syntax checks: `node --check ui-session-execution-edit.js`, `node --check ui-routine-execution-edit.js`, and `node --check components/set-editor.js`, and they succeeded. 
- No additional automated UI tests were available in this environment to validate visual selection, so changes were verified via static checks only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b7908b3c8332819dec4003a01cdb)