### PR TITLE
Colonne contextuelle des séries : historique unique et navigation circulaire

### DIFF
--- a/style.css
+++ b/style.css
@@ -2219,8 +2219,8 @@ textarea:focus{
   grid-template-columns: minmax(2.1ch, 0.4fr) 1.2fr 1.2fr 1.4fr 1fr; /* # | Reps | Poids | RPE | Repos */
 }
 .exec-grid.routine-set-grid.routine-set-grid--with-meta{
-  --exec-meta-width: 70px;
-  grid-template-columns: minmax(2.1ch, 0.4fr) 1.2fr 1.2fr 1.4fr 1fr var(--exec-meta-width); /* # | Reps | Poids | RPE | Repos | Infos */
+  --exec-meta-width: 112px;
+  grid-template-columns: minmax(2.1ch, 0.4fr) 1.2fr 1.2fr 1fr 1fr var(--exec-meta-width); /* # | Reps | Poids | RPE | Repos | Infos */
 }
 .routine-set-grid > *{ min-width:0; }
 .exec-head{ font-weight: var(--fw-strong); }

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -14,6 +14,9 @@
         activeTab: 'session',
         showSessionTab: true,
         metaMode: 'history',
+        historyCursor: 0,
+        historyLabel: 'Historique',
+        historySessionCount: 0,
         pendingFocus: null,
         replaceCallerScreen: 'screenExecEdit'
     };
@@ -397,8 +400,12 @@
             void prefillExercisePendingSets();
         });
         execMetaToggle.addEventListener('click', () => {
-            const nextMode = getNextMetaMode();
-            setMetaMode(nextMode);
+            if (state.metaMode !== 'history') {
+                const nextMode = getNextMetaMode();
+                setMetaMode(nextMode);
+                return;
+            }
+            cycleHistorySession();
         });
     }
 
@@ -686,23 +693,14 @@
     }
 
     function getMetaModeLabel(mode = state.metaMode) {
-        switch (mode) {
-            case 'goals':
-                return 'Objectifs';
-            case 'medals':
-                return 'Médailles';
-            case 'record':
-                return 'Record';
-            default:
-                return 'Historique';
+        if (mode !== 'history') {
+            return 'Historique';
         }
+        return state.historyLabel || 'Historique';
     }
 
     function getNextMetaMode() {
-        const order = ['history', 'goals', 'medals', 'record'];
-        const currentIndex = order.indexOf(state.metaMode);
-        const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % order.length;
-        return order[nextIndex];
+        return 'history';
     }
 
     function setMetaMode(nextMode) {
@@ -719,6 +717,17 @@
         closeInlineInputs();
         clearMedalPopover();
         clearDetailsPopover();
+        void refreshSetMetaFrom(0);
+    }
+
+    function cycleHistorySession() {
+        if (state.historySessionCount <= 1) {
+            return;
+        }
+        state.historyCursor = (state.historyCursor + 1) % state.historySessionCount;
+        const { execMetaToggle } = assertRefs();
+        execMetaToggle.textContent = getMetaHeaderLabel();
+        execMetaToggle.setAttribute('aria-label', getMetaHeaderLabel());
         void refreshSetMetaFrom(0);
     }
 
@@ -772,6 +781,7 @@
             return;
         }
         const sets = Array.isArray(exercise.sets) ? exercise.sets : [];
+        state.historyCursor = 0;
         const meta = await buildSetMeta(exercise, sets);
         if (execMetaToggle) {
             execMetaToggle.textContent = getMetaHeaderLabel();
@@ -834,6 +844,13 @@
             return;
         }
         const meta = metaOverride || (await buildSetMeta(exercise, sets));
+        state.historyLabel = meta?.activeHistoryLabel || 'Historique';
+        state.historySessionCount = safeInt(meta?.historySessions?.length, 0);
+        const { execMetaToggle } = assertRefs();
+        if (execMetaToggle) {
+            execMetaToggle.textContent = getMetaHeaderLabel();
+            execMetaToggle.setAttribute('aria-label', getMetaHeaderLabel());
+        }
         const rows = Array.from(execSets.querySelectorAll('.exec-set-row'));
         rows.forEach((row, index) => {
             if (index < startIndex || !sets[index]) {
@@ -1413,8 +1430,13 @@
         const { dateKey = state.dateKey } = options;
         const exerciseId = exercise?.exercise_id;
         const weightUnit = exercise?.weight_unit === 'imperial' ? 'lb' : 'kg';
-        const previous = await findPreviousSessionForHistory(exerciseId, dateKey);
-        const previousSets = Array.isArray(previous?.exercise?.sets) ? [...previous.exercise.sets] : [];
+        const historySessions = await collectPreviousSessionsForHistory(exerciseId, dateKey, 6);
+        const sessionCount = historySessions.length;
+        if (state.historyCursor >= sessionCount) {
+            state.historyCursor = 0;
+        }
+        const activeHistory = historySessions[state.historyCursor] || null;
+        const previousSets = Array.isArray(activeHistory?.exercise?.sets) ? [...activeHistory.exercise.sets] : [];
         previousSets.sort((a, b) => safeInt(a?.pos, 0) - safeInt(b?.pos, 0));
         const historyByPos = buildHistorySetMap(previousSets, weightUnit);
         const goalsByPos = buildHistorySetMap(previousSets, weightUnit);
@@ -1422,7 +1444,19 @@
         const recordByPos = buildRecordSetMap(previousAllSets, weightUnit);
         const medalsByPos = await buildMedalMap(exerciseId, currentSets, dateKey, previousAllSets);
         const historyDetailsByPos = buildHistoryDetailsMap(previousAllSets, weightUnit);
-        return { historyByPos, goalsByPos, recordByPos, medalsByPos, historyDetailsByPos, weightUnit };
+        const activeHistoryLabel = activeHistory?.date ? formatDateKeyForMeta(activeHistory.date) : 'Historique';
+        state.historyLabel = activeHistoryLabel;
+        state.historySessionCount = sessionCount;
+        return {
+            historyByPos,
+            goalsByPos,
+            recordByPos,
+            medalsByPos,
+            historyDetailsByPos,
+            historySessions,
+            activeHistoryLabel,
+            weightUnit
+        };
     }
 
     function buildHistorySetMap(sets, weightUnit) {
@@ -1616,25 +1650,41 @@
         return String(normalized);
     }
 
-    async function findPreviousSessionForHistory(exerciseId, dateKey = state.dateKey) {
+    async function collectPreviousSessionsForHistory(exerciseId, dateKey = state.dateKey, limit = 6) {
         if (!exerciseId || !dateKey) {
-            return null;
+            return [];
         }
         const sessions = await db.listSessionDates();
         const previousDates = sessions
             .map((entry) => entry.date)
             .filter((date) => date && date < dateKey)
             .sort((a, b) => b.localeCompare(a));
+        const results = [];
         for (const date of previousDates) {
             const session = await db.getSession(date);
             const exercise = Array.isArray(session?.exercises)
                 ? session.exercises.find((item) => item.exercise_id === exerciseId)
                 : null;
             if (exercise && Array.isArray(exercise.sets) && exercise.sets.length) {
-                return { date, session, exercise };
+                results.push({ date, session, exercise });
+                if (results.length >= limit) {
+                    break;
+                }
             }
         }
-        return null;
+        return results;
+    }
+
+    function formatDateKeyForMeta(dateKey) {
+        if (!dateKey || typeof dateKey !== 'string') {
+            return 'Historique';
+        }
+        const [year, month, day] = dateKey.split('-').map((part) => Number(part));
+        const date = new Date(year, (month || 1) - 1, day || 1);
+        if (Number.isNaN(date.getTime())) {
+            return 'Historique';
+        }
+        return formatExecDateTab(date);
     }
 
     function formatOrmValue(value) {


### PR DESCRIPTION
### Motivation
- La colonne contextuelle des séries doit n’afficher que l’`Historique` (plus d’alternance Record/Objectifs/Médailles). 
- Par défaut elle montre la valeur de la série de même rang pour la séance précédente et permet de faire défiler les séances antérieures par clic sur le badge. 
- Le libellé du badge doit afficher la date de la séance historique affichée. 
- La colonne historique doit être plus large en prenant de la place sur la colonne RPE, et la largeur de la colonne `RPE` doit être égale à celle de `Repos`.

### Description
- Ajout d’un curseur d’historique et d’état : `historyCursor`, `historyLabel`, `historySessionCount` dans `ui-session-execution-edit.js` pour suivre la séance historique active. 
- Remplacement du comportement multi-mode par un mode `history` fixe et ajout de la fonction `cycleHistorySession()` déclenchée au clic sur `execMetaToggle` pour faire défiler circulairement les séances précédentes (limitées à 6). 
- Ajout de `collectPreviousSessionsForHistory(exerciseId, dateKey, limit = 6)` qui récupère jusqu’à 6 séances précédentes contenant l’exercice et formatage de la date via `formatDateKeyForMeta`. 
- `buildSetMeta` sélectionne désormais la séance historique active (`historyCursor`) et expose `historySessions` / `activeHistoryLabel` pour l’affichage ; `refreshSetMetaFrom` met à jour le label du badge et le nombre de séances disponibles. 
- Réinitialisation du `historyCursor` à l’ouverture/rafraîchissement des sets (`renderSets`). 
- Ajustement CSS dans `style.css` : `--exec-meta-width` augmenté et modification de la grille pour réduire la colonne `RPE` à `1fr` et ainsi aligner `RPE` et `Repos`, et agrandir la colonne historique.
- Fichiers modifiés : `ui-session-execution-edit.js`, `style.css`.

### Testing
- Exécution de vérification syntaxique JavaScript : `node --check ui-session-execution-edit.js`, `node --check components/set-editor.js`, `node --check ui-session.js` — toutes les vérifications sont passées avec succès. 
- Aucune capture UI automatique disponible dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91f6f0dcc8332a6434ddf0a3e0604)