### PR TITLE
Consolidate RPE tone application to rest container in editors

### DIFF
--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -400,6 +400,7 @@
             applyRpeTone(row, value.rpe);
             applyRpeTone(repsInput, value.rpe);
             applyRpeTone(weightInput, value.rpe);
+            applyRpeTone(restContainer, value.rpe);
         };
 
         const updatePreview = (source, { persist = true } = {}) => {

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1117,9 +1117,6 @@
             applyRpeTone(row, value.rpe);
             applyRpeTone(repsInput, value.rpe);
             applyRpeTone(weightInput, value.rpe);
-            applyRpeTone(rpeInput, value.rpe);
-            applyRpeTone(restMinutesInput, value.rpe);
-            applyRpeTone(restSecondsInput, value.rpe);
             applyRpeTone(restContainer, value.rpe);
         };
 


### PR DESCRIPTION
### Motivation
- Ensure the rest UI element receives RPE-based visual tone and avoid applying tone redundantly to individual inputs in the session editor.

### Description
- Add `applyRpeTone(restContainer, value.rpe)` in `ui-routine-execution-edit.js` so the rest control is tinted by RPE.
- Remove `applyRpeTone` calls targeting `rpeInput`, `restMinutesInput`, and `restSecondsInput` in `ui-session-execution-edit.js` and rely on `restContainer` for rest tinting.
- Keep existing value parsing and preview persistence logic unchanged while consolidating the UI tint target.

### Testing
- Ran the project's automated test suite with `npm test`, and all tests passed. 
- Ran the linter with `npm run lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e132e134548332a72d7b7789eff20a)