### PR TITLE
Ajuste le layout du clavier inline pour les modes timer et edit

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -640,7 +640,7 @@
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
-            timer:   ['timerDisplay', 'timerReset', 'done', '-10', 'timerToggle', '+10', null, null, 'close'],
+            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10'],
             edit:    ['trash', 'up', null, 'down', null, null]
         };
 

--- a/style.css
+++ b/style.css
@@ -2714,7 +2714,8 @@ textarea:focus{
 .inline-keyboard-actions{
   grid-column: span 1;
   display: grid;
-  grid-template-rows: repeat(4, 45px);
+  grid-auto-rows: 45px;
+  align-content: start;
   gap: 10px;
 }
 

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1148,7 +1148,22 @@
 
         const buildKeyboardActions = (mode = 'input') => {
             if (mode === 'timer') {
-                return [];
+                return [
+                    {
+                        label: 'fait',
+                        className: 'inline-keyboard-action--emphase',
+                        close: false,
+                        onClick: () => {
+                            resetTimerToDefault();
+                            inlineKeyboard?.detach?.();
+                            focusNextSetRepsInput();
+                        }
+                    },
+                    {
+                        label: 'fermer\n▼',
+                        className: 'inline-keyboard-action--close'
+                    }
+                ];
             }
             const isEdit = mode === 'edit';
             const toggleAction = {


### PR DESCRIPTION
### Motivation
- Adapter le clavier inline au layout souhaité : timer sur 6 cases (3x2), réinitialiser en dessous, -10/pause/+10 en dessous, et les boutons `fait`/`fermer` à droite en bas comme en mode saisie.
- Supprimer la ligne vide résiduelle en bas en mode `edit` liée à une colonne d’actions à hauteur fixe.

### Description
- Modifie la `layout` `timer` dans `components/set-editor.js` pour retirer `done` et `close` de la grille et laisser seulement `timerDisplay`, `timerReset`, `-10`, `timerToggle`, `+10` (la grille n’affiche donc plus `fait`/`fermer`).
- Ajoute les actions `fait` et `fermer` à la colonne d’actions en mode `timer` dans `ui-session-execution-edit.js` pour conserver le même style/placement que le mode saisie et préserver le comportement attendu (`fait` réinitialise/passe à la série suivante, `fermer` ferme le clavier).
- Ajuste `style.css` pour que la colonne d’actions utilise `grid-auto-rows: 45px` et `align-content: start` au lieu d’un `grid-template-rows` fixe, ce qui supprime l’espace vide en bas en mode `edit`.

### Testing
- `node --check components/set-editor.js` — OK.
- `node --check ui-session-execution-edit.js` — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa010ff6148332b3cde673bd1c41a6)