### PR TITLE
Fix directional rounding for weight and seconds steppers

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -268,7 +268,11 @@
                 return;
             }
             const current = SetEditor.#parseFloat(input.value, 0);
-            let next = current + delta;
+            const step = Math.abs(Number(delta)) || 0;
+            if (!step) {
+                return;
+            }
+            let next = SetEditor.#snapByDirection(current, step, Number(delta) >= 0 ? 1 : -1);
             if (next < 0) {
                 next = 0;
             }
@@ -312,25 +316,33 @@
             if (!refs) {
                 return;
             }
-            let minutes = SetEditor.#parseInt(refs.minutesInput?.value, 0);
-            let seconds = SetEditor.#parseInt(refs.secondsInput?.value, 0);
-            seconds += delta;
-            if (seconds >= 60) {
-                minutes += Math.floor(seconds / 60);
-                seconds %= 60;
-            } else if (seconds < 0) {
-                const borrow = Math.ceil(Math.abs(seconds) / 60);
-                if (minutes >= borrow) {
-                    minutes -= borrow;
-                    seconds = (seconds % 60 + 60) % 60;
-                } else {
-                    minutes = 0;
-                    seconds = 0;
-                }
+            const step = Math.abs(Number(delta)) || 0;
+            if (!step) {
+                return;
             }
-            refs.minutesInput.value = String(Math.max(0, minutes));
-            refs.secondsInput.value = String(Math.max(0, seconds));
+            const direction = Number(delta) >= 0 ? 1 : -1;
+            const minutes = SetEditor.#parseInt(refs.minutesInput?.value, 0);
+            const seconds = SetEditor.#parseInt(refs.secondsInput?.value, 0);
+            const currentTotal = Math.max(0, minutes * 60 + seconds);
+            const nextTotal = Math.max(0, SetEditor.#snapByDirection(currentTotal, step, direction));
+            refs.minutesInput.value = String(Math.floor(nextTotal / 60));
+            refs.secondsInput.value = String(nextTotal % 60);
             SetEditor.#notifyChange();
+        }
+
+        static #snapByDirection(current, step, direction) {
+            const safeCurrent = Number.isFinite(Number(current)) ? Number(current) : 0;
+            const safeStep = Math.abs(Number(step));
+            if (!safeStep) {
+                return safeCurrent;
+            }
+            const quotient = safeCurrent / safeStep;
+            const rounded = Math.round(quotient);
+            const isAligned = Math.abs(quotient - rounded) < 1e-9;
+            if (direction >= 0) {
+                return (isAligned ? rounded + 1 : Math.ceil(quotient)) * safeStep;
+            }
+            return (isAligned ? rounded - 1 : Math.floor(quotient)) * safeStep;
         }
 
         static #sanitizeTimeInputs() {


### PR DESCRIPTION
### Motivation
- The set editor steppers for weight and seconds must round the final value to the clicked step granularity in the step direction (e.g. `10.1 +1 => 11`, `30.1 -2.5 => 30`, `15s +10 => 20s`).

### Description
- Change `#adjustWeight` to snap the current weight to the next/previous multiple of the clicked step instead of simple addition/subtraction.
- Change `#adjustSeconds` to convert minutes+seconds to total seconds and snap that total to the next/previous step (preserves minute rollover) before writing back minutes and seconds.
- Add a shared helper `#snapByDirection(current, step, direction)` to centralize directional snapping logic used by both steppers.
- Modified file: `components/set-editor.js`.

### Testing
- Ran `git status --short` to confirm working tree state and it succeeded.
- Verified the code diff with `git diff -- components/set-editor.js` and inspected the changes successfully.
- Committed the change with `git commit -m "Fix set stepper rounding for weight and seconds"` which completed successfully.
- Created the PR metadata (`make_pr`) which prepared the PR description successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9fbca9e48332baf0c5092747b470)