### PR TITLE
Include sessions from recent months when computing recent exercise counts

### DIFF
--- a/ui-exercises-list.js
+++ b/ui-exercises-list.js
@@ -88,7 +88,7 @@
             return;
         }
 
-        const recentCounts = await getRecentExerciseCounts(12);
+        const recentCounts = await getRecentExerciseCounts({ sessionLimit: 12, monthLimit: 6 });
         const recentExercises = [];
         const otherExercises = [];
 
@@ -213,16 +213,22 @@
         return map;
     }
 
-    async function getRecentExerciseCounts(limit = 12) {
+    async function getRecentExerciseCounts(options = {}) {
+        const { sessionLimit = 12, monthLimit = 6 } = options;
         const counts = new Map();
         const dates = await db.listSessionDates();
+        const now = new Date();
+        const sixMonthsAgo = new Date(now);
+        sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - monthLimit);
+        const sixMonthsAgoKey = toDateKey(sixMonthsAgo);
         const sortedDates = dates
             .map((entry) => entry?.date)
             .filter(Boolean)
-            .sort((a, b) => String(b).localeCompare(String(a)))
-            .slice(0, limit);
+            .sort((a, b) => String(b).localeCompare(String(a)));
 
-        for (const date of sortedDates) {
+        const selectedDates = sortedDates.filter((date, index) => index < sessionLimit || String(date) >= sixMonthsAgoKey);
+
+        for (const date of selectedDates) {
             const session = await db.getSession(date);
             if (!Array.isArray(session?.exercises)) {
                 continue;
@@ -238,6 +244,13 @@
             });
         }
         return counts;
+    }
+
+    function toDateKey(date) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
     }
 
     function appendExerciseSection(container, label, exercises, options = {}) {


### PR DESCRIPTION
### Motivation
- Make the “recent exercises” list more relevant by considering both a fixed number of most-recent sessions and any sessions within a recent month window.
- Allow callers to configure the session and month limits instead of a single positional `limit` parameter.
- Improve date handling for reliable comparisons when filtering session dates.

### Description
- Changed `getRecentExerciseCounts` signature from `limit` to `options` and added `sessionLimit` and `monthLimit` parameters with defaults (`{ sessionLimit: 12, monthLimit: 6 }`).
- Updated call site to `getRecentExerciseCounts({ sessionLimit: 12, monthLimit: 6 })` and adjusted the date-selection logic to include dates that are either within the most recent `sessionLimit` sessions or on/after the computed cutoff date based on `monthLimit`.
- Added `toDateKey` helper to format dates as `YYYY-MM-DD` for stable string comparisons and refactored session filtering and counting to iterate only selected dates.
- Preserved de-duplication of exercise counts within a session and sorting/grouping logic used to render recent vs other exercises.

### Testing
- Ran unit tests via `npm test` and observed no regressions in the test suite.
- Ran linting via `npm run lint` which completed successfully.
- Performed a production build via `npm run build` which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21b0b0ef48332b55b3dd1c4dc2bb9)