### PR TITLE
Synchronise les touches -10/+10 du timer avec le champ repos de la série

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -3011,6 +3011,7 @@
         }
         set.rest = Math.max(0, safeInt(set.rest, 0) + delta);
         updateLastRestDuration(set.rest);
+        syncAttachedSetRestInputs(set.rest, attachment);
         if (session === state.session) {
             await persistSession(false);
         } else {
@@ -3063,10 +3064,42 @@
         }
         set.rest = Math.max(0, safeInt(nextRest, getDefaultRest()));
         updateLastRestDuration(set.rest);
+        syncAttachedSetRestInputs(set.rest, attachment);
         if (session === state.session) {
             await persistSession(false);
         } else {
             await db.saveSession(session);
+        }
+    }
+
+    function syncAttachedSetRestInputs(restValue, attachment = ensureSharedTimer().attachment) {
+        if (!attachment || attachment.dateKey !== state.dateKey || attachment.exerciseId !== state.exerciseId) {
+            return;
+        }
+        const exercise = getExercise();
+        if (!exercise || !Array.isArray(exercise.sets)) {
+            return;
+        }
+        let setIndex = Number.isInteger(attachment.setIndex) ? attachment.setIndex : null;
+        if (!Number.isInteger(setIndex) || setIndex < 0 || setIndex >= exercise.sets.length) {
+            setIndex = exercise.sets.findIndex((set) => set?.id === attachment.setId);
+        }
+        if (!Number.isInteger(setIndex) || setIndex < 0) {
+            return;
+        }
+        const row = refs.execSets?.querySelector?.(`.exec-set-row[data-index="${setIndex}"]`);
+        if (!row) {
+            return;
+        }
+        const next = Math.max(0, safeInt(restValue, 0));
+        const { minutes, seconds } = splitRest(next);
+        const minuteInput = row.querySelector('.exec-rest-minute-cell');
+        const secondInput = row.querySelector('.exec-rest-second-cell');
+        if (minuteInput) {
+            minuteInput.value = String(minutes);
+        }
+        if (secondInput) {
+            secondInput.value = String(seconds).padStart(2, '0');
         }
     }
 


### PR DESCRIPTION
### Motivation
- Corriger le comportement où, en mode timer, l’ajustement `-10`/`+10` (et la réinitialisation) met à jour l’état interne et la persistence mais ne rafraîchit pas immédiatement les champs minutes/secondes du repos pour la série attachée, rendant l’affichage obsolète.

### Description
- Ajout de la fonction `syncAttachedSetRestInputs(restValue, attachment)` qui trouve la série attachée (utilise d’abord `attachment.setIndex` puis retombe sur `setId`) et met à jour les inputs DOM minutes/secondes de la ligne correspondante sans forcer un rerender global.
- Appel de `syncAttachedSetRestInputs` depuis `applyAttachmentRestDelta` et `applyAttachmentRestValue` immédiatement après la mise à jour de `set.rest` et de `updateLastRestDuration`.
- Modification limitée au fichier `ui-session-execution-edit.js` pour synchroniser l’UI visible quand le timer modifie la durée de repos.

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0052489504833296e51a073ca35570)