### PR TITLE
Fix live countdown update in inline keyboard timer mode

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -633,6 +633,7 @@
         let pressedKeyTimer = null;
         let pressedKeyButton = null;
         let timerModePointerGuard = false;
+        let timerRefreshInterval = null;
 
         const layouts = {
             default: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     '.',   '0',  'del'],
@@ -754,6 +755,28 @@
             }, 120);
         };
 
+
+        const stopTimerRefreshLoop = () => {
+            if (!timerRefreshInterval) {
+                return;
+            }
+            window.clearInterval(timerRefreshInterval);
+            timerRefreshInterval = null;
+        };
+
+        const startTimerRefreshLoop = () => {
+            if (!active || active.mode !== 'timer' || timerRefreshInterval) {
+                return;
+            }
+            timerRefreshInterval = window.setInterval(() => {
+                if (!active || active.mode !== 'timer') {
+                    stopTimerRefreshLoop();
+                    return;
+                }
+                renderKeys(currentLayout, currentMode);
+            }, 1000);
+        };
+
         const renderActions = (actions = []) => {
             actionsGrid.innerHTML = '';
             const list = Array.isArray(actions) ? actions : [];
@@ -827,6 +850,7 @@
             document.body?.classList.remove('inline-keyboard-visible');
             document.removeEventListener('pointerdown', handleOutside, true);
             clearPendingOutside();
+            stopTimerRefreshLoop();
             releaseTimerModePointerGuard();
             if (pressedKeyTimer) {
                 window.clearTimeout(pressedKeyTimer);
@@ -1130,6 +1154,11 @@
             if (previousMode !== 'timer' && active.mode === 'timer') {
                 armTimerModePointerGuard();
             }
+            if (active.mode === 'timer') {
+                startTimerRefreshLoop();
+            } else {
+                stopTimerRefreshLoop();
+            }
             if (active.mode === 'input') {
                 selectTarget(active.target);
             }
@@ -1142,6 +1171,11 @@
             applyLayout(layout, mode);
             renderKeys(currentLayout, currentMode);
             renderActions(resolveActions());
+            if (mode === 'timer') {
+                startTimerRefreshLoop();
+            } else {
+                stopTimerRefreshLoop();
+            }
             keyboard.hidden = false;
             keyboard.setAttribute('data-visible', 'true');
             document.body?.classList.add('inline-keyboard-visible');


### PR DESCRIPTION
### Motivation
- The timer display key inside the custom inline keyboard stayed visually frozen while the shared timer ran, so the user couldn’t see the countdown decrement in keyboard timer mode.

### Description
- Add a `timerRefreshInterval` and `startTimerRefreshLoop` / `stopTimerRefreshLoop` helpers that call `renderKeys` every second while the inline keyboard is in `timer` mode.
- Start the refresh loop when entering timer mode (`setMode` / `attach`) and stop it when leaving timer mode, closing the keyboard (`handleClose`) or when the keyboard is no longer in timer mode.
- Ensure the loop cleans up itself if the keyboard or mode becomes inactive to avoid background intervals.
- Changes are limited to `components/set-editor.js` and only affect the inline custom keyboard timer rendering.

### Testing
- Located and inspected relevant timer and keyboard code with `rg` to verify integration points, which succeeded.
- Verified the patch with `git diff -- components/set-editor.js` to review changes, which produced the expected modifications and succeeded.
- Committed the change with `git commit -m "Fix timer key live refresh in custom keyboard"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e8255b7c833282b5587b35fdc35e)