### PR TITLE
Add inline keyboard key feedback and top spacing

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -630,6 +630,15 @@
         actionsGrid.className = 'inline-keyboard-actions';
         content.appendChild(actionsGrid);
 
+        const keyFeedback = document.createElement('div');
+        keyFeedback.className = 'inline-keyboard-feedback';
+        keyFeedback.setAttribute('aria-live', 'polite');
+        keyFeedback.setAttribute('role', 'status');
+        keyFeedback.hidden = true;
+        content.appendChild(keyFeedback);
+
+        let keyFeedbackTimer = null;
+
         const layouts = {
             default: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     '.',   '0',  'del'],
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
@@ -681,10 +690,39 @@
                 }
                 button.addEventListener('click', (event) => {
                     event.preventDefault();
+                    showKeyFeedback(key);
                     handleInput(key);
                 });
                 grid.appendChild(button);
             });
+        };
+
+        const formatKeyFeedback = (key) => {
+            const map = {
+                del: '⌫ Effacer',
+                up: '⬆️ Monter',
+                down: '⬇️ Descendre',
+                trash: '🗑️ Supprimer',
+                ':': ': Séparateur temps',
+                '-': 'RPE vide'
+            };
+            return map[key] || key;
+        };
+
+        const showKeyFeedback = (key) => {
+            if (!key || !active) {
+                return;
+            }
+            if (keyFeedbackTimer) {
+                window.clearTimeout(keyFeedbackTimer);
+            }
+            keyFeedback.textContent = `Touche : ${formatKeyFeedback(key)}`;
+            keyFeedback.hidden = false;
+            keyFeedback.setAttribute('data-visible', 'true');
+            keyFeedbackTimer = window.setTimeout(() => {
+                keyFeedback.removeAttribute('data-visible');
+                keyFeedback.hidden = true;
+            }, 650);
         };
 
         const renderActions = (actions = []) => {
@@ -744,6 +782,12 @@
             document.body?.classList.remove('inline-keyboard-visible');
             document.removeEventListener('pointerdown', handleOutside, true);
             clearPendingOutside();
+            if (keyFeedbackTimer) {
+                window.clearTimeout(keyFeedbackTimer);
+                keyFeedbackTimer = null;
+            }
+            keyFeedback.removeAttribute('data-visible');
+            keyFeedback.hidden = true;
             active?.onClose?.();
             active = null;
         };

--- a/style.css
+++ b/style.css
@@ -2684,6 +2684,7 @@ textarea:focus{
 .inline-keyboard-content{
   display: grid;
   grid-template-columns: 3fr 1fr;
+  margin-top: 8px;
   gap: 10px;
 }
 
@@ -2698,6 +2699,22 @@ textarea:focus{
   display: grid;
   grid-template-rows: repeat(4, 45px);
   gap: 10px;
+}
+
+.inline-keyboard-feedback{
+  grid-column: 1 / -1;
+  min-height: 20px;
+  font-size: 13px;
+  font-weight: var(--fw-strong);
+  color: var(--black);
+  opacity: 0;
+  transform: translateY(-3px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.inline-keyboard-feedback[data-visible="true"]{
+  opacity: 0.85;
+  transform: translateY(0);
 }
 
 .keyboard-spacer{


### PR DESCRIPTION
### Motivation
- Provide immediate visual (and accessible) feedback when a custom inline keyboard key is pressed so the user knows which key was activated.
- Add a small top margin above the first keyboard buttons to reduce accidental taps behind the keyboard.

### Description
- Inserted a transient feedback element into the inline keyboard DOM in `components/set-editor.js` (`keyFeedback` with `aria-live="polite"` and `role="status"`).
- Implemented `showKeyFeedback` and `formatKeyFeedback` and wired the feedback display into key click handlers to announce pressed keys (including special keys like `del`, `up`, `down`, `trash`).
- Ensure feedback timer and visible state are cleared on keyboard close to avoid stale UI state in `components/set-editor.js`.
- Added `margin-top: 8px` to `.inline-keyboard-content` and new styles for `.inline-keyboard-feedback` in `style.css` to space the first row and animate/position the feedback.
- Modified files: `components/set-editor.js`, `style.css`.

### Testing
- Ran `node --check components/set-editor.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2199ed2b0833298f95e7f2ee07c46)