### PR TITLE
Afficher le RPE dans les résumés historiques de séries

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1709,15 +1709,20 @@
         return `= ${left} / ${right}`;
     }
 
-    function formatMetaSetLine(set, weightUnit) {
+    function formatMetaSetLine(set, weightUnit, options = {}) {
+        const { includeRpe = false } = options;
         const reps = Number.isFinite(set?.reps) ? set.reps : null;
         const weight = set?.weight != null ? Number(set.weight) : null;
+        const rpe = set?.rpe != null && set?.rpe !== '' ? Number(set.rpe) : null;
         const parts = [];
         if (reps != null) {
             parts.push(`${reps}x`);
         }
         if (weight != null && !Number.isNaN(weight)) {
             parts.push(`${formatNumber(weight)}${weightUnit}`);
+        }
+        if (includeRpe && rpe != null && !Number.isNaN(rpe)) {
+            parts.push(`@${formatNumber(rpe)}`);
         }
         return parts.length ? parts.join(' ') : '—';
     }
@@ -1749,7 +1754,7 @@
     }
 
     function formatHistorySetLine(set, weightUnit) {
-        return formatMetaSetLine(set, weightUnit);
+        return formatMetaSetLine(set, weightUnit, { includeRpe: true });
     }
 
     function formatHistoryDateLabel(dateKey) {


### PR DESCRIPTION
### Motivation
- Les chips historiques affichant une série compacte doivent aussi montrer le RPE (par ex. `12x 30kg @8.5`) pour retrouver rapidement l'effort perçu sur les séries passées.

### Description
- Le formateur compact `formatMetaSetLine` a été étendu avec un paramètre `options` et une option `includeRpe` pour inclure le RPE quand demandé.
- `formatMetaSetLine` extrait désormais la valeur `rpe` et ajoute `@<rpe>` au rendu si `includeRpe` est vrai.
- La fonction `formatHistorySetLine` appelle maintenant `formatMetaSetLine(..., { includeRpe: true })` afin d'afficher le RPE dans l'historique compact (fichier modifié : `ui-session-execution-edit.js`).

### Testing
- Le fichier modifié a été vérifié en syntaxe avec `node --check ui-session-execution-edit.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4d6688508332b49f5b5315f06176)