### PR TITLE
Fix rest minutes/seconds inputs overflowing execution grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -2331,15 +2331,19 @@ textarea:focus{
   grid-column: 5;
   align-self: stretch;
   height: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 0;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .exec-row .exec-rest-cell .set-edit-input{
-  flex: 1 1 50%;
-  width: auto;
+  width: 100%;
   height: 100%;
   min-height: 100%;
+  min-width: 0;
   border-radius: 0;
 }
 


### PR DESCRIPTION
### Motivation
- Corriger deux régressions dans la colonne `Repos` : les champs minutes/secondes débordaient sur la droite et la saisie de valeurs longues en minutes provoquait un affichage tronqué/instable.

### Description
- Changement du conteneur `.exec-row .exec-rest-cell` de `display: flex` à une grille 2 colonnes avec `grid-template-columns: minmax(0, 1fr) minmax(0, 1fr)` et ajout de `min-width: 0`, `max-width: 100%` et `overflow: hidden` pour contraindre les inputs à la colonne `Repos`.
- Forçage de `width: 100%` et `min-width: 0` sur `.exec-row .exec-rest-cell .set-edit-input` pour empêcher l’expansion du champ lors de la saisie de grandes valeurs (par ex. `1111`).

### Testing
- Exécution de `git diff --check` pour vérifier l’absence d’erreurs de diff/whitespace, résultat : réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df81a10fcc8332936ad3cb32d1cbbc)