### PR TITLE
Corrige clavier inline — modes timer et edit et couleurs des actions

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -640,8 +640,8 @@
             integer: ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     null,  '0',  'del'],
             rpe:     ['5',  '5.5', '6', '6.5', '7', '7.5', '8',    '8.5', '9',     '9.5', '10', '-'],
             time:    ['1',  '2',  '3',  '4',   '5', '6',   '7',    '8',   '9',     ':',   '0',  'del'],
-            timer:   ['timerDisplay', 'timerReset', null, '-10', 'timerToggle', '+10'],
-            edit:    ['trash', 'up', null, 'down', null, null]
+            timer:   ['timerReset', 'timerDisplay', 'timerDisplay', null, '-10', '+10'],
+            edit:    ['trash', 'up', 'up', 'trash', 'down', 'down']
         };
 
         const resolveLayout = (layout, mode) => {
@@ -676,8 +676,7 @@
                     done: 'fait',
                     close: 'fermer\n▼',
                     timerDisplay: '0:00',
-                    timerReset: 'réinitialiser',
-                    timerToggle: 'play'
+                    timerReset: 'Réinit'
                 };
                 const isSplitTimeToggle = key === ':' && layout === 'time' && active?.splitTimeField;
                 const isTimerDisplay = key === 'timerDisplay' && active?.mode === 'timer';
@@ -721,9 +720,6 @@
                 }
                 if (layout === 'rpe' && key !== '-') {
                     button.dataset.rpe = key;
-                }
-                if (key === 'timerDisplay') {
-                    button.disabled = true;
                 }
                 button.addEventListener('click', (event) => {
                     event.preventDefault();
@@ -1116,9 +1112,6 @@
 
         const resolveActions = () => {
             if (!active) {
-                return [];
-            }
-            if (active.mode === 'timer') {
                 return [];
             }
             if (typeof active.actions === 'function') {

--- a/style.css
+++ b/style.css
@@ -2762,6 +2762,12 @@ body.inline-keyboard-visible .keyboard-spacer{
   color: var(--black);
 }
 
+.inline-keyboard-action--emphase-light{
+  background: color-mix(in srgb, var(--emphase) 45%, white);
+  border-color: color-mix(in srgb, var(--emphase) 55%, white);
+  color: #fff;
+}
+
 
 .inline-keyboard-action--close{
   white-space: pre-line;

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1167,9 +1167,8 @@
             }
             const isEdit = mode === 'edit';
             const toggleAction = {
-                icon: isEdit ? '🔢' : '…',
+                label: isEdit ? 'mode saisie' : 'mode edit',
                 ariaLabel: isEdit ? 'Basculer en mode saisie' : 'Basculer en mode édition',
-                className: 'inline-keyboard-action--icon',
                 close: false,
                 onClick: () => inlineKeyboard?.setMode?.(isEdit ? 'input' : 'edit')
             };
@@ -1177,7 +1176,7 @@
                 toggleAction,
                 {
                     label: 'prévu',
-                    className: 'inline-keyboard-action--muted',
+                    className: 'inline-keyboard-action--emphase-light',
                     onClick: async () => {
                         await applySetEditorResult(
                             currentIndex,


### PR DESCRIPTION
### Motivation
- Ajuster le clavier inline pour que les modes `timer` et `edit` correspondent à la maquette demandée (suppression du bouton play/pause, valeur du timer cliquable, organisation des touches). 
- Appliquer la couleur emphase actuelle à la touche `fait` et une variante délavée de cette couleur à `prévu`.

### Description
- Modifié `components/set-editor.js` pour remplacer les layouts `timer` et `edit` afin que la grille affiche `Réinit` à gauche, la valeur du timer cliquable au centre, `-10`/`+10` en bas, et pour empiler correctement `trash`, `up` et `down` en mode `edit`.
- Activé la touche valeur du timer en supprimant le `button.disabled = true` pour `timerDisplay` afin qu’elle serve de toggle play/pause via l’`onKey` existant, et renommé `timerReset` en `Réinit` dans le mapping d’étiquettes.
- Modifié `ui-session-execution-edit.js` pour remplacer l’icône de bascule par le texte `mode edit` / `mode saisie` et pour appliquer la nouvelle classe `inline-keyboard-action--emphase-light` à l’action `prévu` tout en conservant `fait` avec `inline-keyboard-action--emphase`.
- Ajouté `inline-keyboard-action--emphase-light` dans `style.css` (utilisant `color-mix`) pour fournir une version plus claire du bleu emphase demandée.

### Testing
- Exécuté un diff de validation avec `git diff -- components/set-editor.js ui-session-execution-edit.js style.css` et la vérification a affiché les changements attendus (succès). 
- Réalisé le commit avec `git commit -m "Fix timer/edit keyboard layouts and action styling"` et la commande a conclu avec succès. 
- Création du PR via l’outil interne `make_pr` et l’appel a retourné le titre et le body du PR (succès).
- Aucun test automatisé supplémentaire (unit/integration) n’a été exécuté dans cette passe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0661f0c08332a2b66ed86e97b594)