### PR TITLE
Align routine set-entry inline keyboard with session keyboard

### DIFF
--- a/style.css
+++ b/style.css
@@ -2698,12 +2698,13 @@ textarea:focus{
 
 .inline-keyboard-content{
   display: grid;
-  grid-template-columns: 3fr 1fr;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   margin-top: 8px;
   gap: 10px;
 }
 
 .inline-keyboard-grid{
+  grid-column: span 3;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-auto-rows: 45px;
@@ -2711,6 +2712,7 @@ textarea:focus{
 }
 
 .inline-keyboard-actions{
+  grid-column: span 1;
   display: grid;
   grid-template-rows: repeat(4, 45px);
   gap: 10px;

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -544,7 +544,7 @@
             return [
                 toggleAction,
                 {
-                    label: 'planifier',
+                    label: 'prévu',
                     className: 'inline-keyboard-action--muted',
                     onClick: async () => {
                         await applySetEditorResult(currentIndex, {
@@ -552,11 +552,11 @@
                             weight: value.weight,
                             rpe: value.rpe,
                             rest: value.rest
-                        });
+                        }, { done: false });
                     }
                 },
                 {
-                    label: 'enregistrer',
+                    label: 'fait',
                     className: 'inline-keyboard-action--emphase',
                     onClick: async () => {
                         await applySetEditorResult(currentIndex, {
@@ -564,7 +564,8 @@
                             weight: value.weight,
                             rpe: value.rpe,
                             rest: value.rest
-                        });
+                        }, { done: true });
+                        startTimer(value.rest, { setId: set.id, setIndex: currentIndex });
                     }
                 },
                 {


### PR DESCRIPTION
### Motivation
- Harmonize the routine inline keyboard with the session set-entry keyboard so labels and behaviors match the session flow. 
- Fix the keyboard layout so the four columns of buttons appear with equal width and the right action column no longer looks larger.

### Description
- Updated `ui-routine-execution-edit.js` to replace the right-side action labels with the session equivalents and to adjust their behavior: the actions are now toggle, `prévu`, `fait`, and `fermer`. 
- Changed the `prévu` action to save with `{ done: false }` and the `fait` action to save with `{ done: true }` and to call `startTimer(value.rest, { setId, setIndex })` after saving. 
- Adjusted `style.css` keyboard layout so `.inline-keyboard-content` uses `grid-template-columns: repeat(4, minmax(0, 1fr))`, the numeric keypad block spans 3 columns, and the action block spans 1 column to produce four equal-width columns visually. 
- Modified the keyboard DOM grid placement classes (`.inline-keyboard-grid` and `.inline-keyboard-actions`) accordingly to preserve the numeric/action arrangement.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7afa3d3f88332ba0fc552ecdf2091)