### PR TITLE
Keep inline custom keyboard in timer mode when marking set as done

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1176,6 +1176,7 @@
                     className: 'inline-keyboard-action--emphase',
                     close: false,
                     onClick: async () => {
+                        inlineKeyboard?.setMode?.('timer');
                         await applySetEditorResult(
                             currentIndex,
                             { reps: value.reps, weight: value.weight, rpe: value.rpe, rest: value.rest },


### PR DESCRIPTION
### Motivation
- Prevent the inline custom keyboard from closing when the user taps the "fait" action for a session set so the keyboard shows the timer layout instead of disappearing during asynchronous state updates.

### Description
- Immediately call `inlineKeyboard?.setMode?.('timer')` before awaiting `applySetEditorResult(...)` in `ui-session-execution-edit.js` so the keyboard switches to `timer` mode reliably, while keeping the post-save `setMode('timer')` call as a safeguard.

### Testing
- Edited and applied the change in `ui-session-execution-edit.js` and committed it (`git add` + `git commit`) and inspected the modified lines to verify the new call site, and no automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8968b3f548332af41e73c81a5d06d)