### PR TITLE
Add 'Éditer l'exercice' button to execution view and hook to open exercise editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,10 @@
         <section id="execEditTabStats" class="exercise-read-tab" data-tab-panel="stats" hidden>
             <div id="execReadStatsContent" class="exercise-read-panel"></div>
         </section>
+
+        <div class="add-actions">
+            <button id="execExerciseEdit" class="btn full" type="button" title="Éditer l'exercice" aria-label="Éditer l'exercice">Éditer l'exercice</button>
+        </div>
     </main>
 
 </section>

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -239,6 +239,7 @@
         refs.screenData = document.getElementById('screenData');
         refs.tabSessions = document.getElementById('tabSessions');
         refs.execBack = document.getElementById('execBack');
+        refs.execExerciseEdit = document.getElementById('execExerciseEdit');
         refs.execTitle = document.getElementById('execTitle');
         refs.execEditTabs = document.getElementById('execEditTabs');
         refs.execEditDateTab = document.getElementById('execEditDateTab');
@@ -352,6 +353,7 @@
     function wireActions() {
         const {
             execAddSet,
+            execExerciseEdit,
             execDelete,
             execReplaceExercise,
             execMetaToggle,
@@ -363,6 +365,9 @@
         } = assertRefs();
         execAddSet.addEventListener('click', () => {
             void addSet();
+        });
+        execExerciseEdit?.addEventListener('click', () => {
+            void openExerciseDefinitionEdit();
         });
         execDelete.addEventListener('click', () => {
             void removeExercise();
@@ -2476,6 +2481,16 @@
         }
         switchScreen(state.callerScreen || 'screenSessions');
         void refreshSessionViews();
+    }
+
+    async function openExerciseDefinitionEdit() {
+        if (!state.exerciseRefId || typeof A.openExerciseEdit !== 'function') {
+            return;
+        }
+        await A.openExerciseEdit({
+            currentId: state.exerciseRefId,
+            callerScreen: 'screenExerciseRead'
+        });
     }
 
     function switchScreen(target) {


### PR DESCRIPTION
### Motivation
- Provide a quick way to open the exercise definition editor directly from the execution/read view. 
- Improve workflow by allowing users to edit an exercise referenced in an execution without navigating away manually.

### Description
- Add an `Éditer l'exercice` button in `index.html` with id `execExerciseEdit` placed in the execution read/edit UI. 
- Register the new element in `ensureRefs()` by adding `refs.execExerciseEdit = document.getElementById('execExerciseEdit')`. 
- Wire a click handler in `wireActions()` to call a new helper when the edit button is clicked. 
- Implement `openExerciseDefinitionEdit()` to call `A.openExerciseEdit` with `currentId: state.exerciseRefId` and `callerScreen: 'screenExerciseRead'` when `state.exerciseRefId` is present.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9174ed30883328a1854a3766cbccb)