### PR TITLE
Ajuste le libellé de la touche `:` pour les champs minutes/secondes

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -656,7 +656,13 @@
                     down: '⬇️',
                     trash: '🗑️'
                 };
-                button.textContent = labelMap[key] || key;
+                const isSplitTimeToggle = key === ':' && layout === 'time' && active?.splitTimeField;
+                if (isSplitTimeToggle) {
+                    const side = active?.timeField;
+                    button.textContent = side === 'minutes' ? '▸:' : side === 'seconds' ? ':◂' : ':';
+                } else {
+                    button.textContent = labelMap[key] || key;
+                }
                 button.dataset.key = key;
                 if (key === 'up' || key === 'down') {
                     button.dataset.wide = 'true';
@@ -1016,6 +1022,7 @@
             const mode = handlers.mode || 'input';
             active = { target, ...handlers, layout, mode };
             applyLayout(layout, mode);
+            renderKeys(currentLayout, currentMode);
             renderActions(resolveActions());
             keyboard.hidden = false;
             keyboard.setAttribute('data-visible', 'true');

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -558,6 +558,7 @@
                 mode: inlineKeyboard.getMode?.() || 'input',
                 decimalSeparator: field === 'weight' ? ',' : undefined,
                 splitTimeField: field === 'minutes' || field === 'seconds',
+                timeField: field,
                 onKey: (key) => {
                     if (key === ':' && (field === 'minutes' || field === 'seconds')) {
                         selectField?.(field === 'minutes' ? 'seconds' : 'minutes');

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1293,6 +1293,7 @@
                 mode: inlineKeyboard.getMode?.() || 'input',
                 decimalSeparator: field === 'weight' ? ',' : undefined,
                 splitTimeField: field === 'minutes' || field === 'seconds',
+                timeField: field,
                 onKey: (key) => {
                     if (key === ':' && (field === 'minutes' || field === 'seconds')) {
                         selectField?.(field === 'minutes' ? 'seconds' : 'minutes');


### PR DESCRIPTION
### Motivation
- Améliorer l’indication visuelle de la touche `:` du clavier inline quand on édite des champs temps scindés (minutes / secondes) pour réduire l’ambiguïté lors de la saisie.

### Description
- Dans `components/set-editor.js` la fonction de rendu des touches (`renderKeys`) affiche maintenant `▸:` quand le champ actif est `minutes` et `:◂` quand il est `seconds` pour le bouton `:` en layout `time` et `splitTimeField` actif.
- Toujours dans `components/set-editor.js`, l’appel à `renderKeys` est forcé lors de l’`attach` du clavier pour que le libellé reflète immédiatement le champ actif.
- Dans `ui-session-execution-edit.js` et `ui-routine-execution-edit.js` l’objet passé à `inlineKeyboard.attach` reçoit désormais `timeField: field` afin que le clavier connaisse le côté actif (`minutes` ou `seconds`).

### Testing
- Exécutions de vérification de syntaxe JavaScript automatiques réussies : `node --check components/set-editor.js` (succès).
- Exécutions de vérification de syntaxe JavaScript automatiques réussies : `node --check ui-session-execution-edit.js` (succès).
- Exécutions de vérification de syntaxe JavaScript automatiques réussies : `node --check ui-routine-execution-edit.js` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa3d661b48332b5e49717b452dc9f)