### PR TITLE
Fix exercise stats: duplicated title, interactive embedded chart, and 1RM goal trend

### DIFF
--- a/ui-stats.js
+++ b/ui-stats.js
@@ -437,25 +437,11 @@
         if (exerciseId) {
             container.dataset.statsExerciseId = exerciseId;
         }
-        const {
-            statsMetricTags,
-            statsChart,
-            statsChartEmpty,
-            statsRangeTags,
-            statsTimeline,
-            statsExerciseTitle,
-            statsExerciseSubtitle,
-            statsTimelineTitle
-        } = assertStatsRefs();
+        const { statsMetricTags, statsChart, statsChartEmpty, statsRangeTags, statsTimeline, statsExerciseSubtitle, statsTimelineTitle } =
+            assertStatsRefs();
         container.innerHTML = '';
 
-        const heading = document.createElement('div');
-        heading.className = 'bloque';
-        heading.innerHTML = `
-            <div class="element">${escapeHtml(statsExerciseTitle.textContent || 'Exercice')}</div>
-            <div class="details">${escapeHtml(statsExerciseSubtitle.textContent || '')}</div>
-        `;
-        container.appendChild(heading);
+        appendClonedParent(container, statsExerciseSubtitle.closest('.stats-header'));
 
         appendClonedParent(container, statsMetricTags.closest('.stats-tags-group'));
         appendClonedParent(container, statsChart.closest('.stats-chart-card'));
@@ -479,6 +465,16 @@
             embeddedChartEmpty.textContent = statsChartEmpty.textContent || 'Aucune donnée enregistrée.';
             embeddedChartEmpty.hidden = statsChartEmpty.hidden;
         }
+        const embeddedChart = container.querySelector('.stats-chart');
+        const embeddedSubtitle = container.querySelector('.stats-subtitle');
+        if (embeddedSubtitle) {
+            embeddedSubtitle.textContent = statsExerciseSubtitle.textContent || '';
+        }
+        renderChart({
+            statsChart: embeddedChart || statsChart,
+            statsChartEmpty: embeddedChartEmpty || statsChartEmpty,
+            statsExerciseSubtitle: embeddedSubtitle || statsExerciseSubtitle
+        });
 
         if (!container.dataset.statsEmbeddedWired) {
             container.addEventListener('click', (event) => {
@@ -516,15 +512,6 @@
             return;
         }
         container.appendChild(element.cloneNode(true));
-    }
-
-    function escapeHtml(value) {
-        return String(value)
-            .replaceAll('&', '&amp;')
-            .replaceAll('<', '&lt;')
-            .replaceAll('>', '&gt;')
-            .replaceAll('"', '&quot;')
-            .replaceAll("'", '&#39;');
     }
 
     function wireGoalDialogEvents() {
@@ -910,8 +897,11 @@
         element.textContent = `${count} ${sessionLabel}`;
     }
 
-    function renderChart() {
-        const { statsChart, statsChartEmpty, statsExerciseSubtitle } = assertStatsRefs();
+    function renderChart(context = {}) {
+        const { statsChart, statsChartEmpty, statsExerciseSubtitle } = {
+            ...assertStatsRefs(),
+            ...context
+        };
         statsChart.innerHTML = '';
         statsChart.removeAttribute('aria-label');
         const exercise = state.activeExercise;
@@ -1215,10 +1205,11 @@
         }
         const startEntry = findGoalStartEntry(usage, startDate);
         const startValue = Number.isFinite(manualStartValue) ? manualStartValue : startEntry?.metrics?.orm;
-        if (!startEntry || !Number.isFinite(startValue) || startValue <= 0) {
+        const startPointDate = startEntry?.dateObj || startDate;
+        if (!Number.isFinite(startValue) || startValue <= 0) {
             return [];
         }
-        if (targetDate.getTime() <= startEntry.dateObj.getTime()) {
+        if (targetDate.getTime() <= startPointDate.getTime()) {
             return [];
         }
         const delta = targetValue - startValue;
@@ -1226,14 +1217,14 @@
         const upperTarget = startValue + delta * 1.02;
         return [
             {
-                startDate: startEntry.dateObj,
+                startDate: startPointDate,
                 startValue,
                 endDate: targetDate,
                 endValue: lowerTarget,
                 variant: 'min'
             },
             {
-                startDate: startEntry.dateObj,
+                startDate: startPointDate,
                 startValue,
                 endDate: targetDate,
                 endValue: upperTarget,


### PR DESCRIPTION
### Motivation
- Corriger la répétition du nom d’exercice dans la vue statistique embarquée qui dupliquait le header. 
- Restaurer l’interactivité du graphique (sélection du point, barre verticale, mise à jour de la valeur/date) lorsqu’il est affiché dans le conteneur embarqué. 
- Réafficher la courbe d’objectif pointillée pour les objectifs IRM (1RM) même lorsque la valeur de départ est fournie manuellement sans entrée de séance exactement à la date de départ.

### Description
- Modifie `renderChart` pour accepter un `context` optionnel et rendre le SVG directement dans le `statsChart` fourni afin de préserver les listeners pointer et permettre l’interaction en place (`renderChart(context = {})`).
- Remplace l’insertion d’un bloc titre dupliqué dans `renderEmbeddedStatsContent` par la réutilisation du bloc `stats-header` (sous-titre) via `appendClonedParent`, et synchronise le texte du sous-titre embarqué avant d’appeler `renderChart` sur le chart embarqué.
- Corrige `buildOrmGoalTrends` pour utiliser `startPointDate = startEntry?.dateObj || startDate` et ne plus exiger la présence d’un `startEntry` quand une `startValue` manuelle est fournie, en utilisant `startPointDate` comme point de départ des segments de tendance retournés.
- Supprime l’utilitaire `escapeHtml` devenu inutile dans ce chemin de rendu embarqué.

### Testing
- `node --check ui-stats.js` — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92fbdfb7883328d41ca72d1975e73)