### PR TITLE
Harmonize exercise sheet tab bar styling with planning/stat toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,11 +106,11 @@
     </header>
 
     <main class="content">
-        <div id="execEditTabs" class="tags exercise-read-tabs" role="tablist">
-            <button type="button" id="execEditDateTab" class="tag selected" data-tab="session" role="tab" aria-selected="true">—</button>
-            <button type="button" class="tag" data-tab="exec" role="tab" aria-selected="false">Exécution</button>
-            <button type="button" class="tag" data-tab="history" role="tab" aria-selected="false">Histo</button>
-            <button type="button" class="tag" data-tab="stats" role="tab" aria-selected="false">Stats</button>
+        <div id="execEditTabs" class="stats-toggle exercise-read-tabs" role="tablist">
+            <button type="button" id="execEditDateTab" class="stats-toggle-btn is-active" data-tab="session" role="tab" aria-selected="true">—</button>
+            <button type="button" class="stats-toggle-btn" data-tab="exec" role="tab" aria-selected="false">Exécution</button>
+            <button type="button" class="stats-toggle-btn" data-tab="history" role="tab" aria-selected="false">Histo</button>
+            <button type="button" class="stats-toggle-btn" data-tab="stats" role="tab" aria-selected="false">Stats</button>
         </div>
 
         <section id="execEditTabSession" class="exercise-read-tab" data-tab-panel="session">
@@ -369,10 +369,10 @@
 	<!-- Corps de l'écran Consulter un Exercice) -->
 	<main class="content">
 
-        <div id="exReadTabs" class="tags exercise-read-tabs" role="tablist">
-            <button type="button" class="tag selected" data-tab="exec" role="tab" aria-selected="true">Exécution</button>
-            <button type="button" class="tag" data-tab="history" role="tab" aria-selected="false">Historique</button>
-            <button type="button" class="tag" data-tab="stats" role="tab" aria-selected="false">Statistiques</button>
+        <div id="exReadTabs" class="stats-toggle exercise-read-tabs" role="tablist">
+            <button type="button" class="stats-toggle-btn is-active" data-tab="exec" role="tab" aria-selected="true">Exécution</button>
+            <button type="button" class="stats-toggle-btn" data-tab="history" role="tab" aria-selected="false">Historique</button>
+            <button type="button" class="stats-toggle-btn" data-tab="stats" role="tab" aria-selected="false">Statistiques</button>
         </div>
 
         <section id="exReadTabExec" class="exercise-read-tab" data-tab-panel="exec">

--- a/style.css
+++ b/style.css
@@ -934,6 +934,33 @@ textarea:focus{
     border-color: var(--selectedBord);
 }
 
+.stats-toggle{
+    display:flex;
+    gap:6px;
+    width:100%;
+}
+.stats-toggle-btn{
+    flex:1;
+    height:var(--control-h);
+    min-height:0;
+    padding:0 var(--pad-x);
+    border-radius:999px;
+    border:1px solid var(--clickableBord);
+    background:var(--clickableBack);
+    cursor:pointer;
+    touch-action:manipulation;
+    color:var(--black);
+    font-weight:var(--fw-strong);
+    font:inherit;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+}
+.stats-toggle-btn.is-active{
+    color:var(--emphase);
+    border-color:var(--emphase);
+}
+
 /* =========================================================
    7 bis) Planning (sous-onglets)
    ========================================================= */
@@ -1420,17 +1447,21 @@ textarea:focus{
    7 ter) Fiche exercice (onglets)
    ========================================================= */
 #execEditTabs{
-    --tag-columns: 4;
+    display:grid;
+    grid-template-columns:repeat(4, minmax(0, 1fr));
 }
 
 .exercise-read-tabs{
-    --tag-columns: 3;
     position: sticky;
     top: 0;
     z-index: 2;
     background: var(--contentBack);
     padding: 8px 0;
     border-bottom: 1px solid var(--panelBord);
+}
+#exReadTabs{
+    display:grid;
+    grid-template-columns:repeat(3, minmax(0, 1fr));
 }
 .exercise-read-panel{
     display:flex;

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -499,6 +499,7 @@
         exReadTabs.querySelectorAll('[data-tab]').forEach((button) => {
             const isActive = button.getAttribute('data-tab') === tab;
             button.classList.toggle('selected', isActive);
+            button.classList.toggle('is-active', isActive);
             button.setAttribute('aria-selected', isActive ? 'true' : 'false');
         });
         exReadTabExec.hidden = tab !== 'exec';

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -473,6 +473,7 @@
             }
             const isActive = button.getAttribute('data-tab') === tab;
             button.classList.toggle('selected', isActive);
+            button.classList.toggle('is-active', isActive);
             button.setAttribute('aria-selected', isActive ? 'true' : 'false');
         });
         execEditTabSession.hidden = tab !== 'session';


### PR DESCRIPTION
### Motivation
- Unifier le rendu des barres d’onglets de la fiche exercice avec les toggles existants des sections Planning (« Plans / Routines ») et Statistiques (« Volume / Performance ») pour une cohérence visuelle.
- Réutiliser le même style et le même comportement visuel actif afin d’éviter des styles divergents entre écrans proches fonctionnellement.

### Description
- Remplacé les classes `tag` par `stats-toggle` / `stats-toggle-btn` dans le markup des onglets d’édition/exécution et de lecture de la fiche exercice (`index.html`).
- Ajouté des styles réutilisables `.stats-toggle` et `.stats-toggle-btn` (layout, bordures arrondies, état actif `.is-active`) dans `style.css` pour reproduire le rendu des toggles existants.
- Ajusté la mise en page des conteneurs d’onglets en grille (`#execEditTabs` en 4 colonnes et `#exReadTabs` en 3 colonnes) dans `style.css` pour conserver des largeurs homogènes.
- Mis à jour la logique JS pour maintenir la classe d’état visuel en parallèle à l’état existant en toggleant `.is-active` en plus de `.selected` dans `ui-exercise-read.js` et `ui-session-execution-edit.js`.

### Testing
- Executed `node --check ui-exercise-read.js` and the check passed.
- Executed `node --check ui-session-execution-edit.js` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d931a4017883328d742d65eae3e330)