### PR TITLE
Increase contextual menu action button height by ~25%

### DIFF
--- a/style.css
+++ b/style.css
@@ -470,8 +470,8 @@ header .header-left .btn{
     gap:6px;
 }
 .modal-context-action{
-    min-height: 36px;
-    padding: 6px 12px;
+    min-height: 45px;
+    padding: 8px 12px;
     border-radius: var(--radius);
     border: 0;
     background: transparent;


### PR DESCRIPTION
### Motivation
- Improve tap accuracy in contextual menus to reduce accidental selection of adjacent rows on touch devices by increasing the vertical hit area of actions.

### Description
- Updated `.modal-context-action` in `style.css` to increase `min-height` from `36px` to `45px` and adjust vertical `padding` from `6px` to `8px` for better visual balance.

### Testing
- No automated test suite applies to this UI-only CSS change; repository-level checks (`git status`, commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5383c08c833288d4033534c0211f)