### PR TITLE
Aligner le style des séries prévues avec l'écran séance

### DIFF
--- a/style.css
+++ b/style.css
@@ -2526,20 +2526,20 @@ textarea:focus{
 }
 
 .exec-set-planned{
-  background: transparent;
+  background: var(--panelBack);
   color: inherit;
   font-weight: var(--fw-light);
 }
 
 .exec-set-planned .set-edit-button{
-  background: color-mix(in srgb, var(--panelBord) 20%, transparent);
-  border-color: color-mix(in srgb, var(--panelBord) 45%, transparent);
+  background: var(--panelBack);
+  border-color: var(--panelBord);
   color: inherit;
   font-weight: inherit;
 }
 .exec-set-planned .set-edit-input{
-  background: color-mix(in srgb, var(--panelBord) 20%, transparent);
-  border-color: color-mix(in srgb, var(--panelBord) 45%, transparent);
+  background: var(--panelBack);
+  border-color: var(--panelBord);
   color: inherit;
   font-weight: inherit;
 }

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -478,7 +478,7 @@
 
     function renderSetRow(set, index, totalSets) {
         const row = document.createElement('div');
-        row.className = 'exec-grid exec-row routine-set-row routine-set-grid';
+        row.className = 'exec-grid exec-row routine-set-row routine-set-grid exec-set-planned';
         row.dataset.idx = String(index);
 
         const order = document.createElement('div');


### PR DESCRIPTION
### Motivation
- Les lignes de séries en mode prévu affichaient un fond fortement teinté par le RPE, alors que l'écran séance utilise des lignes prévues neutres avec seulement la cellule RPE légèrement teintée.  
- Il faut uniformiser l'apparence entre la saisie de séries (séance et routine) pour éviter que les cellules non-RPE héritent d'une teinte globale.  

### Description
- Mise à jour des règles CSS de `.exec-set-planned` pour utiliser un fond neutre `var(--panelBack)` et une bordure neutre `var(--panelBord)` au lieu d'un fond transparent teinté; les boutons/inputs prévus héritent désormais du style neutre.  
- Conservation des styles RPE pour les éléments marqués avec `data-rpe` afin que seules les cellules RPE restent visuellement codées.  
- Ajout de la classe `exec-set-planned` aux lignes de série rendues par `renderSetRow` dans `ui-routine-execution-edit.js` pour appliquer les mêmes règles de style aux routines (où les séries sont toujours en mode prévu).  

### Testing
- Aucun test automatisé n'est configuré ou exécuté pour ces modifications CSS/DOM.  
- Vérifications de cohérence réalisées via les commandes `git diff`, `git add`/`git commit` et `git rev-parse` qui se sont exécutées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff1f9771348332a8fab3d1229b6a0d)