### PR TITLE
Trigger bottom navigation on press (use pointerdown)

### DIFF
--- a/init.js
+++ b/init.js
@@ -148,7 +148,8 @@
             screenFitHeroMapping
         } = refs;
 
-        tabSessions?.addEventListener('click', async () => {
+        tabSessions?.addEventListener('pointerdown', async (event) => {
+            event.preventDefault();
             const isActive = tabSessions.classList.contains('active');
             const isOnSessions = screenSessions && !screenSessions.hidden;
             if (isActive && isOnSessions) {
@@ -163,13 +164,15 @@
             await A.renderSession();
         });
 
-        tabStats?.addEventListener('click', async () => {
+        tabStats?.addEventListener('pointerdown', async (event) => {
+            event.preventDefault();
             A.setTimerVisibility?.({ hidden: true });
             setActiveTab('tabStats');
             await A.openStatsSection?.();
         });
 
-        tabPlanning?.addEventListener('click', async () => {
+        tabPlanning?.addEventListener('pointerdown', async (event) => {
+            event.preventDefault();
             A.setTimerVisibility?.({ hidden: true });
             setActiveTab('tabPlanning');
             await A.openPlanning?.();


### PR DESCRIPTION
### Motivation
- Éviter les activations accidentelles des actions de la barre de navigation inférieure lors du relâchement du toucher après la fermeture d’un clavier custom.

### Description
- Remplacement des écouteurs `click` par `pointerdown` pour les trois onglets bas (`tabSessions`, `tabStats`, `tabPlanning`) dans `init.js` et ajout de `event.preventDefault()` pour déclencher l’action dès l’appui.

### Testing
- Aucun test automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9cd769a08332b50e583cb6f785e8)