### PR TITLE
Fix custom keyboard "fait" action closing instead of switching to timer mode

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1180,7 +1180,7 @@
                         await applySetEditorResult(
                             currentIndex,
                             { reps: value.reps, weight: value.weight, rpe: value.rpe, rest: value.rest },
-                            { done: true }
+                            { done: true, render: false }
                         );
                         startTimer(value.rest, { setId: set.id, setIndex: currentIndex });
                         inlineKeyboard?.setMode?.('timer');


### PR DESCRIPTION
### Motivation
- Pressing the inline keyboard action "fait" should mark the set done and put the keyboard into timer mode, but the immediate full re-render tore down the inline keyboard and caused it to close instead of switching to `timer` mode.

### Description
- In `ui-session-execution-edit.js` the `fait` action now calls `applySetEditorResult(..., { done: true, render: false })` instead of `{ done: true }`, preventing an immediate full render so the current inline keyboard instance can remain and receive the `setMode('timer')` transition.

### Testing
- No automated tests were run for this change (no test coverage was added); the fix is a small behavior change confined to the inline set editor flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d77f3ef8833295f796559a1af204)