### PR TITLE
Clavier inline timer : bouton principal 'Suivant' / 'Ajouter' et création de série

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1149,17 +1149,30 @@
             }
         };
 
+        const hasNextSet = () => {
+            const sets = Array.isArray(getExercise()?.sets) ? getExercise().sets : [];
+            return currentIndex + 1 < sets.length;
+        };
+
+        const goToNextSetOrCreate = async () => {
+            resetTimerToDefault();
+            if (hasNextSet()) {
+                inlineKeyboard?.detach?.();
+                focusNextSetRepsInput();
+                return;
+            }
+            await addSet();
+        };
+
         const buildKeyboardActions = (mode = 'input') => {
             if (mode === 'timer') {
                 return [
                     {
-                        label: 'fait',
+                        label: hasNextSet() ? 'Suivant' : 'Ajouter',
                         className: 'inline-keyboard-action--emphase',
                         close: false,
                         onClick: () => {
-                            resetTimerToDefault();
-                            inlineKeyboard?.detach?.();
-                            focusNextSetRepsInput();
+                            void goToNextSetOrCreate();
                         }
                     },
                     {
@@ -1395,9 +1408,7 @@
                             return true;
                         }
                         if (key === 'done') {
-                            resetTimerToDefault();
-                            inlineKeyboard?.detach?.();
-                            focusNextSetRepsInput();
+                            void goToNextSetOrCreate();
                             return true;
                         }
                         if (key === 'close') {


### PR DESCRIPTION
### Motivation
- Adapter le comportement du bouton principal du clavier inline en mode `timer` pour afficher `Suivant` s’il existe une série suivante, ou `Ajouter` sinon, et faire en sorte que `Ajouter` crée une nouvelle série et positionne le focus sur la cellule `reps` en mode saisie.

### Description
- Ajout de la fonction helper `hasNextSet()` qui vérifie si une série suivante existe pour l’exercice courant.
- Ajout de l’asynchrone `goToNextSetOrCreate()` qui réinitialise le timer, va sur la série suivante si elle existe, sinon appelle `addSet()` pour créer une nouvelle série (la logique existante de `pendingFocus` place ensuite le focus sur `reps`).
- Modification de `buildKeyboardActions('timer')` pour utiliser un label dynamique (`'Suivant'` / `'Ajouter'`) et déclencher `goToNextSetOrCreate()` au clic.
- Alignement du traitement de la touche logique `done` dans l’inline keyboard pour appeler également `goToNextSetOrCreate()`.

### Testing
- Aucun test automatisé n’a été exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff209d51bc8332a0de15e67a87d5c3)