### PR TITLE
Réordonner les badges de métriques sur l’écran Statistiques

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,12 +417,12 @@
                     >
                         <button type="button" class="tag" data-metric="orm">1RM</button>
                         <button type="button" class="tag" data-metric="tenrm">1RM-rpe</button>
-                        <button type="button" class="tag" data-metric="avgRpe">RPE moyen</button>
-                        <button type="button" class="tag" data-metric="weight">Charge max</button>
-                        <button type="button" class="tag" data-metric="reps">Répétitions</button>
                         <button type="button" class="tag" data-metric="tenrmReal">10RM réel</button>
+                        <button type="button" class="tag" data-metric="weight">Charge max</button>
+                        <button type="button" class="tag" data-metric="avgRpe">RPE moyen</button>
+                        <button type="button" class="tag" data-metric="setsWeek">Série/sem</button>
                         <button type="button" class="tag" data-metric="volume">Volume</button>
-                        <button type="button" class="tag" data-metric="setsWeek">Séries/sem.</button>
+                        <button type="button" class="tag" data-metric="reps">Répétitions</button>
                     </div>
                 </div>
 

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -74,7 +74,7 @@
         },
         {
             key: 'setsWeek',
-            tagLabel: 'Séries/sem.',
+            tagLabel: 'Série/sem',
             label: 'Série semaine',
             axisUnit: 'séries',
             format: formatSeries


### PR DESCRIPTION
### Motivation
- Réorganiser l’ordre des badges affichés sur l’écran Statistiques pour correspondre à la maquette : première ligne `1RM`, `1RM-rpe`, `10RM réel`, `Charge max`; seconde ligne `RPE moyen`, `Série/sem`, `Volume`, `Répétitions`, et uniformiser le libellé de `setsWeek`.

### Description
- Réordonné les boutons de métriques dans `index.html` en ajustant les `data-metric` pour l’ordre demandé (`orm`, `tenrm`, `tenrmReal`, `weight`, puis `avgRpe`, `setsWeek`, `volume`, `reps`).
- Harmonisé le libellé `tagLabel` pour la métrique `setsWeek` dans `ui-stats.js` en le passant de `Séries/sem.` à `Série/sem`.

### Testing
- Exécuté une recherche avec `rg` pour vérifier la présence et l’ordre des `data-metric` (vérification réussie).
- Inspecté les lignes modifiées avec `nl` pour confirmer le nouvel ordre et le `tagLabel` (vérification réussie).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9c3675748332b0edb13107f1cd6a)