### PR TITLE
Ajuste l’écran de saisie des séries (onglets + hauteur des cellules)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1455,9 +1455,15 @@ textarea:focus{
     position: sticky;
     top: 0;
     z-index: 2;
-    background: var(--contentBack);
-    padding: 8px 0;
+    background: #fff;
+    padding: 0 0 8px;
     border-bottom: 1px solid var(--panelBord);
+}
+#screenExecEdit .exercise-read-tabs{
+    margin-top: 0;
+}
+#screenExecEdit .content{
+    padding-top: calc(var(--header-total-h) - 2px);
 }
 #exReadTabs{
     display:grid;
@@ -2286,7 +2292,7 @@ textarea:focus{
   font-weight: var(--fw-strong);
 }
 .exec-row .input{
-  height: var(--control-h); width:100%;
+  height: calc(var(--control-h) * 0.95); width:100%;
   text-align:center; margin:0; padding:0;
 }
 .exec-row{
@@ -2340,7 +2346,7 @@ textarea:focus{
   align-items: stretch;
   justify-content: center;
   gap: 6px;
-  min-height: var(--control-h);
+  min-height: calc(var(--control-h) * 0.95);
   text-align: center;
 }
 


### PR DESCRIPTION
### Motivation
- Éviter que le contenu de la page défile sous la barre d’onglets et crée un effet visuel déroutant en lecture.
- Supprimer l’espace vertical inutile entre le `header` et les onglets sur l’écran d’édition des séries pour gagner de la place.
- Réduire légèrement la hauteur des cellules de saisie pour compacter l’affichage sans impacter l’ergonomie.

### Description
- Mise à jour du fichier `style.css` pour forcer un fond blanc de la barre d’onglets via `.exercise-read-tabs { background: #fff; padding: 0 0 8px; }`.
- Collage visuel des onglets au header sur l’écran ciblé avec `#screenExecEdit .exercise-read-tabs { margin-top: 0; }` et ajustement du padding du contenu via `#screenExecEdit .content { padding-top: calc(var(--header-total-h) - 2px); }`.
- Réduction de ~5% de la hauteur des champs d’entrée avec `.exec-row .input { height: calc(var(--control-h) * 0.95); }` et du bloc méta avec `.exec-meta-cell { min-height: calc(var(--control-h) * 0.95); }`.
- Changements limités au style de l’écran `screenExecEdit` et réalisés uniquement dans `style.css`.

### Testing
- Vérification de la syntaxe du diff avec `git diff --check` exécutée et passée avec succès.
- Ajout et commit du changement avec `git add style.css` et `git commit -m "Ajuste l'espacement des onglets et réduit la hauteur des cellules"` effectués avec succès.
- Aucune capture d’écran automatisée n’a été produite dans cet environnement, les validations restantes sont visuelles en application.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dced1c1c9c83329f340f306b9fc6d4)