### PR TITLE
Simplify and adjust grid-template-columns for .exec-grid routine layouts

### DIFF
--- a/style.css
+++ b/style.css
@@ -2275,11 +2275,11 @@ textarea:focus{
   text-align:center; align-items:center;
 }
 .exec-grid.routine-set-grid{
-  grid-template-columns: minmax(2.1ch, 0.4fr) 1.2fr 1.2fr 1.4fr 1fr; /* # | Reps | Poids | RPE | Repos */
+  grid-template-columns: 2.1ch 1.2fr 1.2fr 1fr 1fr; /* # | Reps | Poids | RPE | Repos */
 }
 .exec-grid.routine-set-grid.routine-set-grid--with-meta{
   --exec-meta-width: 80px;
-  grid-template-columns: minmax(2.1ch, 0.4fr) 1.32fr 1.32fr 1.1fr 1.1fr var(--exec-meta-width); /* # | Reps | Poids | RPE | Repos | Infos */
+  grid-template-columns: 2.1ch 1.2fr 1.2fr 1fr 1fr 2fr; /* # | Reps | Poids | RPE | Repos | Infos */
 }
 .routine-set-grid > *{ min-width:0; }
 .exec-head{ font-weight: var(--fw-strong); }


### PR DESCRIPTION
### Motivation
- Stabilize and simplify column sizing for the execution/routine set grid by removing the `minmax(...)` expression and normalizing fraction values for more predictable alignment and layout behavior.

### Description
- Updated `grid-template-columns` for `.exec-grid.routine-set-grid` from `minmax(2.1ch, 0.4fr) 1.2fr 1.2fr 1.4fr 1fr` to `2.1ch 1.2fr 1.2fr 1fr 1fr` and for `.exec-grid.routine-set-grid.routine-set-grid--with-meta` from `minmax(2.1ch, 0.4fr) 1.32fr 1.32fr 1.1fr 1.1fr var(--exec-meta-width)` to `2.1ch 1.2fr 1.2fr 1fr 1fr 2fr` to simplify sizing and layout.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9d6496a48332b1394c2a53dcde75)