### PR TITLE
Simplify set input selection to native behavior in session and routine editors

### DIFF
--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -569,20 +569,8 @@
                     }
                 },
                 getValue: () => input.value,
-                onChange: (next, meta = {}) => {
+                onChange: (next) => {
                     input.value = next;
-                    if (field === 'rest' && typeof meta?.caretPosition === 'number') {
-                        const caretPosition = Math.max(0, Math.min(String(next).length, meta.caretPosition));
-                        requestAnimationFrame(() => {
-                            input.focus({ preventScroll: true });
-                            input.setSelectionRange(caretPosition, caretPosition);
-                        });
-                    } else if (typeof meta?.caretPosition === 'number') {
-                        const position = Math.max(0, Math.min(String(next).length, meta.caretPosition));
-                        requestAnimationFrame(() => {
-                            input.setSelectionRange(position, position);
-                        });
-                    }
                     if (field === 'rpe') {
                         applyRpeTone(input, next);
                     }
@@ -595,32 +583,6 @@
                     input.blur();
                     ensureInlineEditor()?.close();
                 }
-            });
-        };
-
-        const selectInput = (input, field, options = {}) => {
-            if (!input) {
-                return;
-            }
-            requestAnimationFrame(() => {
-                input.focus({ preventScroll: true });
-                if (field !== 'rest') {
-                    input.select();
-                    return;
-                }
-                const restPart = options.restPart === 'seconds' ? 'seconds' : 'minutes';
-                const valueText = String(input.value ?? '');
-                const colonIndex = valueText.indexOf(':');
-                if (colonIndex < 0) {
-                    input.select();
-                    return;
-                }
-                if (restPart === 'seconds') {
-                    const start = colonIndex + 1;
-                    input.setSelectionRange(start, valueText.length);
-                    return;
-                }
-                input.setSelectionRange(0, colonIndex);
             });
         };
 
@@ -640,9 +602,6 @@
             };
             input._update = update;
             update();
-            input.addEventListener('focus', () => {
-                selectInput(input, field);
-            });
             const commit = () => {
                 if (field === 'rpe') {
                     applyRpeTone(input, input.value);
@@ -659,7 +618,6 @@
             input.addEventListener('click', () => {
                 openEditor(field);
                 attachInlineKeyboard(input, field);
-                selectInput(input, field, field === 'rest' ? { restPart: 'minutes' } : {});
             });
             return input;
         };
@@ -687,7 +645,7 @@
                 return;
             }
             attachInlineKeyboard(target, field);
-            selectInput(target, field, field === 'rest' ? { restPart: 'minutes' } : {});
+            target.focus({ preventScroll: true });
         };
 
         row.append(order, repsInput, weightInput, rpeInput, restInput);

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1303,20 +1303,8 @@
                     }
                 },
                 getValue: () => input.value,
-                onChange: (next, meta = {}) => {
+                onChange: (next) => {
                     input.value = next;
-                    if (field === 'rest' && typeof meta?.caretPosition === 'number') {
-                        const caretPosition = Math.max(0, Math.min(String(next).length, meta.caretPosition));
-                        requestAnimationFrame(() => {
-                            input.focus({ preventScroll: true });
-                            input.setSelectionRange(caretPosition, caretPosition);
-                        });
-                    } else if (typeof meta?.caretPosition === 'number') {
-                        const position = Math.max(0, Math.min(String(next).length, meta.caretPosition));
-                        requestAnimationFrame(() => {
-                            input.setSelectionRange(position, position);
-                        });
-                    }
                     if (field === 'rpe') {
                         applyRpeTone(input, next);
                     }
@@ -1329,32 +1317,6 @@
                     input.blur();
                     ensureInlineEditor()?.close();
                 }
-            });
-        };
-
-        const selectInput = (input, field, options = {}) => {
-            if (!input) {
-                return;
-            }
-            requestAnimationFrame(() => {
-                input.focus({ preventScroll: true });
-                if (field !== 'rest') {
-                    input.select();
-                    return;
-                }
-                const restPart = options.restPart === 'seconds' ? 'seconds' : 'minutes';
-                const valueText = String(input.value ?? '');
-                const colonIndex = valueText.indexOf(':');
-                if (colonIndex < 0) {
-                    input.select();
-                    return;
-                }
-                if (restPart === 'seconds') {
-                    const start = colonIndex + 1;
-                    input.setSelectionRange(start, valueText.length);
-                    return;
-                }
-                input.setSelectionRange(0, colonIndex);
             });
         };
 
@@ -1374,9 +1336,6 @@
             };
             input._update = update;
             update();
-            input.addEventListener('focus', () => {
-                selectInput(input, field);
-            });
             const commit = () => {
                 if (field === 'rpe') {
                     applyRpeTone(input, input.value);
@@ -1393,7 +1352,6 @@
             input.addEventListener('click', () => {
                 openEditor(field);
                 attachInlineKeyboard(input, field);
-                selectInput(input, field, field === 'rest' ? { restPart: 'minutes' } : {});
             });
             return input;
         };
@@ -1421,7 +1379,7 @@
                 return;
             }
             attachInlineKeyboard(target, field);
-            selectInput(target, field, field === 'rest' ? { restPart: 'minutes' } : {});
+            target.focus({ preventScroll: true });
         };
 
         const metaCell = buildMetaCell(set, index, meta);


### PR DESCRIPTION
### Motivation
- The custom caret/selection logic for series inputs made editing too specific and confusing, so inputs should behave like normal browser text fields. 
- The change restores default focus/selection semantics while preserving the inline keyboard features already in place.

### Description
- Removed the `selectInput` helper and all explicit `select()` / `setSelectionRange()` calls used to force caret placement in set row inputs. 
- Removed caret-position handling from inline keyboard `onChange` handlers and simplified the signature to `onChange: (next) => { ... }`.
- Replaced explicit selection calls with a simple `target.focus({ preventScroll: true })` where a programmatic focus is needed. 
- Modified `ui-session-execution-edit.js` and `ui-routine-execution-edit.js` to apply the above changes.

### Testing
- Ran `node --check ui-session-execution-edit.js` which succeeded. 
- Ran `node --check ui-routine-execution-edit.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4fc064388332a75b3211e0446f78)