### PR TITLE
Aligner l'ouverture des blocs exercice de routine sur la séance

### DIFF
--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -956,11 +956,15 @@
         name.textContent = move.exerciseName || 'Exercice';
         name.addEventListener('click', (event) => {
             event.stopPropagation();
-            if (!move.exerciseId) {
+            if (!move?.id) {
                 return;
             }
             setRoutineScrollTarget(move.id);
-            void A.openExerciseRead({ currentId: move.exerciseId, callerScreen: 'screenRoutineEdit' });
+            void A.openRoutineMoveEdit({
+                routineId: state.routineId,
+                moveId: move.id,
+                callerScreen: 'screenRoutineEdit'
+            });
         });
         const titleRow = document.createElement('div');
         titleRow.className = 'exercise-card-title-row';


### PR DESCRIPTION
### Motivation
- Garantir que le clic sur le nom d'un exercice dans l'écran d'édition de routine ouvre l'éditeur de séries de la même manière que les blocs exercice de la séance, en conservant le ciblage/restauration du scroll.

### Description
- Remplacé l'ouverture vers la lecture d'exercice par un appel à `A.openRoutineMoveEdit({ routineId, moveId, callerScreen: 'screenRoutineEdit' })` après `setRoutineScrollTarget(move.id)` dans le gestionnaire de clic du nom d'exercice (fichier `ui-routine-edit.js`).

### Testing
- Vérification syntaxique exécutée avec `node --check ui-routine-edit.js` et sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e325cfc26c8332b95299963f59a28f)