### PR TITLE
Corrige le stepper de poids dans l'éditeur inline

### DIFF
--- a/components/set-editor.js
+++ b/components/set-editor.js
@@ -1483,6 +1483,20 @@
             const current = Math.max(0, parseFloatSafe(weightValue, 0));
             return current <= 30 ? 1 : 2.5;
         };
+        const snapByDirection = (current, step, direction) => {
+            const safeCurrent = Number.isFinite(Number(current)) ? Number(current) : 0;
+            const safeStep = Math.abs(Number(step));
+            if (!safeStep) {
+                return safeCurrent;
+            }
+            const quotient = safeCurrent / safeStep;
+            const rounded = Math.round(quotient);
+            const isAligned = Math.abs(quotient - rounded) < 1e-9;
+            if (direction >= 0) {
+                return (isAligned ? rounded + 1 : Math.ceil(quotient)) * safeStep;
+            }
+            return (isAligned ? rounded - 1 : Math.floor(quotient)) * safeStep;
+        };
 
         const formatDeltaValue = (value) => {
             const numeric = Number(value);
@@ -1540,7 +1554,8 @@
                 case 'weight': {
                     const current = Math.max(0, parseFloatSafe(state.weight, 0));
                     const step = getWeightDeltaStep(current);
-                    let next = current + (delta * step);
+                    const direction = delta >= 0 ? 1 : -1;
+                    let next = snapByDirection(current, step, direction);
                     if (next < 0) {
                         next = 0;
                     }


### PR DESCRIPTION
### Motivation
- Garantir que les boutons d'incrément/décrément du poids s'alignent sur le pas actif (1 kg jusqu'à 30 kg, puis 2.5 kg) pour corriger les comportements sur des valeurs non alignées (ex: `31.5kg +2.5 → 32.5kg`, puis `-2.5 → 30kg`).

### Description
- Ajout d'une fonction `snapByDirection` et remplacement du calcul naïf `current + delta * step` par un snapping directionnel dans le cas `weight` de `adjustState(...)` dans `components/set-editor.js`, en conservant la logique de `getWeightDeltaStep` et l'arrondi/borne non-négative.

### Testing
- Aucun test automatisé n'a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0992da02ac83328a41375c3aacab92)