### PR TITLE
Remove duplicated 'Éditer l'exercice' button from exercise sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,9 +149,6 @@
             <div id="execReadStatsContent" class="exercise-read-panel"></div>
         </section>
 
-        <div class="add-actions">
-            <button id="execExerciseEdit" class="btn full" type="button" title="Éditer l'exercice" aria-label="Éditer l'exercice">Éditer l'exercice</button>
-        </div>
     </main>
 
 </section>


### PR DESCRIPTION
### Motivation
- Le bouton d'édition `execExerciseEdit` était dupliqué dans la fiche exercice et s'affichait dans tous les onglets au lieu d'apparaître uniquement dans l'onglet «Exécution», ce qui casse l'ergonomie et les comportements contextuels.

### Description
- Suppression du bouton dupliqué en dehors des panneaux d'onglets dans `index.html`, en conservant uniquement le bouton présent dans la section `#execEditTabExec` pour préserver la fenêtre contextuelle (éditer, supprimer, convertir, etc.) et les gestionnaires existants.

### Testing
- Vérification automatique de la présence unique de l'identifiant avec `rg -n "id=\"execExerciseEdit\"" index.html` et inspection du diff pour confirmer la suppression réussie (une seule occurrence restante).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d922103b1c8332a093cc4b2a0a6ae1)