### PR TITLE
Normalize moveId and compare IDs as strings in routine move editor

### DIFF
--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -46,7 +46,7 @@
             return;
         }
         state.routineId = routineId;
-        state.moveId = moveId;
+        state.moveId = moveId == null ? null : String(moveId);
         state.callerScreen = callerScreen;
         state.replaceCallerScreen = 'screenRoutineMoveEdit';
         if (Number.isInteger(focusSetIndex) && focusSetIndex >= 0) {
@@ -75,7 +75,7 @@
             return;
         }
         state.routineId = routineId;
-        state.moveId = moveId;
+        state.moveId = moveId == null ? null : String(moveId);
         state.callerScreen = callerScreen;
         state.replaceCallerScreen = callerScreen;
         state.pendingFocus = null;
@@ -1131,7 +1131,11 @@
         if (!state.routine) {
             return null;
         }
-        return state.routine.moves?.find((move) => move.id === state.moveId) || null;
+        const targetId = state.moveId == null ? null : String(state.moveId);
+        if (!targetId) {
+            return null;
+        }
+        return state.routine.moves?.find((move) => String(move.id) === targetId) || null;
     }
 
     function returnToCaller() {


### PR DESCRIPTION
### Motivation
- The routine set-entry screen could fail to open when the move identifier coming from the DOM (a string) did not strictly match the stored move ID type (e.g. number), causing the move lookup to return null.

### Description
- Normalize `moveId` to a string in `A.openRoutineMoveEdit` and `A.openRoutineMoveMeta` by assigning `state.moveId = moveId == null ? null : String(moveId)`.
- Make `findMove()` robust by comparing IDs as strings (`String(move.id) === targetId`) so moves with non-string stored IDs are found correctly (file: `ui-routine-execution-edit.js`).

### Testing
- Ran `node --check ui-routine-execution-edit.js` which completed without errors.
- Earlier smoke checks `node --check ui-routine-execution-edit.js && node --check ui-routine-edit.js && node --check components/set-editor.js` also passed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2662c34c0833281c41e71f2c76683)