### PR TITLE
Aligner les actions Timer du clavier inline avec les actions Édit/Saisie

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -639,7 +639,7 @@
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
-            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10', null, null, null, null, 'done', 'close'],
+            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10', null, null, null, null, null, null],
             edit:    ['trash', 'up', null, null, null, null, null, 'down', null]
         };
 
@@ -1093,6 +1093,12 @@
         const resolveActions = () => {
             if (!active) {
                 return [];
+            }
+            if (active.mode === 'timer') {
+                return [
+                    { label: 'fait', className: 'inline-keyboard-action--emphase', close: false, onClick: () => handleInput('done') },
+                    { label: 'fermer', className: 'inline-keyboard-action--muted', close: false, onClick: () => handleInput('close') }
+                ];
             }
             if (typeof active.actions === 'function') {
                 return active.actions(active.mode);


### PR DESCRIPTION
### Motivation
- Rendre le clavier inline en mode Timer cohérent avec les modes Édit et Saisie en plaçant les actions « fait » et « fermer » dans la colonne d'actions au lieu de la grille numérique.

### Description
- Retrait des clés `done` et `close` du layout `timer` dans `components/set-editor.js` en supprimant ces entrées de `layouts.timer`.
- Ajout d'un retour spécifique dans `resolveActions` pour `active.mode === 'timer'` qui fournit deux actions `fait` et `fermer` affichées dans la colonne d'actions avec les classes `inline-keyboard-action--emphase` et `inline-keyboard-action--muted`.
- Les actions appellent respectivement `handleInput('done')` et `handleInput('close')` pour conserver le comportement existant du minuteur.
- Changement limité à `components/set-editor.js` sans modification du reste du flux de minuteur ou des gestionnaires existants.

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e0514f948332ae4d14d780f3c19e)