### PR TITLE
Ajuste le libellé du bouton de fermeture du clavier custom

### DIFF
--- a/style.css
+++ b/style.css
@@ -2709,6 +2709,12 @@ body.inline-keyboard-visible .keyboard-spacer{
   color: var(--black);
 }
 
+
+.inline-keyboard-action--close{
+  white-space: pre-line;
+  line-height: 1.1;
+}
+
 .inline-keyboard-action--span-2{
   grid-row: span 2;
 }

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -451,7 +451,8 @@
                     }
                 },
                 {
-                    label: 'fermer clavier ⬇️'
+                    label: 'fermer\n▼',
+                    className: 'inline-keyboard-action--close'
                 }
             ];
         };

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1179,7 +1179,8 @@
                     }
                 },
                 {
-                    label: 'fermer clavier ⬇️'
+                    label: 'fermer\n▼',
+                    className: 'inline-keyboard-action--close'
                 }
             ];
         };


### PR DESCRIPTION
### Motivation
- Rendre le bouton de fermeture du clavier plus compact et lisible en affichant `fermer` sur la première ligne et la flèche `▼` sur la ligne du dessous.

### Description
- Remplace le label `fermer clavier ⬇️` par `fermer\n▼` dans `ui-routine-execution-edit.js` et `ui-session-execution-edit.js`, et ajoute la classe CSS `.inline-keyboard-action--close` dans `style.css` avec `white-space: pre-line` et `line-height: 1.1` pour gérer le saut de ligne.

### Testing
- Exécuté `git diff --check` et `git status --short`, et la modification a été commitée avec succès (pas de vérifications unitaires automatisées supplémentaires dans cet environnement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf1557a9483328f2565b3d9df4154)