### PR TITLE
Fix month arrows in 1RM goal date picker calendar

### DIFF
--- a/ui-month-calendar.js
+++ b/ui-month-calendar.js
@@ -47,6 +47,7 @@
         if (!pickerMonth || options.resetMonth) {
             pickerMonth = options.baseDate || new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1);
         }
+        delete pickerOptions.resetMonth;
         calendarContext = {
             mode: 'picker',
             baseMonth: new Date(pickerMonth.getFullYear(), pickerMonth.getMonth(), 1),
@@ -63,7 +64,7 @@
             },
             onMonthChange: async (nextMonth) => {
                 pickerMonth = nextMonth;
-                await A.openCalendarPicker(pickerOptions || {});
+                await A.openCalendarPicker({ ...(pickerOptions || {}), resetMonth: false });
             }
         });
     };
@@ -76,7 +77,7 @@
         const nextMonth = new Date(context.baseMonth.getFullYear(), context.baseMonth.getMonth() - 1, 1);
         if (context.mode === 'picker') {
             pickerMonth = nextMonth;
-            await A.openCalendarPicker(pickerOptions || {});
+            await A.openCalendarPicker({ ...(pickerOptions || {}), resetMonth: false });
             return;
         }
         A.calendarMonth = nextMonth;
@@ -91,7 +92,7 @@
         const nextMonth = new Date(context.baseMonth.getFullYear(), context.baseMonth.getMonth() + 1, 1);
         if (context.mode === 'picker') {
             pickerMonth = nextMonth;
-            await A.openCalendarPicker(pickerOptions || {});
+            await A.openCalendarPicker({ ...(pickerOptions || {}), resetMonth: false });
             return;
         }
         A.calendarMonth = nextMonth;


### PR DESCRIPTION
### Motivation
- The 1RM goal date picker month navigation arrows and swipe were effectively resetting to the initially selected month, making left/right navigation appear non-functional when choosing start/target dates.

### Description
- Updated `ui-month-calendar.js` to stop carrying the initial `resetMonth` behavior into subsequent picker opens by deleting `resetMonth` from the stored `pickerOptions` and by calling `A.openCalendarPicker({ ...(pickerOptions || {}), resetMonth: false })` from the picker's `onMonthChange` and the global prev/next handlers so the picker preserves the current month while navigating.

### Testing
- Ran a JavaScript syntax check with `node --check ui-month-calendar.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf2f1e1d083328d32db5f32a666b5)