### PR TITLE
Align routine move editor with session edit flow and tabbed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -591,24 +591,30 @@
 <!-- ==================== -->
 
 <!-- ========== 3.1.1 Routine > modification des séries  ========== -->
-<section id="screenRoutineMoveEdit" class="screen screen-sheet-overlay" hidden>
+<section id="screenRoutineMoveEdit" class="screen" hidden>
 
-    <div class="screen-sheet">
-        <header class="header">
-            <div class="header-left">
-                <button id="routineMoveBack" class="btn ghost" title="Retour">◀︎</button>
-            </div>
+    <header class="header">
+        <div class="header-left">
+            <button id="routineMoveBack" class="btn ghost" title="Retour">◀︎</button>
+        </div>
 
-            <div class="header-center">
-                <div class="title" id="routineMoveTitle">Exercice</div>
-            </div>
+        <div class="header-center">
+            <div class="title" id="routineMoveTitle">Exercice</div>
+        </div>
 
-            <div class="header-right">
-            </div>
-        </header>
+        <div class="header-right">
+        </div>
+    </header>
 
-        <main class="content">
+    <main class="content">
+        <div id="routineMoveTabs" class="stats-toggle exercise-read-tabs" role="tablist" aria-label="Détails exercice de routine">
+            <button type="button" class="stats-toggle-btn is-active" data-tab="routine" role="tab" aria-selected="true">Routine</button>
+            <button type="button" class="stats-toggle-btn" data-tab="exec" role="tab" aria-selected="false">Exécution</button>
+            <button type="button" class="stats-toggle-btn" data-tab="history" role="tab" aria-selected="false">Histo</button>
+            <button type="button" class="stats-toggle-btn" data-tab="stats" role="tab" aria-selected="false">Stats</button>
+        </div>
 
+        <section id="routineMoveTabRoutine" class="exercise-read-tab" data-tab-panel="routine">
             <div class="exec-grid exec-head routine-set-grid routine-set-head">
                 <div class="lbl">#</div>
                 <div class="lbl">Reps</div>
@@ -622,9 +628,18 @@
             <div class="add-actions">
                 <button id="routineMoveAddSet" class="btn cta full">+ Ajouter une série</button>
             </div>
-            <div class="keyboard-spacer" aria-hidden="true"></div>
-        </main>
-    </div>
+        </section>
+        <section id="routineMoveTabExec" class="exercise-read-tab" data-tab-panel="exec" hidden>
+            <div id="routineMoveExecPanel"></div>
+        </section>
+        <section id="routineMoveTabHistory" class="exercise-read-tab" data-tab-panel="history" hidden>
+            <div id="routineMoveHistoryPanel"></div>
+        </section>
+        <section id="routineMoveTabStats" class="exercise-read-tab" data-tab-panel="stats" hidden>
+            <div id="routineMoveStatsPanel"></div>
+        </section>
+        <div class="keyboard-spacer" aria-hidden="true"></div>
+    </main>
 
 </section>
 <!-- ==================== -->

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -12,7 +12,8 @@
         routine: null,
         pendingSave: null,
         pendingFocus: null,
-        replaceCallerScreen: 'screenRoutineMoveEdit'
+        replaceCallerScreen: 'screenRoutineMoveEdit',
+        activeTab: 'routine'
     };
     const instructionsState = {
         move: null,
@@ -28,6 +29,7 @@
     document.addEventListener('DOMContentLoaded', () => {
         ensureRefs();
         wireNavigation();
+        wireTabs();
         wireActions();
         wireMetaDialog();
         wireDetailsDialog();
@@ -65,7 +67,10 @@
 
         const { routineMoveTitle } = assertRefs();
         routineMoveTitle.textContent = move.exerciseName || 'Exercice';
+        state.activeTab = 'routine';
+        resetRoutineMoveSecondaryTabs();
         renderSets();
+        await setRoutineMoveActiveTab(state.activeTab);
         switchScreen('screenRoutineMoveEdit');
     };
 
@@ -115,6 +120,14 @@
         refs.screenData = document.getElementById('screenData');
         refs.routineMoveTitle = document.getElementById('routineMoveTitle');
         refs.routineMoveSets = document.getElementById('routineMoveSets');
+        refs.routineMoveTabs = document.getElementById('routineMoveTabs');
+        refs.routineMoveTabRoutine = document.getElementById('routineMoveTabRoutine');
+        refs.routineMoveTabExec = document.getElementById('routineMoveTabExec');
+        refs.routineMoveTabHistory = document.getElementById('routineMoveTabHistory');
+        refs.routineMoveTabStats = document.getElementById('routineMoveTabStats');
+        refs.routineMoveExecPanel = document.getElementById('routineMoveExecPanel');
+        refs.routineMoveHistoryPanel = document.getElementById('routineMoveHistoryPanel');
+        refs.routineMoveStatsPanel = document.getElementById('routineMoveStatsPanel');
         refs.routineMoveBack = document.getElementById('routineMoveBack');
         refs.routineMoveDone = document.getElementById('routineMoveDone');
         refs.routineMoveAddSet = document.getElementById('routineMoveAddSet');
@@ -147,6 +160,14 @@
             'screenRoutineMoveEdit',
             'routineMoveTitle',
             'routineMoveSets',
+            'routineMoveTabs',
+            'routineMoveTabRoutine',
+            'routineMoveTabExec',
+            'routineMoveTabHistory',
+            'routineMoveTabStats',
+            'routineMoveExecPanel',
+            'routineMoveHistoryPanel',
+            'routineMoveStatsPanel',
             'routineMoveBack',
             'routineMoveAddSet',
             'routineMoveDelete',
@@ -177,6 +198,93 @@
         routineMoveDone?.addEventListener('click', () => {
             inlineKeyboard?.detach?.();
             returnToCaller();
+        });
+    }
+
+    function wireTabs() {
+        const { routineMoveTabs } = assertRefs();
+        routineMoveTabs?.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-tab]');
+            if (!button) {
+                return;
+            }
+            const nextTab = button.dataset.tab;
+            void setRoutineMoveActiveTab(nextTab);
+        });
+    }
+
+    async function setRoutineMoveActiveTab(tab) {
+        const {
+            routineMoveTabs,
+            routineMoveTabRoutine,
+            routineMoveTabExec,
+            routineMoveTabHistory,
+            routineMoveTabStats
+        } = assertRefs();
+        const nextTab = ['routine', 'exec', 'history', 'stats'].includes(tab) ? tab : 'routine';
+        state.activeTab = nextTab;
+
+        routineMoveTabs.querySelectorAll('[data-tab]').forEach((button) => {
+            const isActive = button.dataset.tab === nextTab;
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        });
+        routineMoveTabRoutine.hidden = nextTab !== 'routine';
+        routineMoveTabExec.hidden = nextTab !== 'exec';
+        routineMoveTabHistory.hidden = nextTab !== 'history';
+        routineMoveTabStats.hidden = nextTab !== 'stats';
+
+        await renderRoutineMoveTab(nextTab);
+    }
+
+    async function renderRoutineMoveTab(tab, options = {}) {
+        const { force = false } = options;
+        const move = findMove();
+        if (!move?.exerciseId) {
+            return;
+        }
+        const { routineMoveExecPanel, routineMoveHistoryPanel, routineMoveStatsPanel } = assertRefs();
+        if (tab === 'exec' && (force || !routineMoveExecPanel.dataset.loaded)) {
+            routineMoveExecPanel.innerHTML = '';
+            const exercise = await db.get('exercises', move.exerciseId);
+            if (exercise && typeof A.renderExerciseReadExecPanel === 'function') {
+                A.renderExerciseReadExecPanel({
+                    exercise,
+                    container: routineMoveExecPanel,
+                    originLabel: 'Routine'
+                });
+            }
+            routineMoveExecPanel.dataset.loaded = '1';
+        }
+        if (tab === 'history' && (force || !routineMoveHistoryPanel.dataset.loaded)) {
+            routineMoveHistoryPanel.innerHTML = '';
+            const exercise = await db.get('exercises', move.exerciseId);
+            if (exercise && typeof A.renderExerciseReadHistoryPanel === 'function') {
+                await A.renderExerciseReadHistoryPanel({
+                    exercise,
+                    exerciseId: move.exerciseId,
+                    container: routineMoveHistoryPanel
+                });
+            }
+            routineMoveHistoryPanel.dataset.loaded = '1';
+        }
+        if (tab === 'stats' && (force || !routineMoveStatsPanel.dataset.loaded)) {
+            routineMoveStatsPanel.innerHTML = '';
+            if (typeof A.renderExerciseReadStatsPanel === 'function') {
+                await A.renderExerciseReadStatsPanel({
+                    exerciseId: move.exerciseId,
+                    container: routineMoveStatsPanel
+                });
+            }
+            routineMoveStatsPanel.dataset.loaded = '1';
+        }
+    }
+
+    function resetRoutineMoveSecondaryTabs() {
+        const { routineMoveExecPanel, routineMoveHistoryPanel, routineMoveStatsPanel } = assertRefs();
+        [routineMoveExecPanel, routineMoveHistoryPanel, routineMoveStatsPanel].forEach((panel) => {
+            panel.innerHTML = '';
+            delete panel.dataset.loaded;
         });
     }
 


### PR DESCRIPTION
### Motivation
- The routine move editor should open and behave like the session exercise editor so users get the same simple opening flow from the exercise list and the same information layout. 
- The routine series edit screen must use the same 4-tab structure as session edit (`Routine`, `Exécution`, `Histo`, `Stats`) and avoid the translucent sheet overlay so it appears as a normal full screen. 

### Description
- Converted `screenRoutineMoveEdit` from a sheet overlay to a full-screen section and added a 4-tab structure in `index.html` with panels `routineMoveTabRoutine`, `routineMoveTabExec`, `routineMoveTabHistory`, and `routineMoveTabStats` and corresponding containers. 
- Added tab state to the routine move editor (`state.activeTab`) and wired tab clicks via `wireTabs()` that call `setRoutineMoveActiveTab()` in `ui-routine-execution-edit.js`. 
- Implemented `renderRoutineMoveTab()` with lazy rendering that reuses existing helpers (`A.renderExerciseReadExecPanel`, `A.renderExerciseReadHistoryPanel`, `A.renderExerciseReadStatsPanel`) to populate the secondary tabs on demand. 
- Reset the secondary tab caches on open (`resetRoutineMoveSecondaryTabs()`), initialize the editor on the `routine` tab, and keep existing set-editing behavior in the `Routine` tab; modified DOM refs accordingly. 

### Testing
- Ran `node --check ui-routine-execution-edit.js` which succeeded. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3911a2b508332a43358ea21de7cc2)