### PR TITLE
Scinder le champ "temps de repos" en minutes/secondes pour l'édition des séries

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -856,6 +856,12 @@
             if (!active) {
                 return;
             }
+            if (typeof active.onKey === 'function') {
+                const handled = active.onKey(key, { mode: active.mode, layout: active.layout });
+                if (handled) {
+                    return;
+                }
+            }
             if (active.mode === 'edit') {
                 const edit = active.edit || {};
                 if (key === 'up') {
@@ -874,6 +880,29 @@
             }
             const current = String(active.getValue?.() ?? '');
             const layout = active.layout || 'default';
+            const splitTimeField = Boolean(active.splitTimeField);
+
+            if (layout === 'time' && splitTimeField) {
+                if (key === ':') {
+                    active.onTimeToggle?.();
+                    return;
+                }
+                if (key !== 'del' && !/^\d$/.test(key)) {
+                    return;
+                }
+                const digitsOnly = current.replace(/\D/g, '');
+                const shouldReplace = active.replaceOnInput || hasFullSelection(current);
+                const base = shouldReplace ? '' : digitsOnly;
+                let next = base;
+                if (key === 'del') {
+                    next = base.slice(0, -1);
+                } else {
+                    next = `${base}${key}`;
+                }
+                active.replaceOnInput = false;
+                active.onChange?.(next);
+                return;
+            }
 
             if (layout === 'time') {
                 const normalized = normalizeTimeInput(current);

--- a/style.css
+++ b/style.css
@@ -2331,9 +2331,35 @@ textarea:focus{
   grid-column: 5;
   align-self: stretch;
   height: 100%;
-  background: var(--panelBord);
-  border-color: var(--black);
-  color: var(--black);
+  display: flex;
+  gap: 0;
+}
+
+.exec-row .exec-rest-cell .set-edit-input{
+  flex: 1 1 50%;
+  width: auto;
+  height: 100%;
+  min-height: 100%;
+  border-radius: 0;
+}
+
+.exec-row .exec-rest-minute-cell{
+  border-top-left-radius: var(--radius);
+  border-bottom-left-radius: var(--radius);
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  text-align: right;
+  padding-right: 6px;
+}
+
+.exec-row .exec-rest-second-cell{
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+  text-align: left;
+  padding-left: 6px;
+  margin-left: -1px;
 }
 
 .exec-row .exec-meta-cell{
@@ -2765,6 +2791,7 @@ body.inline-keyboard-visible .keyboard-spacer{
 
 .exec-rest-cell{
   font-variant-numeric: tabular-nums;
+  background: transparent;
 }
 
 .span-two{

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -472,7 +472,8 @@
                     reps: repsInput.value,
                     weight: weightInput.value,
                     rpe: rpeInput.value,
-                    rest: parseRestInput(restInput.value, value.rest)
+                    minutes: restMinutesInput.value,
+                    seconds: restSecondsInput.value
                 }),
                 onSelectField: (field) => selectField?.(field),
                 onMove: (direction) => {
@@ -522,6 +523,12 @@
                 case 'rest':
                     next.rest = parseRestInput(rawValue, value.rest);
                     break;
+                case 'minutes':
+                    next.rest = composeRestFromParts(rawValue, restSecondsInput.value);
+                    break;
+                case 'seconds':
+                    next.rest = composeRestFromParts(restMinutesInput.value, rawValue);
+                    break;
                 default:
                     return;
             }
@@ -536,7 +543,7 @@
             if (field === 'rpe') {
                 return 'rpe';
             }
-            if (field === 'rest') {
+            if (field === 'rest' || field === 'minutes' || field === 'seconds') {
                 return 'time';
             }
             return 'default';
@@ -550,6 +557,14 @@
                 layout: resolveKeyboardLayout(field),
                 mode: inlineKeyboard.getMode?.() || 'input',
                 decimalSeparator: field === 'weight' ? ',' : undefined,
+                splitTimeField: field === 'minutes' || field === 'seconds',
+                onKey: (key) => {
+                    if (key === ':' && (field === 'minutes' || field === 'seconds')) {
+                        selectField?.(field === 'minutes' ? 'seconds' : 'minutes');
+                        return true;
+                    }
+                    return false;
+                },
                 actions: buildKeyboardActions,
                 edit: {
                     onMove: (direction) => {
@@ -631,15 +646,25 @@
             { inputMode: 'decimal', type: 'text' }
         );
         const rpeInput = createInput(() => (value.rpe == null ? '' : String(value.rpe)), 'rpe', 'exec-rpe-cell');
-        const restInput = createInput(() => formatRestDisplay(value.rest), 'rest', 'exec-rest-cell');
-        collectInputs(repsInput, weightInput, rpeInput, restInput);
+        const restMinutesInput = createInput(() => splitRest(value.rest).minutes, 'minutes', 'exec-rest-minute-cell');
+        const restSecondsInput = createInput(
+            () => String(splitRest(value.rest).seconds).padStart(2, '0'),
+            'seconds',
+            'exec-rest-second-cell'
+        );
+        const restContainer = document.createElement('div');
+        restContainer.className = 'exec-rest-cell';
+        restContainer.append(restMinutesInput, restSecondsInput);
+        collectInputs(repsInput, weightInput, rpeInput, restMinutesInput, restSecondsInput);
         syncRowTone();
         const selectField = (field) => {
             const map = {
                 reps: repsInput,
                 weight: weightInput,
                 rpe: rpeInput,
-                rest: restInput
+                rest: restMinutesInput,
+                minutes: restMinutesInput,
+                seconds: restSecondsInput
             };
             const target = map[field];
             if (!target) {
@@ -649,7 +674,7 @@
             target.focus({ preventScroll: true });
         };
 
-        row.append(order, repsInput, weightInput, rpeInput, restInput);
+        row.append(order, repsInput, weightInput, rpeInput, restContainer);
         return row;
     }
 
@@ -1370,6 +1395,20 @@
         }
         const minutes = safeInt(parts[0], 0);
         const seconds = safeInt(parts[1], 0);
+        return Math.max(0, minutes * 60 + seconds);
+    }
+
+    function parseRestPart(rawValue, fallback = 0) {
+        if (rawValue == null || rawValue === '') {
+            return Math.max(0, safeInt(fallback, 0));
+        }
+        return Math.max(0, safeInt(rawValue, fallback));
+    }
+
+    function composeRestFromParts(minutesValue, secondsValue) {
+        const minutes = parseRestPart(minutesValue, 0);
+        const secondsRaw = parseRestPart(secondsValue, 0);
+        const seconds = Math.min(59, secondsRaw);
         return Math.max(0, minutes * 60 + seconds);
     }
 

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1201,7 +1201,8 @@
                     reps: repsInput.value,
                     weight: weightInput.value,
                     rpe: rpeInput.value,
-                    rest: parseRestInput(restInput.value, value.rest)
+                    minutes: restMinutesInput.value,
+                    seconds: restSecondsInput.value
                 }),
                 onSelectField: (field) => selectField?.(field),
                 onMove: async (direction) => {
@@ -1252,6 +1253,12 @@
                 case 'rest':
                     next.rest = parseRestInput(rawValue, value.rest);
                     break;
+                case 'minutes':
+                    next.rest = composeRestFromParts(rawValue, restSecondsInput.value);
+                    break;
+                case 'seconds':
+                    next.rest = composeRestFromParts(restMinutesInput.value, rawValue);
+                    break;
                 default:
                     return;
             }
@@ -1271,7 +1278,7 @@
             if (field === 'rpe') {
                 return 'rpe';
             }
-            if (field === 'rest') {
+            if (field === 'rest' || field === 'minutes' || field === 'seconds') {
                 return 'time';
             }
             return 'default';
@@ -1285,6 +1292,14 @@
                 layout: resolveKeyboardLayout(field),
                 mode: inlineKeyboard.getMode?.() || 'input',
                 decimalSeparator: field === 'weight' ? ',' : undefined,
+                splitTimeField: field === 'minutes' || field === 'seconds',
+                onKey: (key) => {
+                    if (key === ':' && (field === 'minutes' || field === 'seconds')) {
+                        selectField?.(field === 'minutes' ? 'seconds' : 'minutes');
+                        return true;
+                    }
+                    return false;
+                },
                 actions: buildKeyboardActions,
                 edit: {
                     onMove: async (direction) => {
@@ -1365,15 +1380,25 @@
             { inputMode: 'decimal', type: 'text' }
         );
         const rpeInput = createInput(() => (value.rpe == null ? '' : String(value.rpe)), 'rpe', 'exec-rpe-cell');
-        const restInput = createInput(() => formatRestDisplay(value.rest), 'rest', 'exec-rest-cell');
-        collectInputs(repsInput, weightInput, rpeInput, restInput);
+        const restMinutesInput = createInput(() => splitRest(value.rest).minutes, 'minutes', 'exec-rest-minute-cell');
+        const restSecondsInput = createInput(
+            () => String(splitRest(value.rest).seconds).padStart(2, '0'),
+            'seconds',
+            'exec-rest-second-cell'
+        );
+        const restContainer = document.createElement('div');
+        restContainer.className = 'exec-rest-cell';
+        restContainer.append(restMinutesInput, restSecondsInput);
+        collectInputs(repsInput, weightInput, rpeInput, restMinutesInput, restSecondsInput);
         syncRowTone();
         selectField = (field) => {
             const map = {
                 reps: repsInput,
                 weight: weightInput,
                 rpe: rpeInput,
-                rest: restInput
+                rest: restMinutesInput,
+                minutes: restMinutesInput,
+                seconds: restSecondsInput
             };
             const target = map[field];
             if (!target) {
@@ -1384,7 +1409,7 @@
         };
 
         const metaCell = buildMetaCell(set, index, meta);
-        row.append(order, repsInput, weightInput, rpeInput, restInput, metaCell);
+        row.append(order, repsInput, weightInput, rpeInput, restContainer, metaCell);
         return row;
     }
 
@@ -2645,6 +2670,20 @@
         }
         const minutes = safeInt(parts[0], 0);
         const seconds = safeInt(parts[1], 0);
+        return Math.max(0, minutes * 60 + seconds);
+    }
+
+    function parseRestPart(rawValue, fallback = 0) {
+        if (rawValue == null || rawValue === '') {
+            return Math.max(0, safeInt(fallback, 0));
+        }
+        return Math.max(0, safeInt(rawValue, fallback));
+    }
+
+    function composeRestFromParts(minutesValue, secondsValue) {
+        const minutes = parseRestPart(minutesValue, 0);
+        const secondsRaw = parseRestPart(secondsValue, 0);
+        const seconds = Math.min(59, secondsRaw);
         return Math.max(0, minutes * 60 + seconds);
     }
 


### PR DESCRIPTION
### Motivation
- Améliorer la saisie du `temps de repos` en proposant deux sous-champs (minutes et secondes) tout en conservant la compatibilité avec le format de stockage existant (durée en secondes). 
- Offrir une interaction clavier adaptée (touche `:` du clavier personnalisé) pour passer rapidement entre minutes et secondes.

### Description
- Remplacement du champ unique de repos par deux inputs adjacents `minutes` et `seconds` dans les éditeurs de série pour séance et routine via `ui-session-execution-edit.js` et `ui-routine-execution-edit.js`, et création d'un conteneur `exec-rest-cell` qui regroupe les deux inputs. 
- Recomposition de la valeur finale `rest` (en secondes) avant persistance en ajoutant les fonctions `parseRestPart` et `composeRestFromParts` pour garantir la compatibilité descendante avec les données/export existants. 
- Adaptation du composant clavier/éditeur (`components/set-editor.js`) pour supporter un hook `onKey`, un mode `splitTimeField` et la gestion spécifique de `:`/saisie sur les champs séparés afin de basculer le focus entre minutes et secondes sans casser le comportement des champs temps existants. 
- Mise à jour du style dans `style.css` pour que les deux cases aient l'apparence d'un seul champ (bordures arrondies à gauche/droite respectivement, texte minute aligné à droite, texte seconde aligné à gauche, pas d'espace entre elles et largeur totale identique à l'ancienne cellule). 

### Testing
- Vérification de la syntaxe des modules modifiés via `node --check components/set-editor.js` (succès). 
- Vérification de la syntaxe via `node --check ui-session-execution-edit.js` (succès). 
- Vérification de la syntaxe via `node --check ui-routine-execution-edit.js` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7b9fe4188332ad2ccfead372a3af)