### PR TITLE
Fix stats tab objective placement and interactive chart focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,10 +402,7 @@
 
         <section id="exReadTabStats" class="exercise-read-tab" data-tab-panel="stats" hidden>
             <div class="panel exercise-read-panel">
-                <div class="row between">
-                    <div id="statsExerciseTitle" class="sr-only">Exercice</div>
-                    <button id="statsGoal" class="btn primary" type="button" title="Objectif">obj</button>
-                </div>
+                <div id="statsExerciseTitle" class="sr-only">Exercice</div>
 
                 <div class="bloque stats-header">
                     <div class="stats-subtitle" id="statsExerciseSubtitle"></div>
@@ -447,6 +444,8 @@
                         <button type="button" class="tag" data-range="12M">12 m.</button>
                     </div>
                 </div>
+
+                <button id="statsGoal" class="btn primary full" type="button" title="Objectif">Objectif</button>
 
                 <section>
                     <h2 class="stats-section-title" id="statsTimelineTitle">Historique</h2>

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -1084,16 +1084,15 @@
             updateSubtitleForPoint(point);
         };
 
-        const handlePointerDown = (event) => {
+        const findClosestPoint = (clientX) => {
             if (!points.length) {
-                return;
+                return null;
             }
-            event.preventDefault();
             const rect = svg.getBoundingClientRect();
             if (!rect.width) {
-                return;
+                return null;
             }
-            const chartX = ((event.clientX - rect.left) / rect.width) * width;
+            const chartX = ((clientX - rect.left) / rect.width) * width;
             let closest = points[0];
             let minDistance = Math.abs(points[0].x - chartX);
             for (let i = 1; i < points.length; i += 1) {
@@ -1104,10 +1103,38 @@
                     closest = candidate;
                 }
             }
+            return closest;
+        };
+
+        const handlePointerDown = (event) => {
+            if (!points.length) {
+                return;
+            }
+            event.preventDefault();
+            const closest = findClosestPoint(event.clientX);
+            if (!closest) {
+                return;
+            }
             updateFocusAtPoint(closest);
         };
 
+        const handlePointerMove = (event) => {
+            const closest = findClosestPoint(event.clientX);
+            if (!closest) {
+                return;
+            }
+            updateFocusAtPoint(closest);
+        };
+
+        const clearFocus = () => {
+            focusGroup.setAttribute('data-visible', 'false');
+            points.forEach((item) => item.element?.classList.remove('is-active'));
+            updateExerciseSummary(statsExerciseSubtitle);
+        };
+
         svg.addEventListener('pointerdown', handlePointerDown);
+        svg.addEventListener('pointermove', handlePointerMove);
+        svg.addEventListener('pointerleave', clearFocus);
 
         points.forEach((point) => {
             const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
@@ -1118,6 +1145,8 @@
             point.element = circle;
             svg.appendChild(circle);
         });
+
+        updateFocusAtPoint(points[points.length - 1]);
 
         statsChart.setAttribute(
             'aria-label',


### PR DESCRIPTION
### Motivation
- Restore the expected UI/UX in the Exercise -> Statistiques tab that had been regressed, namely the full-width objective button placement and interactive chart behavior.
- Improve chart interaction so users can see the emphasized nearest point and a vertical focus line while moving the pointer.

### Description
- Moved the objective action from the top inline row into a full-width button labeled `Objectif` placed just before the session history list by updating `index.html`.
- Replaced the short `obj` label with the full `Objectif` text and removed the inline row to avoid a visible duplicate exercise title by keeping `statsExerciseTitle` as `sr-only`.
- Reworked chart pointer logic in `ui-stats.js` to add `findClosestPoint`, `pointermove` handling and `pointerleave` clearing, to highlight the nearest point and move the vertical focus line continuously.
- Initialize the chart focus on the latest point and restore the summary subtitle when leaving the chart area.

### Testing
- Ran syntax checks with `node --check ui-stats.js`, `node --check ui-exercise-read.js` and `node --check init.js`, which all passed.
- Ran `git diff --check` to validate whitespace/patch issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9198bd9548332a3952c189ebdae9f)