### PR TITLE
Remove 'fait' action from routine inline keyboard

### DIFF
--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -556,19 +556,6 @@
                     }
                 },
                 {
-                    label: 'fait',
-                    className: 'inline-keyboard-action--emphase',
-                    onClick: async () => {
-                        await applySetEditorResult(currentIndex, {
-                            reps: value.reps,
-                            weight: value.weight,
-                            rpe: value.rpe,
-                            rest: value.rest
-                        }, { done: true });
-                        startTimer(value.rest, { setId: set.id, setIndex: currentIndex });
-                    }
-                },
-                {
                     label: 'fermer\n▼',
                     className: 'inline-keyboard-action--close'
                 }


### PR DESCRIPTION
### Motivation
- Remove the `fait` action from the routine execution inline keyboard so the custom keyboard only exposes the intended actions (toggle mode, `prévu`, and close).

### Description
- Deleted the `fait` action object from `buildKeyboardActions` in `ui-routine-execution-edit.js`, keeping only the toggle action, the `prévu` action, and the close action.

### Testing
- Ran code inspection commands (`rg` + viewing the updated `ui-routine-execution-edit.js`) to confirm the `fait` action no longer appears in the inline keyboard actions and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b125f564833295f23c09a0df1ade)