### PR TITLE
Guard screen-specific UI wiring when refs are unavailable

### DIFF
--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -28,6 +28,9 @@
     /* WIRE */
     document.addEventListener('DOMContentLoaded', () => {
         ensureRefs();
+        if (!refs.screenRoutineMoveEdit) {
+            return;
+        }
         wireNavigation();
         wireTabs();
         wireActions();

--- a/ui-routines-list.js
+++ b/ui-routines-list.js
@@ -33,6 +33,9 @@
     /* WIRE */
     document.addEventListener('DOMContentLoaded', () => {
         ensureRefs();
+        if (!refs.screenRoutineList) {
+            return;
+        }
         wireCreateButton();
         wireBackButton();
         wireFilters();

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -102,6 +102,9 @@
     /* WIRE */
     document.addEventListener('DOMContentLoaded', () => {
         ensureRefs();
+        if (!refs.screenExecEdit) {
+            return;
+        }
         wireNavigation();
         wireActions();
         wireDetails();


### PR DESCRIPTION
### Motivation
- Several UI modules were throwing null-dereference errors during bootstrap when their target screen markup was not present, causing `addEventListener` on `null` and `assertRefs()` exceptions that cascaded into broader failures.
- This happens in partial/older HTML builds or when serving pages (e.g. GitHub Pages) that do not include every screen DOM node the scripts expect.

### Description
- Added early-return guards in `DOMContentLoaded` handlers to skip wiring when the target screen refs are absent in `ui-routines-list.js`, `ui-routine-execution-edit.js`, and `ui-session-execution-edit.js`.
- The change checks `refs.screenRoutineList`, `refs.screenRoutineMoveEdit`, and `refs.screenExecEdit` respectively before attaching listeners and running screen-specific wiring.
- No behavior change when the screens are present; `assertRefs()` and the existing wiring remain unchanged for normal builds.

### Testing
- Ran syntax checks with `node --check` on `ui-routines-list.js`, `ui-routine-execution-edit.js` and `ui-session-execution-edit.js`, and they passed. 
- Verified the modified files contain the added early-return guards and that the altered modules parse cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc59e1183c833285a46d5b6ae1b5a1)