### PR TITLE
Supprime les lignes vides finales du clavier inline en mode timer

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -639,7 +639,7 @@
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
-            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10', null, null, null, null, null, null],
+            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10'],
             edit:    ['trash', 'up', null, null, null, null, null, 'down', null]
         };
 


### PR DESCRIPTION
### Motivation
- Le clavier personnalisé en mode `timer` affichait deux lignes vides finales qui créaient un grand espace inutile et rendaient la hauteur du clavier différente selon le mode.

### Description
- Supprimé les cellules placeholder finales de l'array `layouts.timer` dans `components/set-editor.js`, réduisant le nombre de touches rendues en mode `timer`.
- Aucun style ni variable de hauteur (`--inline-keyboard-h` / spacer) n'a été modifié, donc la hauteur minimale globale du clavier reste inchangée.

### Testing
- Aucun test automatisé n'a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e465e5108332a2683c7a2324355e)