### PR TITLE
Ajuster le comportement du curseur et harmoniser le style des cellules de saisie

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -135,7 +135,9 @@
 
         static #selectOnFocus(event) {
             const target = event.currentTarget;
-            if (target?.select) {
+            const role = target?.dataset?.role;
+            const shouldSelectAll = role === 'minutes' || role === 'seconds';
+            if (shouldSelectAll && target?.select) {
                 target.select();
             }
         }
@@ -542,7 +544,9 @@
             if (target) {
                 window.requestAnimationFrame(() => {
                     target.focus();
-                    if (target.select) {
+                    const role = target?.dataset?.role;
+                    const shouldSelectAll = role === 'minutes' || role === 'seconds';
+                    if (shouldSelectAll && target.select) {
                         target.select();
                     }
                 });

--- a/style.css
+++ b/style.css
@@ -2325,6 +2325,7 @@ textarea:focus{
   grid-column: 4;
   align-self: stretch;
   height: 100%;
+  border-radius: 999px;
 }
 
 .exec-row .exec-rest-cell{
@@ -2427,7 +2428,7 @@ textarea:focus{
 
 
 .routine-set-row-active{
-  box-shadow: inset 0 -2px var(--emphase);
+  box-shadow: none;
 }
 
 .routine-set-order{
@@ -2442,19 +2443,19 @@ textarea:focus{
 .set-edit-button{
   width:100%;
   min-height: var(--control-h);
-  font-weight: var(--fw-strong);
+  font-weight: var(--fw-base);
   color: var(--black);
-  background: var(--panelBord);
-  border-color: var(--black);
+  background: color-mix(in srgb, var(--panelBord) 35%, transparent);
+  border-color: color-mix(in srgb, var(--panelBord) 55%, transparent);
 }
 .set-edit-input{
   width:100%;
   min-height: var(--control-h);
   text-align:center;
-  font-weight: var(--fw-strong);
+  font-weight: var(--fw-base);
   color: var(--black);
-  background: var(--panelBord);
-  border-color: var(--black);
+  background: color-mix(in srgb, var(--panelBord) 35%, transparent);
+  border-color: color-mix(in srgb, var(--panelBord) 55%, transparent);
 }
 .routine-set-grid .set-edit-button{
   color: var(--black);
@@ -2496,20 +2497,20 @@ textarea:focus{
 }
 
 .exec-set-planned{
-  background: color-mix(in srgb, var(--panelBord) 20%, transparent);
-  color: color-mix(in srgb, var(--black) 65%, transparent);
+  background: transparent;
+  color: inherit;
   font-weight: var(--fw-light);
 }
 
 .exec-set-planned .set-edit-button{
-  background: color-mix(in srgb, var(--panelBord) 35%, transparent);
-  border-color: color-mix(in srgb, var(--panelBord) 55%, transparent);
+  background: color-mix(in srgb, var(--panelBord) 20%, transparent);
+  border-color: color-mix(in srgb, var(--panelBord) 45%, transparent);
   color: inherit;
   font-weight: inherit;
 }
 .exec-set-planned .set-edit-input{
-  background: color-mix(in srgb, var(--panelBord) 35%, transparent);
-  border-color: color-mix(in srgb, var(--panelBord) 55%, transparent);
+  background: color-mix(in srgb, var(--panelBord) 20%, transparent);
+  border-color: color-mix(in srgb, var(--panelBord) 45%, transparent);
   color: inherit;
   font-weight: inherit;
 }
@@ -2625,8 +2626,8 @@ textarea:focus{
 }
 
 .set-edit-input--active{
-  color: var(--emphase);
   border-color: var(--emphase);
+  box-shadow: inset 0 0 0 1px var(--emphase);
 }
 
 .inline-set-editor-row{
@@ -2785,6 +2786,20 @@ body.inline-keyboard-visible .keyboard-spacer{
 .exec-rest-cell{
   font-variant-numeric: tabular-nums;
   background: transparent;
+}
+
+.exec-set-executed .set-edit-input[data-rpe],
+.exec-set-executed .set-edit-button[data-rpe],
+.exec-rest-cell[data-rpe] .set-edit-input{
+  background: color-mix(in srgb, var(--rpe-bg) 35%, transparent);
+  border-color: color-mix(in srgb, var(--rpe-border) 50%, var(--panelBord));
+}
+
+.exec-set-planned .set-edit-input[data-rpe],
+.exec-set-planned .set-edit-button[data-rpe],
+.exec-set-planned .exec-rest-cell[data-rpe] .set-edit-input{
+  background: color-mix(in srgb, var(--rpe-bg) 20%, transparent);
+  border-color: color-mix(in srgb, var(--rpe-border) 35%, var(--panelBord));
 }
 
 .span-two{

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1116,6 +1116,10 @@
         const syncRowTone = () => {
             applyRpeTone(repsInput, value.rpe);
             applyRpeTone(weightInput, value.rpe);
+            applyRpeTone(rpeInput, value.rpe);
+            applyRpeTone(restMinutesInput, value.rpe);
+            applyRpeTone(restSecondsInput, value.rpe);
+            applyRpeTone(restContainer, value.rpe);
         };
 
         const updatePreview = (source, { persist = true } = {}) => {


### PR DESCRIPTION
### Motivation
- Rendre le comportement du curseur plus naturel lors de la saisie des séries en enlevant l’auto-sélection systématique. 
- Faire en sorte que les champs de repos et la case RPE reprennent la colorimétrie et le style des blocs exercice pour une apparence cohérente. 
- Simplifier l’emphase visuelle pour qu’elle s’applique à la case active et non au conteneur de la ligne.

### Description
- Restreint l’auto-sélection au focus (`select`) uniquement aux champs `minutes` et `seconds` dans `components/set-editor.js` et appliqué la même logique lors du focus programmatique (fonction `#selectOnFocus` et `#focusField`).
- Étendu `syncRowTone()` dans `ui-session-execution-edit.js` pour appeler `applyRpeTone` sur `rpe`, `restMinutes`, `restSeconds` et le conteneur `rest` afin d’appliquer la teinte RPE aux champs repos.
- Ajusté `style.css` pour neutraliser la surbrillance du conteneur de ligne active, appliquer l’emphase sur la cellule active via `border-color`/`box-shadow`, harmoniser les fonds/bordures des `.set-edit-*` avec les blocs séance, arrondir la cellule RPE (`border-radius: 999px`) et appliquer les variantes de teinte RPE aux champs repos selon l’état planifié / fait.
- Petites corrections de poids visuel (`font-weight`) et transparences pour aligner le rendu des boutons/inputs avec les blocs d’exercice.

### Testing
- Exécuté la vérification syntaxique JavaScript avec `node --check components/set-editor.js && node --check ui-session-execution-edit.js`, qui a réussi. 
- Vérification rapide des fichiers modifiés pour s’assurer que les fonctions visées et les classes CSS ont bien été mises à jour (non visuel).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e120dd90a083329c2d4d8f2fad4cb2)