### PR TITLE
Uniformiser les écrans routine avec les écrans séance (suppression de la colonne contextuelle)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1690,6 +1690,14 @@ textarea:focus{
 .exercise-card--full-sets .exercise-card-title-row{
   padding-right: 52px;
 }
+
+.exercise-card--no-context .exercise-card-title-row{
+  padding-right: 0;
+}
+.exercise-card--no-context .list-card__end{
+  display:none;
+}
+
 .exercise-card-stats{
   font-size: 12px;
   line-height: 1.35;
@@ -1791,6 +1799,13 @@ textarea:focus{
   border:1px solid var(--panelBord);
   border-radius:10px;
   background: color-mix(in srgb, var(--panelBord) 20%, transparent);
+}
+.routine-card-sets-row{
+  grid-template-columns:
+    minmax(0, 0.4fr)
+    minmax(0, 1.0fr)
+    minmax(0, 1.0fr)
+    minmax(0, 0.7fr);
 }
 .session-card-sets-row[data-rpe]{
   background: color-mix(in srgb, var(--rpe-bg) 35%, transparent);

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -945,10 +945,9 @@
 
     function renderMoveCard(move) {
         const structure = listCard.createStructure({
-            endClass: 'exercise-card-end--top',
-            cardClass: 'exercise-card--full-sets'
+            cardClass: 'exercise-card--full-sets exercise-card--no-context'
         });
-        const { card, start, body, end } = structure;
+        const { card, start, body } = structure;
         card.dataset.moveId = move.id;
         start.classList.add('list-card__start--solo');
 
@@ -969,19 +968,6 @@
         const statsLine = document.createElement('div');
         statsLine.className = 'exercise-card-stats';
         statsLine.textContent = formatExerciseStatsText(move.sets);
-        const detailsButton = document.createElement('button');
-        detailsButton.type = 'button';
-        detailsButton.className = 'exercise-card-menu-button';
-        detailsButton.textContent = 'ⓘ';
-        detailsButton.setAttribute('aria-label', "Afficher les instructions de l'exercice");
-        detailsButton.addEventListener('click', (event) => {
-            event.stopPropagation();
-            const instructions = typeof move.instructions_routine_exercice === 'string'
-                ? move.instructions_routine_exercice.trim()
-                : '';
-            showDetailsPopover(detailsButton, instructions);
-        });
-        end.appendChild(detailsButton);
         const setsWrapper = document.createElement('div');
         setsWrapper.className = 'session-card-sets';
         renderRoutineCardSets(move, setsWrapper);
@@ -1003,7 +989,7 @@
         if (sets.length) {
             sets.forEach((set, index) => {
                 const line = document.createElement('div');
-                line.className = 'session-card-sets-row';
+                line.className = 'session-card-sets-row routine-card-sets-row';
                 const pos = set?.pos ?? index + 1;
                 const openWithFocus = (field) => {
                     setRoutineScrollTarget(move.id);
@@ -1043,8 +1029,7 @@
                         field: 'rpe',
                         rpeValue: set?.rpe,
                         onClick: stopAndOpen('rpe')
-                    }),
-                    createEmptySetCell({ className: 'session-card-set-cell--goal' })
+                    })
                 );
                 setsWrapper.appendChild(line);
             });


### PR DESCRIPTION
### Motivation
- Rendre l'affichage des routines cohérent avec celui des séances en réutilisant la structure visuelle des cartes de séance pour les blocs d'exercice de routine. 
- Supprimer la colonne contextuelle (bouton d'info / colonne finale) qui n'est pas souhaitée côté routine et simplifier la grille des séries. 
- Ne pas introduire de bouton « ajouter routine » dans le flux d'édition des routines afin de conserver l'expérience demandée.

### Description
- `ui-routine-edit.js` : `renderMoveCard` utilise désormais la variante de carte sans colonne de fin via la classe `exercise-card--no-context`, le bouton d'information latéral (`ⓘ`) a été supprimé et les lignes de séries de routine utilisent la classe dédiée `routine-card-sets-row` sans cellule de « goal ». 
- `style.css` : ajout de règles pour `exercise-card--no-context` pour masquer la zone de fin et ajuster le padding, et ajout de `routine-card-sets-row` définissant une grille à 4 colonnes (`# / Reps / Poids / RPE`). 
- Les modifications concernent principalement les fichiers `ui-routine-edit.js` et `style.css` pour ajuster le DOM rendu et le style des cartes/séries de routine.

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check ui-routine-edit.js`, qui a réussi. 
- Aucun test visuel automatisé n'a été exécuté dans cet environnement (vérifications manuelles / capture écran non disponibles ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2605765808332b3cf2de9777cde45)