### PR TITLE
Ouvrir le clavier timer depuis le bouton central de la barre de navigation

### DIFF
--- a/init.js
+++ b/init.js
@@ -153,8 +153,13 @@
             const isActive = tabSessions.classList.contains('active');
             const isOnSessions = screenSessions && !screenSessions.hidden;
             if (isActive && isOnSessions) {
-                const isHidden = A.isTimerHidden?.();
-                A.setTimerVisibility?.({ hidden: isHidden === false });
+                const opened = A.openTimerKeyboard?.();
+                if (!opened) {
+                    const isHidden = A.isTimerHidden?.();
+                    A.setTimerVisibility?.({ hidden: isHidden === false });
+                } else {
+                    A.setTimerVisibility?.({ hidden: true });
+                }
                 return;
             }
             A.setTimerVisibility?.({ hidden: true });

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -3033,6 +3033,21 @@
         return Boolean(timerVisibility?.hidden);
     }
     A.isTimerHidden = () => isTimerHidden();
+    A.openTimerKeyboard = () => {
+        if (!inlineKeyboard) {
+            return false;
+        }
+        const activeInput = document.activeElement instanceof HTMLInputElement ? document.activeElement : null;
+        const fallbackInput = refs.execSets?.querySelector?.('.exec-rest-second-cell, .exec-rest-minute-cell, .exec-reps-cell');
+        const input = activeInput || fallbackInput;
+        if (!(input instanceof HTMLInputElement)) {
+            return false;
+        }
+        input.click();
+        inlineKeyboard.setMode?.('timer');
+        inlineKeyboard.refresh?.();
+        return true;
+    };
 
     function resetTimerState() {
         const timer = ensureSharedTimer();


### PR DESCRIPTION
### Motivation
- Simplifier l'expérience quand on reclique sur l'onglet central `tabSessions` en ouvrant directement le clavier inline en mode `timer` au lieu d'afficher/masquer la boîte de dialogue timer.

### Description
- Ajout de l'API `A.openTimerKeyboard()` dans `ui-session-execution-edit.js` qui réutilise l'élément input actif (ou un input de secours dans les séries), simule un `click`, bascule le clavier inline en mode `timer` et retourne `true`/`false` selon le succès.
- Modification de l'écouteur `pointerdown` du bouton central dans `init.js` pour appeler `A.openTimerKeyboard()` et n'utiliser le comportement historique de toggle de la visibilité du timer (`A.setTimerVisibility`) que si l'ouverture du clavier échoue.
- Quand l'ouverture du clavier réussit, la visibilité de la boîte de dialogue timer est explicitement masquée via `A.setTimerVisibility({ hidden: true })`.

### Testing
- Exécution des opérations Git de base : `git status --short` (OK) et `git add` + `git commit` (OK).
- Création du PR via l'outil interne (`make_pr`) réussie et retours de commit/PR positifs.
- Aucun test unitaire automatisé spécifique au changement n'a été exécuté dans la session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005b4854c08332b738d12a635d4ea8)