### PR TITLE
Align routine set rows with session layout (hide contextual column)

### DIFF
--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -1044,8 +1044,7 @@
                         rpeValue: set?.rpe,
                         onClick: stopAndOpen('rpe')
                     }),
-                    createEmptySetCell({ className: 'session-card-set-cell--goal' }),
-                    createEmptySetCell({ className: 'session-card-set-cell--medal' })
+                    createEmptySetCell({ className: 'session-card-set-cell--goal' })
                 );
                 setsWrapper.appendChild(line);
             });


### PR DESCRIPTION
### Motivation
- Reuse the session screen set-row layout for routine exercises while removing the trailing contextual/placeholder column so routine move rows align with session rows and match the requested visual difference.

### Description
- Removed the extra trailing contextual cell from routine set rows by changing `ui-routine-edit.js` to stop appending the `session-card-set-cell--medal` placeholder so routine cards render with the same columns as session cards.

### Testing
- Ran a syntax check with `node --check ui-routine-edit.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25d6d5a608332bd4ec54a32a46fae)