### PR TITLE
Atténuer le texte des tags non sélectionnés dans fiche exercice, statistiques et volume

### DIFF
--- a/style.css
+++ b/style.css
@@ -2940,6 +2940,24 @@ input[type="number"]{ -moz-appearance:textfield; }
     gap: 6px;
 }
 
+#exEquip .tag,
+#exSecMuscles .tag,
+#statsMetricTags .tag,
+#statsRangeTags .tag,
+#volumeRangeTags .tag,
+#volumeMuscleRangeTags .tag {
+    color: var(--labelColor);
+}
+
+#exEquip .tag.selected,
+#exSecMuscles .tag.selected,
+#statsMetricTags .tag.selected,
+#statsRangeTags .tag.selected,
+#volumeRangeTags .tag.selected,
+#volumeMuscleRangeTags .tag.selected {
+    color: var(--selectedColor);
+}
+
 .stats-chart {
     width: 100%;
     min-height: 240px;


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité de l'interface en rendant les étiquettes non sélectionnées des tags (sélecteurs KPI/période et sélecteurs matériel/muscles) moins contrastées afin de mieux distinguer l'état sélectionné.

### Description
- Ajout de règles CSS ciblées dans `style.css` pour les conteneurs de tags concernés (`#exEquip`, `#exSecMuscles`, `#statsMetricTags`, `#statsRangeTags`, `#volumeRangeTags`, `#volumeMuscleRangeTags`) afin que l'état par défaut utilise `color: var(--labelColor)` et l'état `.selected` utilise `color: var(--selectedColor)`.

### Testing
- Aucun test automatisé n'a été exécuté car il s'agit d'une modification purement visuelle de CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd394c3850833281769d4c3367b7ec)