### PR TITLE
Forcer le mode `input` du clavier inline sur cellules de série et afficher ±0.5 sur les steppers RPE

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -1493,7 +1493,7 @@
                     weightButton.textContent = formatStepperDelta(direction * weightStep);
                 }
                 if (rpeButton) {
-                    rpeButton.textContent = formatStepperDelta(direction);
+                    rpeButton.textContent = formatStepperDelta(direction * 0.5);
                 }
             });
         };
@@ -1594,7 +1594,7 @@
             );
             weightBtn.classList.add('inline-set-editor-weight');
             const rpeBtn = createStepperButton(
-                formatStepperDelta(delta),
+                formatStepperDelta(delta * 0.5),
                 () => adjustState(state, 'rpe', delta, config),
                 false,
                 `${type === 'plus' ? 'Augmenter' : 'Diminuer'} le RPE`

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -689,7 +689,7 @@
             }
             inlineKeyboard.attach(input, {
                 layout: resolveKeyboardLayout(field),
-                mode: inlineKeyboard.getMode?.() || 'input',
+                mode: 'input',
                 decimalSeparator: field === 'weight' ? ',' : undefined,
                 splitTimeField: field === 'minutes' || field === 'seconds',
                 timeField: field,

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1344,7 +1344,7 @@
             };
             inlineKeyboard.attach(input, {
                 layout: resolveKeyboardLayout(field),
-                mode: inlineKeyboard.getMode?.() || 'input',
+                mode: 'input',
                 decimalSeparator: field === 'weight' ? ',' : undefined,
                 splitTimeField: field === 'minutes' || field === 'seconds',
                 timeField: field,


### PR DESCRIPTION
### Motivation
- Corriger le comportement où le clavier inline restait en mode `timer` lorsqu’on cliquait une cellule de saisie (reps/poids/rpe/repos) au lieu d’ouvrir le clavier en mode saisie. 
- Afficher des incréments RPE de `±0.5` sur les boutons steppers pour correspondre à l’intervalle réel attendu par l’utilisateur.

### Description
- Dans `ui-session-execution-edit.js` et `ui-routine-execution-edit.js` l’appel à `inlineKeyboard.attach(...)` force désormais `mode: 'input'` au lieu de `mode: inlineKeyboard.getMode?.() || 'input'` pour garantir l’ouverture en mode saisie lors du focus d’une cellule. 
- Dans `components/set-editor.js` l’étiquette des boutons RPE est calculée avec un multiplicateur `0.5` (`formatStepperDelta(direction * 0.5)` et `formatStepperDelta(delta * 0.5)`) afin d’afficher `+0.5` / `−0.5` tout en conservant l’ajustement interne (`adjustState`) inchangé.
- Aucun autre comportement d’ajustement interne (pas de changement de la logique `adjustState` sur la valeur appliquée) n’a été modifié.

### Testing
- Examen du diff avec `git diff -- ui-session-execution-edit.js ui-routine-execution-edit.js components/set-editor.js` exécuté avec succès. 
- Ajout et commit des fichiers modifiés avec `git add ... && git commit -m "Fix inline keyboard mode reset and RPE stepper labels"` exécuté avec succès. 
- Vérification des lignes modifiées via `nl`/affichage de fichier pour confirmer les remplacements; toutes les commandes automatisées ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f772e2188332ac27c0aa3d5b3bf6)