### PR TITLE
Corrige la fermeture et la validation des objectifs de la fenêtre Statistique

### DIFF
--- a/style.css
+++ b/style.css
@@ -3061,6 +3061,10 @@ input[type="number"]{ -moz-appearance:textfield; }
     gap: 8px;
 }
 
+.stats-goal-orm-row + .stats-goal-orm-row {
+    margin-top: 6px;
+}
+
 .stats-goal-orm-label {
     width: 56px;
     margin: 0;

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -535,6 +535,10 @@
                 dlgStatsGoal.close();
             });
         }
+        dlgStatsGoal.addEventListener('close', () => {
+            fillGoalDialog(state.activeExercise);
+            renderExerciseDetail();
+        });
         if (statsGoalSave) {
             statsGoalSave.addEventListener('click', () => {
                 void saveGoalDialog();
@@ -557,8 +561,6 @@
             statsGoalOrmStartValue.addEventListener('input', () => {
                 if (!statsGoalOrmStartValue.value) {
                     delete statsGoalOrmStartValue.dataset.userEdited;
-                    const startDate = getGoalDateInput(refs.statsGoalOrmStart);
-                    updateGoalStartValueFromDate(startDate, { force: true });
                     return;
                 }
                 statsGoalOrmStartValue.dataset.userEdited = 'true';
@@ -726,16 +728,23 @@
         const ormTargetDate = getGoalDateInput(statsGoalOrmTargetDate);
         const ormStartValue = toGoalNumber(statsGoalOrmStartValue?.value);
         const ormTargetValue = toGoalNumber(statsGoalOrmTargetValue?.value);
+        const hasCompleteOrmGoal =
+            ormStart instanceof Date &&
+            ormTargetDate instanceof Date &&
+            Number.isFinite(ormStartValue) &&
+            Number.isFinite(ormTargetValue);
         return {
             setsWeek: buildGoalRange(statsGoalSetsMin?.value, statsGoalSetsMax?.value),
             volume: buildGoalRange(statsGoalVolumeMin?.value, statsGoalVolumeMax?.value),
             reps: buildGoalRange(statsGoalRepsMin?.value, statsGoalRepsMax?.value),
-            orm: {
-                startDate: ormStart && typeof A.ymd === 'function' ? A.ymd(ormStart) : null,
-                targetDate: ormTargetDate && typeof A.ymd === 'function' ? A.ymd(ormTargetDate) : null,
-                startValue: Number.isFinite(ormStartValue) ? ormStartValue : null,
-                targetValue: Number.isFinite(ormTargetValue) ? ormTargetValue : null
-            }
+            orm: hasCompleteOrmGoal
+                ? {
+                      startDate: typeof A.ymd === 'function' ? A.ymd(ormStart) : null,
+                      targetDate: typeof A.ymd === 'function' ? A.ymd(ormTargetDate) : null,
+                      startValue: ormStartValue,
+                      targetValue: ormTargetValue
+                  }
+                : null
         };
     }
 
@@ -1241,15 +1250,17 @@
         if (!(startDate instanceof Date) || !(targetDate instanceof Date) || !Number.isFinite(targetValue)) {
             return null;
         }
-        const startEntry = findGoalStartEntry(usage, startDate);
-        const startValue = Number.isFinite(manualStartValue) ? manualStartValue : startEntry?.metrics?.orm;
-        const startPointDate = startEntry?.dateObj || startDate;
-        if (!Number.isFinite(startValue) || startValue <= 0 || targetDate.getTime() <= startPointDate.getTime()) {
+        const startPointDate = startDate;
+        if (
+            !Number.isFinite(manualStartValue) ||
+            manualStartValue <= 0 ||
+            targetDate.getTime() <= startPointDate.getTime()
+        ) {
             return null;
         }
         return {
             startDate: startPointDate,
-            startValue,
+            startValue: manualStartValue,
             endDate: targetDate,
             endValue: targetValue
         };


### PR DESCRIPTION
### Motivation
- Empêcher la fermeture de la modale Objectif d’appliquer des changements non sauvegardés et garantir que la courbe d’objectif (pointillée) reflète l’état réel après fermeture.
- Améliorer l’ergonomie du formulaire 1RM pour permettre d’effacer complètement les champs Kg et éviter le tracé d’un objectif incomplet.
- Ajouter un léger espacement entre les lignes « Départ » et « Cible » pour une meilleure lisibilité.

### Description
- Ajoute un écouteur `close` sur le `dlgStatsGoal` qui restaure les valeurs d’origine via `fillGoalDialog(state.activeExercise)` et force le rafraîchissement du rendu avec `renderExerciseDetail()` (file: `ui-stats.js`).
- Empêche l’auto-fallback de la valeur de départ 1RM lors de la vidange du champ en supprimant l’appel d’update automatique quand l’utilisateur efface le champ (file: `ui-stats.js`).
- Modifie `buildGoalDataFromInputs()` pour ne créer la propriété `orm` que si l’objectif 1RM est complet (dates + valeurs `startValue` et `targetValue`), sinon `orm` est sauvegardé `null` (file: `ui-stats.js`).
- Supprime le fallback automatique sur la première valeur historique pour la courbe 1RM en forçant `resolveOrmGoalTrend()` à exiger une valeur de départ explicite (file: `ui-stats.js`).
- Ajoute du style `.stats-goal-orm-row + .stats-goal-orm-row { margin-top: 6px; }` pour espacer les lignes « Départ » et « Cible » (file: `style.css`).

### Testing
- Vérifications de syntaxe JavaScript: `node --check ui-stats.js` — réussi.
- Vérifications de syntaxe JavaScript: `node --check init.js` — réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd04e6791883328bad661e2346d46f)