### PR TITLE
Compute exercise card RPE average from current session sets

### DIFF
--- a/ui-session.js
+++ b/ui-session.js
@@ -702,10 +702,9 @@
                 typeof A.buildSessionExerciseMeta === 'function'
                     ? await A.buildSessionExerciseMeta(exercise, sets, { dateKey: key })
                     : { goalsByPos: new Map(), activeHistoryLabel: 'Historique', activeHistorySets: [] };
-            const statsSourceSets = Array.isArray(meta?.activeHistorySets) ? meta.activeHistorySets : [];
             const statsLine = document.createElement('div');
             statsLine.className = 'exercise-card-stats';
-            renderExerciseStatsLine(statsLine, statsSourceSets, meta?.activeHistoryLabel);
+            renderExerciseStatsLine(statsLine, sets, meta?.activeHistoryLabel);
             const detailsButton = document.createElement('button');
             detailsButton.type = 'button';
             detailsButton.className = 'exercise-card-menu-button';
@@ -846,8 +845,7 @@
                 ? await A.buildSessionExerciseMeta(exercise, sets, { dateKey })
                 : { goalsByPos: new Map(), medalsByPos: new Map(), activeHistorySets: [], activeHistoryLabel: 'Historique' };
         if (statsLine) {
-            const statsSourceSets = Array.isArray(meta?.activeHistorySets) ? meta.activeHistorySets : [];
-            renderExerciseStatsLine(statsLine, statsSourceSets, meta?.activeHistoryLabel);
+            renderExerciseStatsLine(statsLine, sets, meta?.activeHistoryLabel);
         }
         await renderSessionCardSets({ exercise, setsWrapper, dateKey, meta });
         return true;


### PR DESCRIPTION
### Motivation
- The exercise card subtitle (including average RPE) was computed from the active history snapshot instead of the currently displayed session sets, causing incorrect averages (e.g. showing 7.5 instead of the expected 8.1).

### Description
- Updated `ui-session.js` to call `renderExerciseStatsLine(statsLine, sets, ...)` so the stats (including `rpeAvg`) are computed from the current exercise `sets` instead of `meta.activeHistorySets` during initial render and when refreshing a card.
- This change affects the initial session card rendering and the `updateSessionExerciseCard` refresh path while keeping existing meta/history data available for other UI elements.

### Testing
- Ran `node --check ui-session.js` to validate the modified file and the syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3823755483328047d5ff75d27e60)