### PR TITLE
Ajuste calcul du RPE moyen pour séries >= 7

### DIFF
--- a/ui-stats.js
+++ b/ui-stats.js
@@ -1790,7 +1790,7 @@
                 maxWeight = weight;
                 hasData = true;
             }
-            if (Number.isFinite(rpe) && rpe >= 5 && rpe <= 10) {
+            if (Number.isFinite(rpe) && rpe >= 7 && rpe <= 10) {
                 rpeSum += rpe;
                 rpeCount += 1;
                 hasData = true;


### PR DESCRIPTION
### Motivation
- L’écran Statistiques doit calculer le RPE moyen uniquement à partir des séries où le RPE est d’au moins 7 (et au plus 10) afin de refléter les efforts réellement significatifs.

### Description
- Dans `ui-stats.js`, la condition d’agrégation pour incrémenter `rpeSum` et `rpeCount` a été modifiée de `rpe >= 5` à `rpe >= 7`.

### Testing
- Vérification de syntaxe JavaScript exécutée avec `node --check ui-stats.js` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9fa6191c833290628a45acb19a5b)