### PR TITLE
Keep timer keyboard open for +/-10 and focus next set on "fait"

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1317,6 +1317,18 @@
             return 'default';
         };
 
+        const focusNextSetRepsInput = () => {
+            const nextRow = row.nextElementSibling?.classList?.contains('exec-set-row')
+                ? row.nextElementSibling
+                : null;
+            const nextRepsInput = nextRow?.querySelector?.('.exec-reps-cell');
+            if (!nextRepsInput) {
+                return;
+            }
+            nextRepsInput.click();
+            inlineKeyboard?.setMode?.('input');
+        };
+
         const attachInlineKeyboard = (input, field) => {
             if (!inlineKeyboard) {
                 return;
@@ -1366,9 +1378,9 @@
                             return true;
                         }
                         if (key === 'done') {
-                            startTimer(value.rest, { setId: set.id, setIndex: currentIndex });
-                            pauseTimer();
+                            resetTimerToDefault();
                             inlineKeyboard?.detach?.();
+                            focusNextSetRepsInput();
                             return true;
                         }
                         if (key === 'close') {


### PR DESCRIPTION
### Motivation
- Préserver le clavier custom en mode `timer` lors des ajustements `+10`/`-10` pour éviter qu’un appui ferme l’UI et interrompe le flux de travail. 
- Changer le comportement du bouton `fait` en mode `timer` pour réinitialiser le timer, fermer le clavier courant et passer la saisie sur la série suivante (case `reps`).

### Description
- Ajout d’une fonction `focusNextSetRepsInput` qui clique la case `reps` de la ligne suivante et force le clavier en mode `input`.
- Modification du gestionnaire `onKey` en mode `timer` pour que `done` appelle `resetTimerToDefault()`, ferme le clavier avec `inlineKeyboard?.detach?.()` et appelle `focusNextSetRepsInput()`.
- Les touches `-10` et `+10` sont explicitement gérées dans `onKey` pour appliquer `adjustTimer(...)` et retourner `true` afin de garder le clavier ouvert pendant l’ajustement.

### Testing
- Exécution de la vérification de syntaxe via `node --check ui-session-execution-edit.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ee33e0648332b61e3dc88d20262d)