### PR TITLE
Ajuste l’affichage RP/1RM dans les cartes d’exercices de séance

### DIFF
--- a/style.css
+++ b/style.css
@@ -1689,6 +1689,25 @@ textarea:focus{
   line-height: 1.35;
   color: var(--muted);
   margin: -2px 0 4px;
+  width:100%;
+  display:grid;
+  grid-template-columns:
+    minmax(0, 0.4fr)
+    minmax(0, 1.0fr)
+    minmax(0, 1.0fr)
+    minmax(0, 0.7fr);
+  column-gap:6px;
+  align-items:center;
+}
+.exercise-card-stats-cell{
+  min-width:0;
+  text-align:center;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+.exercise-card-stats-cell--spacer{
+  visibility:hidden;
 }
 .exercise-card--full-sets .exercise-card-name{
   padding: 0;

--- a/ui-session.js
+++ b/ui-session.js
@@ -107,12 +107,12 @@
         return `@${formatSynopsisRpe(value)}`;
     }
 
-    function formatExerciseMetric(value, suffix = '') {
+    function formatExerciseMetricSingleDecimal(value, suffix = '') {
         const numeric = Number(value);
         if (!Number.isFinite(numeric)) {
             return '—';
         }
-        return `${formatSynopsisNumber(numeric)}${suffix}`;
+        return `${numeric.toFixed(1).replace('.', ',')}${suffix}`;
     }
 
     function computeExerciseStatsLine(sets) {
@@ -161,9 +161,34 @@
         };
     }
 
-    function formatExerciseStatsText(sets) {
+    function formatExerciseStatsValues(sets) {
         const stats = computeExerciseStatsLine(sets);
-        return `1RM ${formatExerciseMetric(stats.orm, 'kg')} · 1RMrpe ${formatExerciseMetric(stats.ormRpe, 'kg')} · RPE moyen ${formatExerciseMetric(stats.rpeAvg)}`;
+        return {
+            orm: formatExerciseMetricSingleDecimal(stats.orm, 'kg'),
+            ormRpe: formatExerciseMetricSingleDecimal(stats.ormRpe, 'kg'),
+            rpeAvg: formatExerciseMetricSingleDecimal(stats.rpeAvg)
+        };
+    }
+
+    function renderExerciseStatsLine(element, sets) {
+        if (!element) {
+            return;
+        }
+        const values = formatExerciseStatsValues(sets);
+        element.innerHTML = '';
+        const spacer = document.createElement('span');
+        spacer.className = 'exercise-card-stats-cell exercise-card-stats-cell--spacer';
+        spacer.setAttribute('aria-hidden', 'true');
+        const orm = document.createElement('span');
+        orm.className = 'exercise-card-stats-cell';
+        orm.textContent = values.orm;
+        const ormRpe = document.createElement('span');
+        ormRpe.className = 'exercise-card-stats-cell';
+        ormRpe.textContent = values.ormRpe;
+        const rpe = document.createElement('span');
+        rpe.className = 'exercise-card-stats-cell';
+        rpe.textContent = values.rpeAvg;
+        element.append(spacer, orm, ormRpe, rpe);
     }
 
     function normalizeFocusField(field) {
@@ -670,7 +695,7 @@
             titleRow.appendChild(name);
             const statsLine = document.createElement('div');
             statsLine.className = 'exercise-card-stats';
-            statsLine.textContent = formatExerciseStatsText(exercise.sets);
+            renderExerciseStatsLine(statsLine, exercise.sets);
             const detailsButton = document.createElement('button');
             detailsButton.type = 'button';
             detailsButton.className = 'exercise-card-menu-button';
@@ -806,7 +831,7 @@
             return false;
         }
         if (statsLine) {
-            statsLine.textContent = formatExerciseStatsText(exercise?.sets);
+            renderExerciseStatsLine(statsLine, exercise?.sets);
         }
         await renderSessionCardSets({ exercise, setsWrapper, dateKey });
         return true;


### PR DESCRIPTION
### Motivation
- Simplifier et réaligner la ligne de statistiques sous le titre des exercices pour qu’elle affiche uniquement les valeurs RP/1RM et s’aligne avec les colonnes de saisie des séries.
- Afficher les trois métriques avec une seule décimale et la virgule française pour une lecture cohérente sur mobile/desktop.
- Faire en sorte que le rendu soit recalculé lors du rafraîchissement d’une carte pour conserver l’alignement après édition ou ajout de séries.

### Description
- Ajout d’une fonction `formatExerciseMetricSingleDecimal` qui force l’affichage à une décimale (virgule) pour les métriques et remplacement de l’ancien formatage en ligne par cette sortie simplifiée dans `ui-session.js`.
- Remplacement du rendu texte `formatExerciseStatsText` par `formatExerciseStatsValues` + `renderExerciseStatsLine` et utilisation de `renderExerciseStatsLine` lors de la création et du rafraîchissement des cartes (appel depuis `renderSession` et `updateSessionExerciseCard`) dans `ui-session.js`.
- Ajout de règles CSS grid dans `style.css` pour `.exercise-card-stats` et de cellules `.exercise-card-stats-cell` afin d’aligner les trois valeurs (avec une cellule vide de décalage) sur les colonnes `index`, `reps`, `weight`, `rpe`.
- Modifications faites dans les fichiers `ui-session.js` et `style.css` pour implémenter le nouveau rendu et l’alignement.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check ui-session.js` qui a réussi.
- Vérification visuelle et comportementale non automatisée (rendu HTML/CSS) non incluse dans les tests automatiques fournis ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db512219c483329d30c82c51a4bc32)