### PR TITLE
Fix timer +/-10 rest persistence in inline set editor

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -1248,6 +1248,7 @@
             if (!editor) {
                 return;
             }
+            value.rest = composeRestFromParts(restMinutesInput.value, restSecondsInput.value);
             const { minutes, seconds } = splitRest(value.rest);
             editor.open(row, {
                 values: { reps: value.reps, weight: value.weight, rpe: value.rpe, minutes, seconds },


### PR DESCRIPTION
### Motivation
- When adjusting the shared timer with `-10/+10`, the displayed minutes/seconds inputs updated but the inline editor's cached `value.rest` could remain stale, so reopening the set showed the previous rest value.

### Description
- Recompute the local `value.rest` from the current minute/second inputs before opening the inline editor by calling `value.rest = composeRestFromParts(restMinutesInput.value, restSecondsInput.value)` in `ui-session-execution-edit.js`.
- This ensures the `editor.open()` call receives synchronized `minutes`/`seconds` derived from the current UI state.

### Testing
- No automated unit or integration tests were available or executed for this change; the fix is a single-line synchronization change applied to `ui-session-execution-edit.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0055b492f48332848289426ffb857d)