### PR TITLE
Keep inline keyboard open when adjusting timer (-10/+10)

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -3012,7 +3012,7 @@
         set.rest = Math.max(0, safeInt(set.rest, 0) + delta);
         updateLastRestDuration(set.rest);
         if (session === state.session) {
-            await persistSession();
+            await persistSession(false);
         } else {
             await db.saveSession(session);
         }
@@ -3064,7 +3064,7 @@
         set.rest = Math.max(0, safeInt(nextRest, getDefaultRest()));
         updateLastRestDuration(set.rest);
         if (session === state.session) {
-            await persistSession();
+            await persistSession(false);
         } else {
             await db.saveSession(session);
         }


### PR DESCRIPTION
### Motivation
- The inline custom keyboard was being closed when pressing `-10`/`+10` in timer mode because saving the session triggered a full rerender that dismissed the keyboard. 
- The change avoids unnecessary UI rerender while preserving persistence of the modified rest value.

### Description
- Replaced `persistSession()` with `persistSession(false)` in `applyAttachmentRestDelta` inside `ui-session-execution-edit.js` to persist the updated rest without forcing a rerender. 
- Made the same replacement in `applyAttachmentRestValue` in `ui-session-execution-edit.js` so timer reset persistence does not close the keyboard. 
- Left the `db.saveSession(session)` path unchanged for cases where the session being updated is not the active in-memory `state.session`.

### Testing
- Searched and inspected code paths with `rg` and `sed` to locate timer key handling and persistence sites and confirmed the two replacements were applied. 
- Verified the diff with `git diff -- ui-session-execution-edit.js` and committed the change with `git commit -m "Fix timer +/-10 keyboard closing in custom keypad"`, both succeeding. 
- Created the PR containing only the two `persistSession(false)` changes and validated the modified lines with `nl`/file inspection; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004fda1bd88332993bf98a16859e7e)