### PR TITLE
Add "Edit exercise" button to execution view and hook to exercise actions dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,9 @@
 
         <section id="execEditTabExec" class="exercise-read-tab" data-tab-panel="exec" hidden>
             <div id="execReadExecContent" class="panel exercise-read-panel"></div>
+            <div class="add-actions">
+                <button id="execExerciseEdit" class="btn full" type="button" title="Éditer l'exercice" aria-label="Éditer l'exercice">Éditer l'exercice</button>
+            </div>
         </section>
 
         <section id="execEditTabHistory" class="exercise-read-tab" data-tab-panel="history" hidden>
@@ -145,6 +148,7 @@
         <section id="execEditTabStats" class="exercise-read-tab" data-tab-panel="stats" hidden>
             <div id="execReadStatsContent" class="exercise-read-panel"></div>
         </section>
+
     </main>
 
 </section>

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -64,6 +64,24 @@
         switchScreen('screenExerciseRead');
     };
 
+    A.openExerciseActionsDialog = async function openExerciseActionsDialog(options = {}) {
+        const { currentId, callerScreen = 'screenExercises' } = options;
+        if (!currentId) {
+            return;
+        }
+        ensureRefs();
+        assertRefs();
+        const exercise = await db.get('exercises', currentId);
+        if (!exercise) {
+            alert('Exercice introuvable.');
+            return;
+        }
+        state.currentId = currentId;
+        state.callerScreen = callerScreen;
+        state.exercise = exercise;
+        openExerciseActions();
+    };
+
     A.renderExerciseReadExecPanel = function renderExerciseReadExecPanel(options = {}) {
         const { exercise, container, originLabel } = options;
         renderExerciseExecPanel(exercise, { container, originLabel });

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -239,6 +239,7 @@
         refs.screenData = document.getElementById('screenData');
         refs.tabSessions = document.getElementById('tabSessions');
         refs.execBack = document.getElementById('execBack');
+        refs.execExerciseEdit = document.getElementById('execExerciseEdit');
         refs.execTitle = document.getElementById('execTitle');
         refs.execEditTabs = document.getElementById('execEditTabs');
         refs.execEditDateTab = document.getElementById('execEditDateTab');
@@ -352,6 +353,7 @@
     function wireActions() {
         const {
             execAddSet,
+            execExerciseEdit,
             execDelete,
             execReplaceExercise,
             execMetaToggle,
@@ -363,6 +365,9 @@
         } = assertRefs();
         execAddSet.addEventListener('click', () => {
             void addSet();
+        });
+        execExerciseEdit?.addEventListener('click', () => {
+            void openExerciseActionsDialog();
         });
         execDelete.addEventListener('click', () => {
             void removeExercise();
@@ -2476,6 +2481,26 @@
         }
         switchScreen(state.callerScreen || 'screenSessions');
         void refreshSessionViews();
+    }
+
+    async function openExerciseActionsDialog() {
+        if (!state.exerciseRefId) {
+            return;
+        }
+        if (typeof A.openExerciseActionsDialog === 'function') {
+            await A.openExerciseActionsDialog({
+                currentId: state.exerciseRefId,
+                callerScreen: 'screenExecEdit'
+            });
+            return;
+        }
+        if (typeof A.openExerciseEdit !== 'function') {
+            return;
+        }
+        await A.openExerciseEdit({
+            currentId: state.exerciseRefId,
+            callerScreen: 'screenExerciseRead'
+        });
     }
 
     function switchScreen(target) {


### PR DESCRIPTION
### Motivation
- Provide a direct way to open the exercise actions/edit UI from the execution (exec) read tab so users can quickly edit or inspect the exercise while viewing a session entry. 
- Reuse existing exercise actions/edit flows when available to keep behavior consistent across screens.

### Description
- Added an `#execExerciseEdit` button to the execution read panel in `index.html` with label "Éditer l'exercice" and appropriate accessibility attributes. 
- Exposed `A.openExerciseActionsDialog` in `ui-exercise-read.js` to load the exercise into `state` and open the shared exercise actions UI. 
- Wired the new button in `ui-session-execution-edit.js` by adding `refs.execExerciseEdit`, attaching a click listener to call `openExerciseActionsDialog`, and implementing a local `openExerciseActionsDialog` that delegates to `A.openExerciseActionsDialog` when available and falls back to `A.openExerciseEdit`. 
- Ensured references and navigation integrate with existing screen/caller handling and state (`state.exerciseRefId`, `callerScreen`).

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9174ed30883328a1854a3766cbccb)