### PR TITLE
Corrige l'alignement de la touche Descendre dans le clavier Édit

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -641,7 +641,7 @@
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
             timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10'],
-            edit:    ['trash', 'up', null, null, null, null, null, 'down', null]
+            edit:    ['trash', 'up', null, 'down', null, null, null, null, null]
         };
 
         const resolveLayout = (layout, mode) => {


### PR DESCRIPTION
### Motivation
- Corriger le placement de la touche Descendre (⬇️) en mode Édit pour la positionner dans la zone centrale/basse (zone bleu) et supprimer l'espace vide inutile sous le clavier.

### Description
- Réordonnage de l'array `edit` dans `components/set-editor.js` de `['trash','up',null,null,null,null,null','down',null]` à `['trash','up',null,'down',null,null,null,null,null]` afin de positionner la touche `down` dans la colonne/ligne prévue sans autre changement de comportement.

### Testing
- Pas de suite de tests automatisés pour ce dépôt ; j'ai exécuté une recherche automatisée (`rg`) pour confirmer que la modification concerne uniquement `components/set-editor.js` et vérifié le contenu du fichier modifié avec des outils automatisés, succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f12a149c83328af9d4121893e67a)