### PR TITLE
Fix inline keyboard layout for edit and timer modes

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -656,6 +656,8 @@
 
         const renderKeys = (layout, mode) => {
             grid.innerHTML = '';
+            grid.dataset.layout = layout;
+            grid.dataset.mode = mode || '';
             const keys = layouts[layout] || layouts.default;
             keys.forEach((key) => {
                 const button = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -2813,6 +2813,55 @@ body.inline-keyboard-visible .keyboard-spacer{
   height: auto;
 }
 
+.inline-keyboard-grid[data-layout="edit"]{
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: 45px;
+}
+
+.inline-keyboard-grid[data-layout="edit"] .inline-keyboard-key[data-key="trash"]{
+  grid-column: 1;
+  grid-row: 1 / span 2;
+}
+
+.inline-keyboard-grid[data-layout="edit"] .inline-keyboard-key[data-key="up"]{
+  grid-column: 2 / span 2;
+  grid-row: 1 / span 2;
+}
+
+.inline-keyboard-grid[data-layout="edit"] .inline-keyboard-key[data-key="down"]{
+  grid-column: 2 / span 2;
+  grid-row: 3 / span 2;
+}
+
+.inline-keyboard-grid[data-layout="timer"]{
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: 45px;
+}
+
+.inline-keyboard-grid[data-layout="timer"] .inline-keyboard-key[data-key="timerReset"]{
+  grid-column: 1;
+  grid-row: 1 / span 2;
+}
+
+.inline-keyboard-grid[data-layout="timer"] .inline-keyboard-key[data-key="timerDisplay"]{
+  grid-column: 2 / span 2;
+  grid-row: 1 / span 2;
+}
+
+.inline-keyboard-grid[data-layout="timer"] .inline-keyboard-key[data-key="-10"]{
+  grid-column: 2;
+  grid-row: 3 / span 2;
+}
+
+.inline-keyboard-grid[data-layout="timer"] .inline-keyboard-key[data-key="+10"]{
+  grid-column: 3;
+  grid-row: 3 / span 2;
+}
+
+.inline-keyboard-grid[data-layout="timer"] + .inline-keyboard-actions{
+  align-content: end;
+}
+
 .inline-keyboard-key:active{
   filter: brightness(0.9);
   transform: translateY(1px);


### PR DESCRIPTION
### Motivation
- Fix misaligned keys in the custom inline keyboard: the `down` key was not horizontally aligned under `up` in edit mode and timer mode layout did not match the intended structure. 
- Ensure mode-specific layouts (`edit` / `timer`) can be targeted without affecting the input/saisie layout. 

### Description
- Added `grid.dataset.layout` and `grid.dataset.mode` in `renderKeys` so the rendered key grid exposes the active layout/mode for CSS targeting (`components/set-editor.js`).
- Introduced mode-scoped CSS rules in `style.css` to reposition keys for `data-layout="edit"` so `trash` remains left and `up`/`down` form a right column with `down` placed under `up`.
- Added CSS for `data-layout="timer"` to place `timerReset` on the left, `timerDisplay` top-right, `-10`/`+10` below, and to lower the side action column via `align-content: end`.

### Testing
- No automated tests were run for this CSS/DOM layout adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6061d9508332bf98a79c203e9cab)