### PR TITLE
Corrige comportement du clavier inline (mode edit / timer)

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -640,8 +640,8 @@
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
-            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10'],
-            edit:    ['trash', 'up', null, 'down', null, null, null, null, null]
+            timer:   ['timerDisplay', 'timerReset', 'done', '-10', 'timerToggle', '+10', null, null, 'close'],
+            edit:    ['trash', 'up', null, 'down', null, null]
         };
 
         const resolveLayout = (layout, mode) => {
@@ -973,17 +973,17 @@
                 handleClose();
                 return;
             }
-            if (key === 'done') {
-                if (active.mode !== 'timer') {
-                    handleClose();
-                }
-                return;
-            }
             if (typeof active.onKey === 'function') {
                 const handled = active.onKey(key, { mode: active.mode, layout: active.layout });
                 if (handled) {
                     return;
                 }
+            }
+            if (key === 'done') {
+                if (active.mode !== 'timer') {
+                    handleClose();
+                }
+                return;
             }
             if (active.mode === 'edit') {
                 const edit = active.edit || {};
@@ -1119,10 +1119,7 @@
                 return [];
             }
             if (active.mode === 'timer') {
-                return [
-                    { label: 'fait', className: 'inline-keyboard-action--emphase', close: false, onClick: () => handleInput('done') },
-                    { label: 'fermer', className: 'inline-keyboard-action--muted', close: false, onClick: () => handleInput('close') }
-                ];
+                return [];
             }
             if (typeof active.actions === 'function') {
                 return active.actions(active.mode);

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1176,7 +1176,6 @@
                     className: 'inline-keyboard-action--emphase',
                     close: false,
                     onClick: async () => {
-                        inlineKeyboard?.setMode?.('timer');
                         await applySetEditorResult(
                             currentIndex,
                             { reps: value.reps, weight: value.weight, rpe: value.rpe, rest: value.rest },
@@ -1184,6 +1183,7 @@
                         );
                         startTimer(value.rest, { setId: set.id, setIndex: currentIndex });
                         inlineKeyboard?.setMode?.('timer');
+                        inlineKeyboard?.refresh?.();
                     }
                 },
                 {


### PR DESCRIPTION
### Motivation
- Réduire l’espace inutile en mode `edit` en supprimant les cases vides de la grille. 
- Afficher immédiatement la valeur du `timer` lors du passage en mode `timer` pour éviter un affichage obsolète d’une seconde. 
- Placer `FERMER` et `FAIT` sur les lignes demandées et éviter la confusion entre grille et actions latérales. 
- Faire en sorte que `FAIT` en mode `timer` déclenche bien la logique attendue (démarrer le timer et passer à la série suivante).

### Description
- Modifie `components/set-editor.js` pour resserrer la grille `edit` (moins de cases `null`) et remplacer la grille `timer` par `['timerDisplay','timerReset','done','-10','timerToggle','+10',null,null,'close']` afin de positionner `fait` et `fermer` dans le bon ordre. 
- Change l’ordre du traitement de la touche `done` dans le gestionnaire `handleInput` pour laisser d’abord `active.onKey` gérer `done` (permettant à la logique timer de prendre la main). 
- Remplace l’affichage d’actions latérales en mode `timer` par une liste vide (`resolveActions` retourne `[]` en `timer`) pour éviter doublons et incohérences de placement. 
- Adapte `ui-session-execution-edit.js` pour ne plus basculer prématurément le clavier en `timer` avant d’appeler `startTimer`, et ajoute un `inlineKeyboard?.refresh?.()` juste après le démarrage du timer pour forcer l’affichage instantané de la valeur correcte.

### Testing
- Exécution du contrôle syntaxique JavaScript avec `node --check components/set-editor.js && node --check ui-session-execution-edit.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb5e927c8332aa6c042218a01ecf)