### PR TITLE
Réorganise le clavier custom en modes édition et timer

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -639,8 +639,8 @@
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
-            timer:   [null, null, null, null,  null, null, null,   null,  null,    null,  'done', 'close'],
-            edit:    ['up', null, null, 'down', null, 'trash', null, null, null]
+            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10', null, null, null, null, 'done', 'close'],
+            edit:    ['trash', 'up', null, null, null, null, null, 'down', null]
         };
 
         const resolveLayout = (layout, mode) => {
@@ -673,12 +673,21 @@
                     down: '⬇️',
                     trash: '🗑️',
                     done: 'fait',
-                    close: 'fermer\n▼'
+                    close: 'fermer\n▼',
+                    timerDisplay: '0:00',
+                    timerReset: 'réinitialiser',
+                    timerToggle: 'play'
                 };
                 const isSplitTimeToggle = key === ':' && layout === 'time' && active?.splitTimeField;
+                const isTimerDisplay = key === 'timerDisplay' && active?.mode === 'timer';
+                const isTimerToggle = key === 'timerToggle' && active?.mode === 'timer';
                 if (isSplitTimeToggle) {
                     const side = active?.timeField;
                     button.textContent = side === 'minutes' ? '▸:' : side === 'seconds' ? ':◂' : ':';
+                } else if (isTimerDisplay) {
+                    button.textContent = active?.getTimerDisplay?.() || labelMap[key];
+                } else if (isTimerToggle) {
+                    button.textContent = active?.getTimerToggleLabel?.() || labelMap[key];
                 } else {
                     button.textContent = labelMap[key] || key;
                 }
@@ -686,6 +695,18 @@
                 if (key === 'up' || key === 'down') {
                     button.dataset.wide = 'true';
                     button.dataset.tall = 'true';
+                }
+                if (key === 'timerDisplay') {
+                    button.dataset.wide = 'true';
+                    button.dataset.tall = 'true';
+                    button.dataset.timerRole = 'display';
+                }
+                if (key === 'timerReset') {
+                    button.dataset.wide = 'true';
+                    button.dataset.timerRole = 'reset';
+                }
+                if (key === '-10' || key === '+10' || key === 'timerToggle') {
+                    button.dataset.timerRole = key === 'timerToggle' ? 'toggle' : 'adjust';
                 }
                 if (key === 'trash') {
                     button.dataset.tall = 'true';
@@ -699,6 +720,9 @@
                 }
                 if (layout === 'rpe' && key !== '-') {
                     button.dataset.rpe = key;
+                }
+                if (key === 'timerDisplay') {
+                    button.disabled = true;
                 }
                 button.addEventListener('click', (event) => {
                     event.preventDefault();
@@ -926,10 +950,9 @@
                 return;
             }
             if (key === 'done') {
-                if (active.mode === 'timer') {
-                    return;
+                if (active.mode !== 'timer') {
+                    handleClose();
                 }
-                handleClose();
                 return;
             }
             if (typeof active.onKey === 'function') {
@@ -1127,7 +1150,14 @@
             contains,
             selectTarget,
             setMode,
-            getMode: () => active?.mode || 'input'
+            getMode: () => active?.mode || 'input',
+            refresh: () => {
+                if (!active) {
+                    return;
+                }
+                renderKeys(currentLayout, currentMode);
+                renderActions(resolveActions());
+            }
         };
         components.inlineKeyboard = api;
         return api;

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1321,13 +1321,61 @@
             if (!inlineKeyboard) {
                 return;
             }
+            const getTimerDisplayLabel = () => {
+                const timer = ensureSharedTimer();
+                const remaining = safeInt(timer.remainSec, 0);
+                const sign = remaining < 0 ? '-' : '';
+                const absolute = Math.abs(remaining);
+                const minutes = Math.floor(absolute / 60);
+                const seconds = absolute % 60;
+                return `${sign}${minutes}:${String(seconds).padStart(2, '0')}`;
+            };
             inlineKeyboard.attach(input, {
                 layout: resolveKeyboardLayout(field),
                 mode: inlineKeyboard.getMode?.() || 'input',
                 decimalSeparator: field === 'weight' ? ',' : undefined,
                 splitTimeField: field === 'minutes' || field === 'seconds',
                 timeField: field,
-                onKey: (key) => {
+                getTimerDisplay: getTimerDisplayLabel,
+                getTimerToggleLabel: () => (ensureSharedTimer().running ? 'pause' : 'play'),
+                onKey: (key, context = {}) => {
+                    if (context.mode === 'timer') {
+                        if (key === 'timerReset') {
+                            resetTimerToDefault();
+                            inlineKeyboard?.refresh?.();
+                            return true;
+                        }
+                        if (key === '-10') {
+                            adjustTimer(-10);
+                            inlineKeyboard?.refresh?.();
+                            return true;
+                        }
+                        if (key === '+10') {
+                            adjustTimer(10);
+                            inlineKeyboard?.refresh?.();
+                            return true;
+                        }
+                        if (key === 'timerToggle') {
+                            const timer = ensureSharedTimer();
+                            if (timer.running) {
+                                pauseTimer();
+                            } else {
+                                resumeTimer();
+                            }
+                            inlineKeyboard?.refresh?.();
+                            return true;
+                        }
+                        if (key === 'done') {
+                            startTimer(value.rest, { setId: set.id, setIndex: currentIndex });
+                            pauseTimer();
+                            inlineKeyboard?.detach?.();
+                            return true;
+                        }
+                        if (key === 'close') {
+                            inlineKeyboard?.detach?.();
+                            return true;
+                        }
+                    }
                     if (key === ':' && (field === 'minutes' || field === 'seconds')) {
                         selectField?.(field === 'minutes' ? 'seconds' : 'minutes');
                         return true;
@@ -3074,6 +3122,9 @@
         timerDisplay.classList.toggle('tmr-display--warning', isWarning);
         timerDisplay.classList.toggle('tmr-display--negative', isNegative);
         timerDisplay.textContent = `${sign}${minutes}:${String(seconds).padStart(2, '0')}`;
+        if (inlineKeyboard?.isOpen?.() && inlineKeyboard?.getMode?.() === 'timer') {
+            inlineKeyboard.refresh?.();
+        }
         syncTimerBarSpacer(execTimerBar, false);
     }
 


### PR DESCRIPTION
### Motivation
- Rendre le clavier inline cohérent avec le nouveau layout demandé pour le mode **édit** et pour le mode **timer**, et faire en sorte que le clavier utilise la même source de vérité que la barre/fenêtre timer.

### Description
- Modifie la grille du clavier inline dans `components/set-editor.js` en inversant la disposition du mode `edit` pour placer la corbeille à gauche (`trash`) et centrer les flèches (`up`/`down`) sur les colonnes 2–3, et remodèle le layout `timer` pour introduire les touches `timerDisplay`, `timerReset`, `-10`, `timerToggle`, `+10`, `done` et `close`.
- Ajoute des labels et des attributs spécifiques aux touches timer (`timerDisplay`, `timerReset`, `timerToggle`, `-10`, `+10`) et rend le rendu du `timerDisplay` dynamique via des callbacks fournis par l'instance active (`getTimerDisplay`, `getTimerToggleLabel`).
- Étend l'API de l'inline keyboard avec `refresh()` pour forcer le rerender des touches/actions, et adapte `handleInput`/`onKey` pour déléguer les actions timer (`reset`, `±10s`, `play/pause`, `done`, `close`) vers l'état de timer partagé (fonctions `resetTimerToDefault`, `adjustTimer`, `pauseTimer`, `resumeTimer`, `startTimer`).
- Fait en sorte que la mise à jour du timer (`updateTimerUI`) rafraîchisse automatiquement le clavier si celui-ci est ouvert en mode `timer`, afin d'afficher continuellement le temps restant et l'état play/pause.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check components/set-editor.js` qui a réussi. 
- Exécution de la vérification de syntaxe JavaScript avec `node --check ui-session-execution-edit.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8db22d9588332bdd6f5f7741640fd)