### PR TITLE
Allow admin card helper text to wrap (fix truncation in Admin screen)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1645,6 +1645,11 @@ textarea:focus{
   text-overflow:ellipsis;
   white-space:nowrap;
 }
+#screenAdmin .list-card__body .details{
+  overflow:visible;
+  text-overflow:clip;
+  white-space:normal;
+}
 .exercise-card-text{
   display:-webkit-box;
   -webkit-box-orient:vertical;


### PR DESCRIPTION
### Motivation
- The helper description under admin buttons was being truncated by the global list-card styles, preventing multiline explanatory text in the Admin screen.

### Description
- Add a targeted CSS override in `style.css` (`#screenAdmin .list-card__body .details`) to set `overflow: visible`, `text-overflow: clip` and `white-space: normal` so admin card descriptions can wrap while preserving truncation behavior elsewhere.

### Testing
- Applied the patch and verified the change was written to `style.css` and `git commit` completed successfully via `git status --short` and `git add`/`git commit` (both succeeded); no automated UI tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05868d9a4483329be5e5581cd4ea07)