### PR TITLE
Fix screenRoutineMoveEdit not appearing when opened from routine

### DIFF
--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -1288,7 +1288,14 @@
             element.hidden = key !== target;
         });
         if (screenRoutineMoveEdit) {
-            screenRoutineMoveEdit.classList.remove('is-active', 'is-closing');
+            if (target === 'screenRoutineMoveEdit') {
+                screenRoutineMoveEdit.classList.remove('is-closing');
+                requestAnimationFrame(() => {
+                    screenRoutineMoveEdit.classList.add('is-active');
+                });
+            } else {
+                screenRoutineMoveEdit.classList.remove('is-active', 'is-closing');
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Opening `screenRoutineMoveEdit` from a routine could show the custom keyboard while the sheet stayed translated off-screen because `is-active` was never added, leaving the sheet hidden.
- The opening behavior should match `screenExecEdit` so the sheet animation runs reliably when the screen is shown.

### Description
- Update `switchScreen` in `ui-routine-execution-edit.js` to explicitly activate the sheet when `target === 'screenRoutineMoveEdit'` by removing `is-closing` and adding `is-active` inside a `requestAnimationFrame` callback.
- Preserve the previous cleanup path when leaving the screen by removing both `is-active` and `is-closing` for non-target cases.
- This change ensures the CSS transition (`transform: translateY(...)`) is applied after unhide so the sheet slides up visibly.

### Testing
- Ran a syntax/parse check with `node --check ui-routine-execution-edit.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38ac84a688332868fd9b0a910a7d5)