### PR TITLE
Ajouter durée estimée de séance + préférence durée par répétition

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
         </div>
 
         <div class="session-comments-header">
+            <input id="sessionDurationPreview" class="input session-duration-preview" type="text" readonly aria-label="Durée estimée de la séance" value="0mn" />
             <button id="btnSessionComments" class="session-comments-content" type="button" aria-label="Ajouter un commentaire de séance">
                 <span id="sessionCommentsPreview" class="session-comments-text details" data-empty="true" data-placeholder="commentaires"></span>
             </button>
@@ -1000,6 +1001,16 @@
                     </div>
                 </div>
             </article >
+            <article id="btnPreferencesRepDuration" class="exercise-card list-card clickable" role="button" aria-label="Durée d'une répétition pour le calcul de la séance">
+                <div class="exercise-card-row list-card__row">
+                    <div class="exercise-card-left list-card__start">
+                        <div class="exercise-card-text list-card__body">
+                            <div class="element">Durée d'une répétition</div>
+                            <div id="prefRepDurationSummary" class="details"></div>
+                        </div>
+                    </div>
+                </div>
+            </article>
 
            <article id="btnPreferencesNewSet" class="exercise-card list-card clickable" role="button" aria-label="Valeurs pour une nouvelle série">
                 <div class="exercise-card-row list-card__row">
@@ -1161,6 +1172,23 @@
         </div>
         <div class="modal-footer">
             <button id="prefRestSave" class="btn cta full" type="button">ok</button>
+        </div>
+    </form>
+</dialog>
+<dialog id="dlgPreferencesRepDuration" class="modal modal-fixed modal-centered">
+    <form method="dialog" class="modal-form">
+        <div class="modal-header">
+            <div class="title modal-title">Durée d'une répétition</div>
+            <button id="prefRepDurationCancel" class="btn ghost modal-close" type="button">✕</button>
+        </div>
+        <div class="modal-body">
+            <div class="bloque">
+                <label class="lbl" for="prefRepDurationSeconds">Temps d'une répétition (secondes)</label>
+                <input id="prefRepDurationSeconds" class="input" type="number" min="1" step="1" inputmode="numeric" aria-label="Secondes par répétition" />
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button id="prefRepDurationSave" class="btn cta full" type="button">ok</button>
         </div>
     </form>
 </dialog>

--- a/preferences.js
+++ b/preferences.js
@@ -7,7 +7,8 @@
         restDefaultEnabled: true,
         restDefaultDuration: 80,
         lastRestDuration: 80,
-        newSetValueSource: 'last_set'
+        newSetValueSource: 'last_set',
+        repDurationSeconds: 4
     };
     let cache = null;
 
@@ -37,6 +38,7 @@
         cache.restDefaultDuration = sanitizeDuration(cache.restDefaultDuration);
         cache.lastRestDuration = sanitizeDuration(cache.lastRestDuration, cache.restDefaultDuration);
         cache.newSetValueSource = normalizeNewSetValueSource(cache.newSetValueSource);
+        cache.repDurationSeconds = sanitizeRepDuration(cache.repDurationSeconds);
         return cache;
     }
 
@@ -54,6 +56,14 @@
     function sanitizeDuration(value, fallback = DEFAULTS.restDefaultDuration) {
         const number = Number(value);
         if (!Number.isFinite(number) || number < 0) {
+            return fallback;
+        }
+        return Math.round(number);
+    }
+
+    function sanitizeRepDuration(value, fallback = DEFAULTS.repDurationSeconds) {
+        const number = Number(value);
+        if (!Number.isFinite(number) || number <= 0) {
             return fallback;
         }
         return Math.round(number);
@@ -121,6 +131,19 @@
         data.newSetValueSource = normalizeNewSetValueSource(value);
         persist();
         return data.newSetValueSource;
+    };
+
+    preferences.getRepDurationSeconds = function getRepDurationSeconds() {
+        const data = ensureLoaded();
+        return sanitizeRepDuration(data.repDurationSeconds);
+    };
+
+    preferences.setRepDurationSeconds = function setRepDurationSeconds(seconds) {
+        const data = ensureLoaded();
+        const sanitized = sanitizeRepDuration(seconds);
+        data.repDurationSeconds = sanitized;
+        persist();
+        return sanitized;
     };
 
     preferences.getDefaultTimerDuration = function getDefaultTimerDuration() {

--- a/style.css
+++ b/style.css
@@ -2224,6 +2224,12 @@ textarea:focus{
     font: inherit;
     cursor: pointer;
 }
+.session-duration-preview{
+    flex: 0 0 72px;
+    width: 72px;
+    text-align: center;
+    padding: 0 6px;
+}
 .session-comments-text{
     display:block;
     min-height: 1.2em;

--- a/ui-preferences.js
+++ b/ui-preferences.js
@@ -9,6 +9,7 @@
         ensureRefs();
         wireEvents();
         renderRestSummary();
+        renderRepDurationSummary();
         renderNewSetSummary();
     });
 
@@ -25,6 +26,12 @@
         refs.prefRestSave = document.getElementById('prefRestSave');
         refs.prefRestCancel = document.getElementById('prefRestCancel');
         refs.btnPreferencesNewSet = document.getElementById('btnPreferencesNewSet');
+        refs.btnPreferencesRepDuration = document.getElementById('btnPreferencesRepDuration');
+        refs.prefRepDurationSummary = document.getElementById('prefRepDurationSummary');
+        refs.dlgPreferencesRepDuration = document.getElementById('dlgPreferencesRepDuration');
+        refs.prefRepDurationSeconds = document.getElementById('prefRepDurationSeconds');
+        refs.prefRepDurationSave = document.getElementById('prefRepDurationSave');
+        refs.prefRepDurationCancel = document.getElementById('prefRepDurationCancel');
         refs.prefNewSetSummary = document.getElementById('prefNewSetSummary');
         refs.dlgPreferencesNewSet = document.getElementById('dlgPreferencesNewSet');
         refs.prefNewSetLastSet = document.getElementById('prefNewSetLastSet');
@@ -41,6 +48,10 @@
             dlgPreferencesRest,
             prefRestSave,
             prefRestCancel,
+            btnPreferencesRepDuration,
+            dlgPreferencesRepDuration,
+            prefRepDurationSave,
+            prefRepDurationCancel,
             btnPreferencesNewSet,
             dlgPreferencesNewSet,
             prefNewSetSave,
@@ -64,6 +75,19 @@
 
         dlgPreferencesRest?.addEventListener('close', () => {
             renderRestSummary();
+        });
+        btnPreferencesRepDuration?.addEventListener('click', () => openRepDurationDialog());
+        prefRepDurationSave?.addEventListener('click', (event) => {
+            event.preventDefault();
+            saveRepDurationPreferences();
+            dlgPreferencesRepDuration?.close();
+        });
+        prefRepDurationCancel?.addEventListener('click', (event) => {
+            event.preventDefault();
+            dlgPreferencesRepDuration?.close();
+        });
+        dlgPreferencesRepDuration?.addEventListener('close', () => {
+            renderRepDurationSummary();
         });
 
         btnPreferencesNewSet?.addEventListener('click', () => {
@@ -141,6 +165,35 @@
         if (typeof dlgPreferencesNewSet.showModal === 'function') {
             dlgPreferencesNewSet.showModal();
         }
+    }
+
+    function openRepDurationDialog() {
+        const { dlgPreferencesRepDuration, prefRepDurationSeconds } = ensureRefs();
+        if (!dlgPreferencesRepDuration || !prefRepDurationSeconds) {
+            return;
+        }
+        prefRepDurationSeconds.value = String(A.preferences?.getRepDurationSeconds?.() ?? 4);
+        if (typeof dlgPreferencesRepDuration.showModal === 'function') {
+            dlgPreferencesRepDuration.showModal();
+        }
+    }
+
+    function saveRepDurationPreferences() {
+        const { prefRepDurationSeconds } = ensureRefs();
+        if (!prefRepDurationSeconds) {
+            return;
+        }
+        const value = Math.max(1, safeInt(prefRepDurationSeconds.value, 4));
+        A.preferences?.setRepDurationSeconds?.(value);
+    }
+
+    function renderRepDurationSummary() {
+        const { prefRepDurationSummary } = ensureRefs();
+        if (!prefRepDurationSummary) {
+            return;
+        }
+        const seconds = A.preferences?.getRepDurationSeconds?.() ?? 4;
+        prefRepDurationSummary.textContent = `${seconds}s par répétition`;
     }
 
     function saveNewSetPreferences() {

--- a/ui-session.js
+++ b/ui-session.js
@@ -659,6 +659,7 @@
         const session = await db.getSession(key);
         updateSessionEditButtons(session);
         updateSessionCommentsPreview(session);
+        updateSessionDurationPreview(session);
         sessionList.innerHTML = '';
         if (!(session?.exercises?.length)) {
             sessionList.innerHTML = '<div class="empty">Aucun exercice pour cette date.</div>';
@@ -1784,6 +1785,7 @@
         refs.dlgExecMoveEditor = document.getElementById('dlgExecMoveEditor');
         refs.btnSessionComments = document.getElementById('btnSessionComments');
         refs.sessionCommentsPreview = document.getElementById('sessionCommentsPreview');
+        refs.sessionDurationPreview = document.getElementById('sessionDurationPreview');
         refs.sessionCreateRoutine = document.getElementById('sessionCreateRoutine');
         refs.sessionDelete = document.getElementById('sessionDelete');
         refs.sessionShare = document.getElementById('sessionShare');
@@ -2251,6 +2253,41 @@
             : '';
         sessionCommentsPreview.textContent = comment;
         sessionCommentsPreview.dataset.empty = comment ? 'false' : 'true';
+    }
+
+    function updateSessionDurationPreview(session) {
+        const { sessionDurationPreview } = ensureRefs();
+        if (!sessionDurationPreview) {
+            return;
+        }
+        const totalSeconds = computeSessionEstimatedDurationSeconds(session);
+        sessionDurationPreview.value = formatSessionDuration(totalSeconds);
+    }
+
+    function computeSessionEstimatedDurationSeconds(session) {
+        const repDurationSeconds = Math.max(1, safeInt(A.preferences?.getRepDurationSeconds?.(), 4));
+        const exercises = Array.isArray(session?.exercises) ? session.exercises : [];
+        let totalSeconds = 0;
+        for (const exercise of exercises) {
+            const sets = Array.isArray(exercise?.sets) ? exercise.sets : [];
+            for (const set of sets) {
+                const reps = Math.max(0, safeInt(set?.reps, 0));
+                const rest = Math.max(0, safeInt(set?.rest, 0));
+                totalSeconds += rest + (reps * repDurationSeconds);
+            }
+        }
+        return totalSeconds;
+    }
+
+    function formatSessionDuration(totalSeconds) {
+        const safeSeconds = Math.max(0, safeInt(totalSeconds, 0));
+        const totalMinutes = Math.round(safeSeconds / 60);
+        if (totalMinutes < 60) {
+            return `${totalMinutes}mn`;
+        }
+        const hours = Math.floor(totalMinutes / 60);
+        const minutes = totalMinutes % 60;
+        return `${hours}h${String(minutes).padStart(2, '0')}mn`;
     }
 
     async function resolveSessionInstructionsText() {


### PR DESCRIPTION
### Motivation
- Afficher dans l’écran Séance une estimation de la durée (non éditable) sur la même ligne que le champ commentaire pour permettre à l’utilisateur d’anticiper la durée d’une séance planifiée.
- Calculer la durée en additionnant les temps de repos et la durée des répétitions, avec une durée par répétition configurable (défaut 4s) via les Préférences.
- Afficher la durée au format heures+minutes `HhMMmn` si >= 1h ou en minutes `Xmn` si < 1h.

### Description
- Ajout d’un champ de lecture seule `sessionDurationPreview` dans `index.html` positionné avant le commentaire et stylé via la classe `.session-duration-preview` dans `style.css` pour une largeur fixe proche d’un bouton.
- Ajout dans `preferences.js` d’une préférence persistée `repDurationSeconds` (défaut `4`) avec sanitation, getter `getRepDurationSeconds` et setter `setRepDurationSeconds`.
- Ajout d’une entrée et d’une modale dans l’écran Préférences (`index.html`) et wiring dans `ui-preferences.js` pour afficher/éditer la durée d’une répétition en secondes et mettre à jour la préférence.
- Implémentation dans `ui-session.js` de `computeSessionEstimatedDurationSeconds`, `formatSessionDuration` et `updateSessionDurationPreview`, et branchement de la mise à jour lors du rendu de la séance pour calculer la somme des `rest + reps * repDurationSeconds` sur toutes les séries planifiées.

### Testing
- Vérification statique des références et IDs via recherche (`rg`) pour `repDuration` et `sessionDurationPreview`, confirmant la présence des nouvelles références dans `index.html`, `ui-session.js`, `ui-preferences.js` et `preferences.js` (succès).
- Inspection des extraits de fichiers modifiés pour valider la présence des nouvelles fonctions `computeSessionEstimatedDurationSeconds` et `formatSessionDuration` et des getters/setters de préférence (succès).
- Aucune suite de tests automatisés unitaires disponible dans le projet, donc validation limitée aux vérifications statiques ci‑dessus (passées).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00abf3ba3c83329051a8d06d89c95f)