### PR TITLE
Harmonize set-entry row container styling with session exercise blocks

### DIFF
--- a/style.css
+++ b/style.css
@@ -2299,6 +2299,20 @@ textarea:focus{
   align-items: stretch;
 }
 
+.routine-set-row,
+.exec-set-row{
+  border: 1px solid var(--panelBord);
+  border-radius: 10px;
+  padding: 2px 4px;
+  background: color-mix(in srgb, var(--panelBord) 20%, transparent);
+}
+
+.routine-set-row[data-rpe],
+.exec-set-row[data-rpe]{
+  background: color-mix(in srgb, var(--rpe-bg) 35%, transparent);
+  border-color: color-mix(in srgb, var(--rpe-border) 50%, var(--panelBord));
+}
+
 .exec-row .exec-reps-cell{
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -397,6 +397,7 @@
         };
 
         const syncRowTone = () => {
+            applyRpeTone(row, value.rpe);
             applyRpeTone(repsInput, value.rpe);
             applyRpeTone(weightInput, value.rpe);
         };

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1114,6 +1114,7 @@
         };
 
         const syncRowTone = () => {
+            applyRpeTone(row, value.rpe);
             applyRpeTone(repsInput, value.rpe);
             applyRpeTone(weightInput, value.rpe);
             applyRpeTone(rpeInput, value.rpe);


### PR DESCRIPTION
### Motivation
- Make the set-entry lines (séance & routine) visually match the session exercise blocks by adding a container-level background and border so the row feels less “too light” compared to the rest of the session UI.

### Description
- Add shared CSS for `.routine-set-row` and `.exec-set-row` with border, rounded corners, padding and a subtle background fill in `style.css` to visually group the set row contents.
- Add RPE-aware container tinting by styling `[data-rpe]` on the row containers so the entire row receives the RPE tone (background and border color) in `style.css`.
- Update `ui-session-execution-edit.js` to apply the RPE tone to the row container by calling `applyRpeTone(row, value.rpe)` in the row `syncRowTone` logic.
- Update `ui-routine-execution-edit.js` to also apply `applyRpeTone(row, value.rpe)` so routine set rows receive the same row-level tinting as session rows.

### Testing
- Ran syntax checks `node --check ui-session-execution-edit.js` which succeeded.
- Ran syntax checks `node --check ui-routine-execution-edit.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e127354d9483329e5b11388cad5a39)