### PR TITLE
Mettre en surbrillance uniquement la cellule active dans l'éditeur de séries

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -1127,7 +1127,7 @@
             }
         };
 
-        const ACTIVE_CLASSES = ['routine-set-row-active', 'set-editor-highlight'];
+        const ACTIVE_CLASSES = ['routine-set-row-active'];
 
         const close = () => {
             if (!active) {

--- a/style.css
+++ b/style.css
@@ -2624,21 +2624,8 @@ textarea:focus{
   outline:none;
 }
 
-.set-editor-highlight{
-  border-radius: var(--radius);
-  outline: 2px solid var(--emphase);
-  outline-offset: 0;
-}
-
-.set-editor-highlight .set-edit-input,
-.set-editor-highlight .set-edit-button,
-.set-editor-highlight .routine-set-order,
-.set-editor-highlight .exec-meta-chip{
+.set-edit-input--active{
   color: var(--emphase);
-}
-
-.set-editor-highlight .set-edit-input,
-.set-editor-highlight .set-edit-button{
   border-color: var(--emphase);
 }
 

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -457,6 +457,26 @@
             ];
         };
 
+        const activeCellClass = 'set-edit-input--active';
+        const clearActiveCell = () => {
+            row.querySelectorAll(`.${activeCellClass}`).forEach((node) => node.classList.remove(activeCellClass));
+        };
+        const setActiveCell = (field) => {
+            clearActiveCell();
+            const map = {
+                reps: repsInput,
+                weight: weightInput,
+                rpe: rpeInput,
+                rest: restMinutesInput,
+                minutes: restMinutesInput,
+                seconds: restSecondsInput
+            };
+            const target = map[field];
+            if (target) {
+                target.classList.add(activeCellClass);
+            }
+        };
+
         const openEditor = (focusField) => {
             const editor = ensureInlineEditor();
             if (!editor) {
@@ -475,7 +495,10 @@
                     minutes: restMinutesInput.value,
                     seconds: restSecondsInput.value
                 }),
-                onSelectField: (field) => selectField?.(field),
+                onSelectField: (field) => {
+                    setActiveCell(field);
+                    selectField?.(field);
+                },
                 onMove: (direction) => {
                     const delta = direction === 'up' ? -1 : 1;
                     const nextIndex = moveSet(currentIndex, delta, row);
@@ -503,8 +526,11 @@
                 },
                 onDelete: () => removeSet(currentIndex),
                 onChange: updatePreview,
-                onClose: () => row.classList.remove('routine-set-row-active', 'set-editor-highlight'),
-                onOpen: () => row.classList.add('routine-set-row-active', 'set-editor-highlight')
+                onClose: () => {
+                    clearActiveCell();
+                    row.classList.remove('routine-set-row-active');
+                },
+                onOpen: () => row.classList.add('routine-set-row-active')
             });
         };
 
@@ -633,6 +659,7 @@
                 }
             });
             input.addEventListener('click', () => {
+                setActiveCell(field);
                 openEditor(field);
                 attachInlineKeyboard(input, field);
             });
@@ -671,6 +698,7 @@
             if (!target) {
                 return;
             }
+            setActiveCell(field);
             attachInlineKeyboard(target, field);
             target.focus({ preventScroll: true });
         };

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1186,6 +1186,25 @@
         };
 
         let selectField = null;
+        const activeCellClass = 'set-edit-input--active';
+        const clearActiveCell = () => {
+            row.querySelectorAll(`.${activeCellClass}`).forEach((node) => node.classList.remove(activeCellClass));
+        };
+        const setActiveCell = (field) => {
+            clearActiveCell();
+            const map = {
+                reps: repsInput,
+                weight: weightInput,
+                rpe: rpeInput,
+                rest: restMinutesInput,
+                minutes: restMinutesInput,
+                seconds: restSecondsInput
+            };
+            const target = map[field];
+            if (target) {
+                target.classList.add(activeCellClass);
+            }
+        };
         const openEditor = (focusField) => {
             const editor = ensureInlineEditor();
             if (!editor) {
@@ -1204,7 +1223,10 @@
                     minutes: restMinutesInput.value,
                     seconds: restSecondsInput.value
                 }),
-                onSelectField: (field) => selectField?.(field),
+                onSelectField: (field) => {
+                    setActiveCell(field);
+                    selectField?.(field);
+                },
                 onMove: async (direction) => {
                     const delta = direction === 'up' ? -1 : 1;
                     const nextIndex = await moveSet(currentIndex, delta, row);
@@ -1233,8 +1255,11 @@
                 },
                 onDelete: () => removeSet(currentIndex),
                 onChange: updatePreview,
-                onClose: () => row.classList.remove('routine-set-row-active', 'set-editor-highlight'),
-                onOpen: () => row.classList.add('routine-set-row-active', 'set-editor-highlight')
+                onClose: () => {
+                    clearActiveCell();
+                    row.classList.remove('routine-set-row-active');
+                },
+                onOpen: () => row.classList.add('routine-set-row-active')
             });
         };
 
@@ -1367,6 +1392,7 @@
                 }
             });
             input.addEventListener('click', () => {
+                setActiveCell(field);
                 openEditor(field);
                 attachInlineKeyboard(input, field);
             });
@@ -1405,6 +1431,7 @@
             if (!target) {
                 return;
             }
+            setActiveCell(field);
             attachInlineKeyboard(target, field);
             target.focus({ preventScroll: true });
         };


### PR DESCRIPTION
### Motivation
- Éviter que l'ensemble de la ligne de série change de style lors de l'édition d'une cellule pour ne surligner que la cellule sélectionnée.

### Description
- Retiré `set-editor-highlight` des classes actives gérées par l'éditeur inline dans `components/set-editor.js` pour ne plus appliquer un style de ligne global.
- Ajouté la gestion d'une classe de cellule active `set-edit-input--active` dans `ui-session-execution-edit.js` pour marquer et nettoyer l'ancienne cellule lors de la sélection et de la fermeture de l'éditeur inline.
- Même implémentation appliquée dans `ui-routine-execution-edit.js` pour conserver un comportement cohérent entre les écrans séance et routine.
- Remplacé les règles CSS de surlignage global par une règle dédiée `.set-edit-input--active` dans `style.css` pour n'affecter que la cellule sélectionnée.

### Testing
- Exécuté `node --check components/set-editor.js` et la vérification a réussi.
- Exécuté `node --check ui-session-execution-edit.js` et la vérification a réussi.
- Exécuté `node --check ui-routine-execution-edit.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cb9faf3c8332aaad44aac78a47c9)