### PR TITLE
Keep inline keyboard in timer mode after marking set done; add timer layout

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -638,10 +638,19 @@
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
+            timer:   [null, null, null, null,  null, null, null,   null,  null,    null,  'done', 'close'],
             edit:    ['up', null, null, 'down', null, 'trash', null, null, null]
         };
 
-        const resolveLayout = (layout, mode) => (mode === 'edit' ? 'edit' : layout || 'default');
+        const resolveLayout = (layout, mode) => {
+            if (mode === 'edit') {
+                return 'edit';
+            }
+            if (mode === 'timer') {
+                return 'timer';
+            }
+            return layout || 'default';
+        };
 
         const renderKeys = (layout, mode) => {
             grid.innerHTML = '';
@@ -661,7 +670,9 @@
                     del: '⌫',
                     up: '⬆️',
                     down: '⬇️',
-                    trash: '🗑️'
+                    trash: '🗑️',
+                    done: 'fait',
+                    close: 'fermer\n▼'
                 };
                 const isSplitTimeToggle = key === ':' && layout === 'time' && active?.splitTimeField;
                 if (isSplitTimeToggle) {
@@ -678,6 +689,12 @@
                 if (key === 'trash') {
                     button.dataset.tall = 'true';
                     button.classList.add('inline-keyboard-key--danger');
+                }
+                if (key === 'done') {
+                    button.classList.add('inline-keyboard-action--emphase');
+                }
+                if (key === 'close') {
+                    button.classList.add('inline-keyboard-action--close');
                 }
                 if (layout === 'rpe' && key !== '-') {
                     button.dataset.rpe = key;
@@ -880,6 +897,10 @@
 
         const handleInput = (key) => {
             if (!active) {
+                return;
+            }
+            if (key === 'done' || key === 'close') {
+                handleClose();
                 return;
             }
             if (typeof active.onKey === 'function') {

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1147,6 +1147,9 @@
         };
 
         const buildKeyboardActions = (mode = 'input') => {
+            if (mode === 'timer') {
+                return [];
+            }
             const isEdit = mode === 'edit';
             const toggleAction = {
                 icon: isEdit ? '🔢' : '…',
@@ -1171,6 +1174,7 @@
                 {
                     label: 'fait',
                     className: 'inline-keyboard-action--emphase',
+                    close: false,
                     onClick: async () => {
                         await applySetEditorResult(
                             currentIndex,
@@ -1178,6 +1182,7 @@
                             { done: true }
                         );
                         startTimer(value.rest, { setId: set.id, setIndex: currentIndex });
+                        inlineKeyboard?.setMode?.('timer');
                     }
                 },
                 {


### PR DESCRIPTION
### Motivation
- Corriger le comportement observé lors de la saisie de séries en séance où le bouton « fait » ouvrait une version timer du clavier avec la grille 12 touches mais sans comportement attendu. 
- Garder le clavier visible en mode timer après avoir marqué une série comme faite pour permettre un affichage de type minuteur (la majorité des touches restent intentionnellement vides). 

### Description
- Ajout d'un nouveau layout `timer` dans `components/set-editor.js` avec une grille 12 touches majoritairement vides et deux touches actives `done` et `close`. 
- Étendu le résolveur de layout (`resolveLayout`) pour prendre en charge explicitement le mode `timer`. 
- Gestion explicite des touches `done` et `close` dans `handleInput` pour fermer le clavier quand elles sont pressées, et ajout de classes visuelles pour ces touches. 
- Dans `ui-session-execution-edit.js`, modifié `buildKeyboardActions` pour que l'action `fait` n'appelle plus la fermeture du clavier, démarre le timer et bascule le clavier en mode `timer`, et pour que les actions latérales soient masquées quand le clavier est en `timer` mode. 

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check components/set-editor.js` réussie. 
- Exécution de la vérification syntaxique JavaScript avec `node --check ui-session-execution-edit.js` réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b4a82804833281ea3cda4c1c85d1)