### PR TITLE
Masquer la case médaille sur les cartes de séance et élargir l'historique

### DIFF
--- a/style.css
+++ b/style.css
@@ -1771,8 +1771,7 @@ textarea:focus{
     minmax(0, 1.0fr)
     minmax(0, 1.0fr)
     minmax(0, 0.7fr)
-    minmax(0, 1.0fr)
-    minmax(0, 0.5fr);
+    minmax(0, 1.8fr);
   column-gap:6px;
   row-gap:   2px;
   justify-content:center;

--- a/ui-session.js
+++ b/ui-session.js
@@ -769,7 +769,6 @@
                     text: goalInfo?.text ?? '—',
                     rpeValue: goalInfo?.rpe ?? null
                 });
-                const medalsCell = createSetMedalsCell(meta?.medalsByPos?.get?.(pos) || []);
                 line.append(
                     createSetCell({
                         label: formatSetIndex(pos),
@@ -795,8 +794,7 @@
                         rpeValue: set?.rpe,
                         onClick: stopAndOpen('rpe')
                     }),
-                    goalCell,
-                    medalsCell
+                    goalCell
                 );
                 setsWrapper.appendChild(line);
             });


### PR DESCRIPTION
### Motivation
- Ne pas afficher la case « médaille » dans les lignes de séries des cartes de l’écran Séance et redonner l’espace ainsi libéré à la colonne d’`Historique` pour améliorer la lisibilité.

### Description
- Retrait de l’ajout de la cellule médaille dans les lignes de séries de `session` en supprimant `medalsCell` dans `ui-session.js` (la ligne n’ajoute plus la cellule de médailles). 
- Ajustement de la grille d’affichage dans `style.css` en passant `.session-card-sets-row` de 6 à 5 colonnes et en élargissant la dernière colonne historique à `minmax(0, 1.8fr)` pour réutiliser l’espace libéré.

### Testing
- Exécution de la vérification automatique `git -C /workspace/A0 diff --check` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db53fcf8fc83329c3ab99955ca1e0a)