### PR TITLE
Filter volume set counts using minimum tracked RPE threshold

### DIFF
--- a/state.js
+++ b/state.js
@@ -98,6 +98,15 @@
         return existing.calculateOrm(load, count + repsInReserve);
     };
 
+
+    /**
+     * Seuil minimum de RPE utilisé pour les métriques qui filtrent les séries.
+     * @returns {number} Seuil de RPE inclusif.
+     */
+    existing.getMinTrackedRpe = function getMinTrackedRpe() {
+        return 7;
+    };
+
     /**
      * Retourne la date du jour sans composante horaire.
      * @returns {Date} Date du jour.

--- a/ui-session.js
+++ b/ui-session.js
@@ -120,7 +120,7 @@
             const rpe = Number(set?.rpe);
             const reps = Number(set?.reps);
             const weight = Number(set?.weight);
-            return Number.isFinite(rpe) && rpe >= 7 && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
+            return Number.isFinite(rpe) && rpe >= (A.getMinTrackedRpe?.() ?? 7) && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
         });
         if (!eligibleSets.length) {
             return {
@@ -1470,7 +1470,7 @@
 
     function isSetEligibleForOrmMean(set) {
         const rpe = Number(set?.rpe);
-        return Number.isFinite(rpe) && rpe >= 7;
+        return Number.isFinite(rpe) && rpe >= (A.getMinTrackedRpe?.() ?? 7);
     }
 
     function resolveSetOrmValue(set) {

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -1790,7 +1790,7 @@
                 maxWeight = weight;
                 hasData = true;
             }
-            if (Number.isFinite(rpe) && rpe >= 7 && rpe <= 10) {
+            if (Number.isFinite(rpe) && rpe >= (A.getMinTrackedRpe?.() ?? 7) && rpe <= 10) {
                 rpeSum += rpe;
                 rpeCount += 1;
                 hasData = true;

--- a/ui-volume.js
+++ b/ui-volume.js
@@ -393,7 +393,7 @@
                     return;
                 }
                 const sets = Array.isArray(sessionExercise.sets) ? sessionExercise.sets : [];
-                const doneSets = sets.reduce((total, set) => total + (set?.done === true ? 1 : 0), 0);
+                const doneSets = countTrackedSets(sets);
                 if (doneSets === 0) {
                     return;
                 }
@@ -865,6 +865,22 @@
         return null;
     }
 
+
+
+    function countTrackedSets(sets) {
+        const minRpe = A.getMinTrackedRpe?.() ?? 7;
+        return (Array.isArray(sets) ? sets : []).reduce((total, set) => {
+            if (set?.done !== true) {
+                return total;
+            }
+            const rpe = Number(set?.rpe);
+            if (!Number.isFinite(rpe) || rpe < minRpe) {
+                return total;
+            }
+            return total + 1;
+        }, 0);
+    }
+
     function computeMuscleStats(sessions, exercises, muscleKey, start, end) {
         const exerciseById = new Map(exercises.map((exercise) => [exercise.id, exercise]));
         const stats = { sessions: 0, sets: 0 };
@@ -889,7 +905,7 @@
                     return;
                 }
                 const sets = Array.isArray(sessionExercise.sets) ? sessionExercise.sets : [];
-                const doneSets = sets.reduce((total, set) => total + (set?.done === true ? 1 : 0), 0);
+                const doneSets = countTrackedSets(sets);
                 if (doneSets === 0) {
                     return;
                 }
@@ -969,7 +985,7 @@
                     return;
                 }
                 const sets = Array.isArray(sessionExercise.sets) ? sessionExercise.sets : [];
-                const doneSets = sets.reduce((total, set) => total + (set?.done === true ? 1 : 0), 0);
+                const doneSets = countTrackedSets(sets);
                 if (doneSets === 0) {
                     return;
                 }


### PR DESCRIPTION
### Motivation
- Align volume counting with other metrics by only counting completed sets whose RPE meets the same minimum threshold used for average RPE and session 1RM computations.
- Centralize the minimum tracked RPE so multiple screens and stats use a single source of truth.

### Description
- Added `existing.getMinTrackedRpe()` in `state.js` to expose the minimum inclusive RPE threshold (default 7).
- Added `countTrackedSets()` in `ui-volume.js` and updated volume computations (`computeVolumeStats`, `computeMuscleStats`, per-exercise aggregation) to count only `done === true` sets with `rpe >= getMinTrackedRpe()`.
- Replaced hard-coded `rpe >= 7` checks in `ui-session.js` and `ui-stats.js` with `A.getMinTrackedRpe?.() ?? 7` so exercise stat-line eligibility, session ORM mean, and avg RPE calculations share the same threshold.
- Modified files: `state.js`, `ui-volume.js`, `ui-session.js`, `ui-stats.js`.

### Testing
- Parsed the updated JS files with Node using `node -e "['state.js','ui-session.js','ui-stats.js','ui-volume.js'].forEach(f=>new Function(require('fs').readFileSync(f,'utf8')));` and it completed successfully.
- Verified a commit was created for the change with message `Filter volume set counts by minimum tracked RPE` and the working tree updated without syntax errors.
- Created the PR metadata via the local `make_pr` helper (title: the PR title above) after validation steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee58435f48332aa64263771c4ece9)