### PR TITLE
Align exercise card subtitle metrics with set columns and show history date

### DIFF
--- a/style.css
+++ b/style.css
@@ -1695,7 +1695,8 @@ textarea:focus{
     minmax(0, 0.4fr)
     minmax(0, 1.0fr)
     minmax(0, 1.0fr)
-    minmax(0, 0.7fr);
+    minmax(0, 0.7fr)
+    minmax(0, 1.8fr);
   column-gap:6px;
   align-items:center;
 }
@@ -1708,6 +1709,9 @@ textarea:focus{
 }
 .exercise-card-stats-cell--spacer{
   visibility:hidden;
+}
+.exercise-card-stats-cell--history{
+  text-align:left;
 }
 .exercise-card--full-sets .exercise-card-name{
   padding: 0;

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1415,6 +1415,7 @@
             medalsByPos,
             historyDetailsByPos,
             historySessions,
+            activeHistorySets: previousSets,
             activeHistoryLabel,
             weightUnit
         };

--- a/ui-session.js
+++ b/ui-session.js
@@ -170,7 +170,7 @@
         };
     }
 
-    function renderExerciseStatsLine(element, sets) {
+    function renderExerciseStatsLine(element, sets, historyLabel = 'Historique') {
         if (!element) {
             return;
         }
@@ -187,8 +187,11 @@
         ormRpe.textContent = values.ormRpe;
         const rpe = document.createElement('span');
         rpe.className = 'exercise-card-stats-cell';
-        rpe.textContent = values.rpeAvg;
-        element.append(spacer, orm, ormRpe, rpe);
+        rpe.textContent = `@${values.rpeAvg}`;
+        const history = document.createElement('span');
+        history.className = 'exercise-card-stats-cell exercise-card-stats-cell--history';
+        history.textContent = historyLabel || 'Historique';
+        element.append(spacer, orm, ormRpe, rpe, history);
     }
 
     function normalizeFocusField(field) {
@@ -693,9 +696,16 @@
             const titleRow = document.createElement('div');
             titleRow.className = 'exercise-card-title-row';
             titleRow.appendChild(name);
+            const sets = Array.isArray(exercise.sets) ? [...exercise.sets] : [];
+            sets.sort((a, b) => (a?.pos ?? 0) - (b?.pos ?? 0));
+            const meta =
+                typeof A.buildSessionExerciseMeta === 'function'
+                    ? await A.buildSessionExerciseMeta(exercise, sets, { dateKey: key })
+                    : { goalsByPos: new Map(), activeHistoryLabel: 'Historique', activeHistorySets: [] };
+            const statsSourceSets = Array.isArray(meta?.activeHistorySets) ? meta.activeHistorySets : [];
             const statsLine = document.createElement('div');
             statsLine.className = 'exercise-card-stats';
-            renderExerciseStatsLine(statsLine, exercise.sets);
+            renderExerciseStatsLine(statsLine, statsSourceSets, meta?.activeHistoryLabel);
             const detailsButton = document.createElement('button');
             detailsButton.type = 'button';
             detailsButton.className = 'exercise-card-menu-button';
@@ -714,7 +724,7 @@
             end.appendChild(detailsButton);
             const setsWrapper = document.createElement('div');
             setsWrapper.className = 'session-card-sets';
-            await renderSessionCardSets({ exercise, setsWrapper, dateKey: key });
+            await renderSessionCardSets({ exercise, setsWrapper, dateKey: key, meta });
             body.append(titleRow, statsLine, setsWrapper);
 
             card.setAttribute('aria-label', exerciseName);
@@ -725,7 +735,7 @@
         restoreSessionScroll();
     };
 
-    async function renderSessionCardSets({ exercise, setsWrapper, dateKey }) {
+    async function renderSessionCardSets({ exercise, setsWrapper, dateKey, meta: providedMeta = null }) {
         if (!exercise || !setsWrapper) {
             return;
         }
@@ -734,9 +744,10 @@
         const sets = Array.isArray(exercise.sets) ? [...exercise.sets] : [];
         sets.sort((a, b) => (a?.pos ?? 0) - (b?.pos ?? 0));
         const meta =
-            typeof A.buildSessionExerciseMeta === 'function'
+            providedMeta
+            || (typeof A.buildSessionExerciseMeta === 'function'
                 ? await A.buildSessionExerciseMeta(exercise, sets, { dateKey })
-                : { goalsByPos: new Map(), medalsByPos: new Map() };
+                : { goalsByPos: new Map(), medalsByPos: new Map(), activeHistorySets: [], activeHistoryLabel: 'Historique' });
         if (sets.length) {
             sets.forEach((set, index) => {
                 const line = document.createElement('div');
@@ -828,10 +839,17 @@
         if (!setsWrapper) {
             return false;
         }
+        const sets = Array.isArray(exercise?.sets) ? [...exercise.sets] : [];
+        sets.sort((a, b) => (a?.pos ?? 0) - (b?.pos ?? 0));
+        const meta =
+            typeof A.buildSessionExerciseMeta === 'function'
+                ? await A.buildSessionExerciseMeta(exercise, sets, { dateKey })
+                : { goalsByPos: new Map(), medalsByPos: new Map(), activeHistorySets: [], activeHistoryLabel: 'Historique' };
         if (statsLine) {
-            renderExerciseStatsLine(statsLine, exercise?.sets);
+            const statsSourceSets = Array.isArray(meta?.activeHistorySets) ? meta.activeHistorySets : [];
+            renderExerciseStatsLine(statsLine, statsSourceSets, meta?.activeHistoryLabel);
         }
-        await renderSessionCardSets({ exercise, setsWrapper, dateKey });
+        await renderSessionCardSets({ exercise, setsWrapper, dateKey, meta });
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Aligner le sous‑titre des cartes d’exercices sur la grille des colonnes de séries pour que chaque métrique apparaisse au‑dessus de la colonne correspondante (reps / poids / RPE) et afficher la date d’historique source utilisée.

### Description
- Ajout de `activeHistorySets` dans le meta renvoyé par `buildSetMeta` pour exposer les séries d’historique actives utilisées comme source des métriques du sous‑titre (`ui-session-execution-edit.js`).
- Calcul et rendu des métriques du sous‑titre à partir des séries d’historique actives, formatage du RPE avec le préfixe `@` et ajout d’une cellule finale affichant la date d’historique (`ui-session.js`).
- Passage de l’objet `meta` pré‑calculé aux fonctions de rendu de la carte pour réutiliser la même source (cohérence entre colonne historique et sous‑titre) (`ui-session.js`).
- Ajustement du CSS de la grille des sous‑titres pour ajouter une colonne d’historique et style pour l’étiquette de date (`style.css`).

### Testing
- Vérification de la syntaxe JavaScript avec `node --check ui-session.js` qui a réussi.
- Vérification de la syntaxe JavaScript avec `node --check ui-session-execution-edit.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc795f7c4833281912bdde5a69ef8)