### PR TITLE
Fix crash in inline set editor stepper label formatter

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -1330,6 +1330,14 @@
             return current <= 30 ? 1 : 2.5;
         };
 
+        const formatDeltaValue = (value) => {
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric)) {
+                return '0';
+            }
+            return Number.isInteger(numeric) ? String(numeric) : numeric.toFixed(2).replace(/\.?0+$/, '');
+        };
+
         const formatStepperDelta = (deltaValue) => {
             const numeric = Number(deltaValue);
             if (!Number.isFinite(numeric) || numeric === 0) {
@@ -1337,7 +1345,7 @@
             }
             const abs = Math.abs(numeric);
             const sign = numeric > 0 ? '+' : '−';
-            return `${sign}${formatDecimal(abs)}`;
+            return `${sign}${formatDeltaValue(abs)}`;
         };
 
         const refreshStepperLabels = (state) => {


### PR DESCRIPTION
### Motivation
- A recent change formatted inline stepper labels using `formatDecimal(...)` which is not available in the inline editor scope, causing a runtime error that blocked the inline keyboard from opening when set input cells are clicked. 
- The goal is to restore normal inline editing behavior while keeping adaptive weight step labels intact.

### Description
- Added a local helper `formatDeltaValue` and replaced the out-of-scope `formatDecimal` call inside `formatStepperDelta` with `formatDeltaValue` to avoid the runtime error. 
- Preserved the adaptive step logic via `getWeightDeltaStep` and continued to use `refreshStepperLabels` after state changes so labels reflect the current weight. 
- `formatDeltaValue` formats integers without decimals and trims trailing zeros for fractional values to keep labels compact (e.g. `+1`, `+2.5`).

### Testing
- Ran `node --check components/set-editor.js` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65defeb148332b421c5fde34981a0)