### PR TITLE
Fix set editor highlight styling and rest-time editing interactions

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -888,12 +888,10 @@
                 const minuteSide = hasSelection ? selectionStart <= colonIndex : cursor <= colonIndex;
 
                 if (key === ':') {
-                    if (minuteSide) {
-                        active.onChange?.(
-                            `${normalized.minutes}:${String(normalized.seconds).padStart(2, '0')}`,
-                            { caretPosition: String(normalized.minutes).length + 1 }
-                        );
-                    }
+                    const minutesText = String(normalized.minutes);
+                    const secondsText = String(normalized.seconds).padStart(2, '0');
+                    const caretPosition = minuteSide ? minutesText.length + 1 : minutesText.length;
+                    active.onChange?.(`${minutesText}:${secondsText}`, { caretPosition });
                     return;
                 }
 

--- a/style.css
+++ b/style.css
@@ -2570,6 +2570,18 @@ textarea:focus{
   outline-offset: 0;
 }
 
+.set-editor-highlight .set-edit-input,
+.set-editor-highlight .set-edit-button,
+.set-editor-highlight .routine-set-order,
+.set-editor-highlight .exec-meta-chip{
+  color: var(--emphase);
+}
+
+.set-editor-highlight .set-edit-input,
+.set-editor-highlight .set-edit-button{
+  border-color: var(--emphase);
+}
+
 .inline-set-editor-row{
   margin-top: 4px;
 }

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -572,10 +572,10 @@
                 onChange: (next, meta = {}) => {
                     input.value = next;
                     if (field === 'rest' && typeof meta?.caretPosition === 'number') {
-                        const colonIndex = String(next).indexOf(':');
-                        const onMinutes = colonIndex < 0 || meta.caretPosition <= colonIndex;
+                        const caretPosition = Math.max(0, Math.min(String(next).length, meta.caretPosition));
                         requestAnimationFrame(() => {
-                            selectInput(input, 'rest', { restPart: onMinutes ? 'minutes' : 'seconds' });
+                            input.focus({ preventScroll: true });
+                            input.setSelectionRange(caretPosition, caretPosition);
                         });
                     } else if (typeof meta?.caretPosition === 'number') {
                         const position = Math.max(0, Math.min(String(next).length, meta.caretPosition));

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1306,10 +1306,10 @@
                 onChange: (next, meta = {}) => {
                     input.value = next;
                     if (field === 'rest' && typeof meta?.caretPosition === 'number') {
-                        const colonIndex = String(next).indexOf(':');
-                        const onMinutes = colonIndex < 0 || meta.caretPosition <= colonIndex;
+                        const caretPosition = Math.max(0, Math.min(String(next).length, meta.caretPosition));
                         requestAnimationFrame(() => {
-                            selectInput(input, 'rest', { restPart: onMinutes ? 'minutes' : 'seconds' });
+                            input.focus({ preventScroll: true });
+                            input.setSelectionRange(caretPosition, caretPosition);
                         });
                     } else if (typeof meta?.caretPosition === 'number') {
                         const position = Math.max(0, Math.min(String(next).length, meta.caretPosition));


### PR DESCRIPTION
### Motivation
- Harmoniser le style de sélection des lignes de série avec le style « emphase » utilisé ailleurs (texte + bordure emphase). 
- Corriger le comportement de saisie du champ « temps de repos » pour permettre la saisie de plusieurs chiffres en minute et pour que la touche `:` bascule correctement entre minutes et secondes dans les deux sens.

### Description
- Ajuste le rendu CSS de la sélection en édition en appliquant `var(--emphase)` aux éléments internes (`.set-edit-input`, `.set-edit-button`, `.routine-set-order`, `.exec-meta-chip`) et en changeant leur `border-color` dans `style.css`.
- Modifie la gestion de la touche `:` dans `components/set-editor.js` pour construire correctement la chaîne `mm:ss` et fournir une `caretPosition` adaptée selon que l’on bascule vers les minutes ou les secondes.
- Remplace la sélection complète de la partie minutes par un positionnement précis du caret dans `ui-session-execution-edit.js` et `ui-routine-execution-edit.js` en utilisant `input.focus({ preventScroll: true })` + `input.setSelectionRange(...)` pour permettre l’accumulation de plusieurs chiffres.
- Conserve les autres comportements (RPE, weight, etc.) inchangés et réutilise le méta `caretPosition` transmis par le clavier inline.

### Testing
- Exécuté `node --check components/set-editor.js` — a réussi.
- Exécuté `node --check ui-session-execution-edit.js` — a réussi.
- Exécuté `node --check ui-routine-execution-edit.js` — a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9358449808332807ec9762b08d9dd)