### PR TITLE
Admin: allow helper text to wrap in list cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -1645,6 +1645,13 @@ textarea:focus{
   text-overflow:ellipsis;
   white-space:nowrap;
 }
+
+#screenAdmin .list-card__body .details{
+  white-space:normal;
+  overflow:visible;
+  text-overflow:unset;
+}
+
 .exercise-card-text{
   display:-webkit-box;
   -webkit-box-orient:vertical;


### PR DESCRIPTION
### Motivation
- Les textes explicatifs sous les noms de bouton dans l’écran Admin étaient tronqués par le comportement d’ellipsis et doivent pouvoir s’afficher sur plusieurs lignes.

### Description
- Ajout d’une règle CSS scoped à `#screenAdmin` dans `style.css` (`#screenAdmin .list-card__body .details { white-space: normal; overflow: visible; text-overflow: unset; }`) pour permettre le retour à la ligne sans modifier le comportement des autres écrans.

### Testing
- Aucun test automatisé n’a été exécuté (modification CSS d’affichage visuel uniquement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05865f9fac8332bba20c9452b2c071)