### PR TITLE
Restore stats goal button and open actions modal from execution edit

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -2534,7 +2534,17 @@
     }
 
     async function openExerciseDefinitionEdit() {
-        if (!state.exerciseRefId || typeof A.openExerciseEdit !== 'function') {
+        if (!state.exerciseRefId) {
+            return;
+        }
+        if (typeof A.openExerciseActionsDialog === 'function') {
+            await A.openExerciseActionsDialog({
+                currentId: state.exerciseRefId,
+                callerScreen: 'screenExecEdit'
+            });
+            return;
+        }
+        if (typeof A.openExerciseEdit !== 'function') {
             return;
         }
         await A.openExerciseEdit({

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -460,6 +460,13 @@
         appendClonedParent(container, statsMetricTags.closest('.stats-tags-group'));
         appendClonedParent(container, statsChart.closest('.stats-chart-card'));
         appendClonedParent(container, statsRangeTags.closest('.stats-tags-group'));
+        const goalButton = document.createElement('button');
+        goalButton.type = 'button';
+        goalButton.className = 'btn primary full';
+        goalButton.setAttribute('data-stats-goal', 'true');
+        goalButton.title = 'Objectif';
+        goalButton.textContent = 'Objectif';
+        container.appendChild(goalButton);
         appendClonedParent(container, statsTimeline.closest('section'));
 
         const embeddedTimelineTitle = container.querySelector('.stats-section-title');
@@ -487,6 +494,10 @@
                 }
                 const rangeButton = event.target.closest('[data-range]');
                 if (!rangeButton) {
+                    const goalButtonTarget = event.target.closest('[data-stats-goal]');
+                    if (goalButtonTarget) {
+                        openGoalDialog();
+                    }
                     return;
                 }
                 const nextRange = rangeButton.getAttribute('data-range');


### PR DESCRIPTION
### Motivation
- The exercise detail flow lost the inline `Objectif` button in embedded stats and the execution-screen edit action no longer opened the shared actions modal, breaking expected UX for goals and contextual edit actions.

### Description
- Reintroduced a Goal button in the embedded stats renderer by creating a `button` element (data attribute `data-stats-goal`) and inserting it before the history timeline in `renderEmbeddedStatsContent` (`ui-stats.js`).
- Wired embedded stats clicks to detect the new goal button and call `openGoalDialog()` when triggered (`ui-stats.js`).
- Updated the execution-screen edit action to prefer opening the shared exercise actions dialog via `A.openExerciseActionsDialog({ currentId, callerScreen })` and fall back to `A.openExerciseEdit` when the dialog API is not available (`ui-session-execution-edit.js`).
- Modified `ui-stats.js` and `ui-session-execution-edit.js` to implement the above behavior.

### Testing
- Ran static syntax checks: `node --check ui-stats.js && node --check ui-session-execution-edit.js`, both checks succeeded.
- No automated unit tests were present; changes were validated via the above static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92dd1583c8332b7215ffe2960c967)