### PR TITLE
Supprime le feedback texte du clavier inline et assombrit la touche pressée

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -630,14 +630,8 @@
         actionsGrid.className = 'inline-keyboard-actions';
         content.appendChild(actionsGrid);
 
-        const keyFeedback = document.createElement('div');
-        keyFeedback.className = 'inline-keyboard-feedback';
-        keyFeedback.setAttribute('aria-live', 'polite');
-        keyFeedback.setAttribute('role', 'status');
-        keyFeedback.hidden = true;
-        content.appendChild(keyFeedback);
-
-        let keyFeedbackTimer = null;
+        let pressedKeyTimer = null;
+        let pressedKeyButton = null;
 
         const layouts = {
             default: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     '.',   '0',  'del'],
@@ -690,39 +684,32 @@
                 }
                 button.addEventListener('click', (event) => {
                     event.preventDefault();
-                    showKeyFeedback(key);
+                    flashPressedKey(button);
                     handleInput(key);
                 });
                 grid.appendChild(button);
             });
         };
 
-        const formatKeyFeedback = (key) => {
-            const map = {
-                del: '⌫ Effacer',
-                up: '⬆️ Monter',
-                down: '⬇️ Descendre',
-                trash: '🗑️ Supprimer',
-                ':': ': Séparateur temps',
-                '-': 'RPE vide'
-            };
-            return map[key] || key;
-        };
-
-        const showKeyFeedback = (key) => {
-            if (!key || !active) {
+        const flashPressedKey = (button) => {
+            if (!button) {
                 return;
             }
-            if (keyFeedbackTimer) {
-                window.clearTimeout(keyFeedbackTimer);
+            const pressedClass = 'inline-keyboard-key--pressed';
+            if (pressedKeyTimer) {
+                window.clearTimeout(pressedKeyTimer);
             }
-            keyFeedback.textContent = `Touche : ${formatKeyFeedback(key)}`;
-            keyFeedback.hidden = false;
-            keyFeedback.setAttribute('data-visible', 'true');
-            keyFeedbackTimer = window.setTimeout(() => {
-                keyFeedback.removeAttribute('data-visible');
-                keyFeedback.hidden = true;
-            }, 650);
+            if (pressedKeyButton) {
+                pressedKeyButton.classList.remove(pressedClass);
+            }
+            pressedKeyButton = button;
+            button.classList.add(pressedClass);
+            pressedKeyTimer = window.setTimeout(() => {
+                button.classList.remove(pressedClass);
+                if (pressedKeyButton === button) {
+                    pressedKeyButton = null;
+                }
+            }, 120);
         };
 
         const renderActions = (actions = []) => {
@@ -782,12 +769,12 @@
             document.body?.classList.remove('inline-keyboard-visible');
             document.removeEventListener('pointerdown', handleOutside, true);
             clearPendingOutside();
-            if (keyFeedbackTimer) {
-                window.clearTimeout(keyFeedbackTimer);
-                keyFeedbackTimer = null;
+            if (pressedKeyTimer) {
+                window.clearTimeout(pressedKeyTimer);
+                pressedKeyTimer = null;
             }
-            keyFeedback.removeAttribute('data-visible');
-            keyFeedback.hidden = true;
+            pressedKeyButton?.classList.remove('inline-keyboard-key--pressed');
+            pressedKeyButton = null;
             active?.onClose?.();
             active = null;
         };

--- a/style.css
+++ b/style.css
@@ -2701,22 +2701,6 @@ textarea:focus{
   gap: 10px;
 }
 
-.inline-keyboard-feedback{
-  grid-column: 1 / -1;
-  min-height: 20px;
-  font-size: 13px;
-  font-weight: var(--fw-strong);
-  color: var(--black);
-  opacity: 0;
-  transform: translateY(-3px);
-  transition: opacity 120ms ease, transform 120ms ease;
-}
-
-.inline-keyboard-feedback[data-visible="true"]{
-  opacity: 0.85;
-  transform: translateY(0);
-}
-
 .keyboard-spacer{
   height: 0;
   pointer-events: none;
@@ -2806,12 +2790,16 @@ body.inline-keyboard-visible .keyboard-spacer{
 }
 
 .inline-keyboard-key:active{
-  filter: brightness(0.97);
+  filter: brightness(0.9);
   transform: translateY(1px);
 }
 
 .inline-keyboard-key[data-rpe]:active{
-  filter: brightness(0.94);
+  filter: brightness(0.88);
+}
+
+.inline-keyboard-key--pressed{
+  filter: brightness(0.86);
 }
 
 .exec-rest-cell{


### PR DESCRIPTION
### Motivation
- Le feedback textuel affichant `Touche : …` dans le clavier inline était jugé intrusif et doit être retiré au profit d'un retour visuel plus discret.
- L'intention est de garder un retour d'appui clair sans afficher la saisie texte, en assombrissant brièvement la touche cliquée.

### Description
- Supprime la création et l'utilisation de l'élément de feedback textuel (`.inline-keyboard-feedback`) et les fonctions associées (`formatKeyFeedback` / `showKeyFeedback`) dans `components/set-editor.js`.
- Ajoute un mécanisme visuel `flashPressedKey` avec les variables `pressedKeyTimer` et `pressedKeyButton` et applique temporairement la classe `inline-keyboard-key--pressed` à la touche cliquée, avec nettoyage à la fermeture du clavier dans `components/set-editor.js`.
- Supprime le CSS du bloc `.inline-keyboard-feedback` et ajoute `.inline-keyboard-key--pressed` dans `style.css`, ainsi qu'un renforcement des valeurs `brightness` sur l'état actif pour rendre l'assombrissement plus marqué.
- Modifications appliquées aux fichiers `components/set-editor.js` et `style.css`.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check components/set-editor.js` — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25e7c50388332b6e430ff122807fb)