### PR TITLE
Fix volume counting: only primary and explicit secondary muscles

### DIFF
--- a/ui-volume.js
+++ b/ui-volume.js
@@ -357,13 +357,9 @@
                 return;
             }
             const primaryKey = normalizeKey(exercise.muscle);
-            const secondaryKeys = [
-                exercise.muscleGroup1,
-                exercise.muscleGroup2,
-                exercise.muscleGroup3
-            ]
-                .filter(Boolean)
-                .map(normalizeKey);
+            const secondaryKeys = Array.isArray(exercise.secondaryMuscles)
+                ? exercise.secondaryMuscles.filter(Boolean).map(normalizeKey)
+                : [];
 
             if (primaryKey && primaryKey === normalizedMuscle) {
                 primaryExercises.push(exercise);
@@ -934,19 +930,11 @@
             }
             keySet.add(normalizeKey(value));
         };
-        [
-            exercise.muscle,
-            exercise.muscleGroup1,
-            exercise.muscleGroup2,
-            exercise.muscleGroup3
-        ].forEach(addKey);
-
-        if (typeof CFG.decodeMuscle === 'function') {
-            const decoded = CFG.decodeMuscle(exercise.muscle);
-            if (decoded) {
-                [decoded.g1, decoded.g2, decoded.g3].forEach(addKey);
-            }
-        }
+        addKey(exercise.muscle);
+        const secondaryMuscles = Array.isArray(exercise.secondaryMuscles)
+            ? exercise.secondaryMuscles
+            : [];
+        secondaryMuscles.forEach(addKey);
         return Array.from(keySet);
     }
 


### PR DESCRIPTION
### Motivation
- Corriger le comptage de volume par muscle pour n’inclure que les exercices où le muscle est soit principal (`exercise.muscle`), soit explicitement listé dans `exercise.secondaryMuscles` afin d’éviter le sur-comptage via les familles/groupes musculaires.
- Conserver l’affichage détaillé du muscle (liste des exercices) en montrant à la fois les exercices principaux et secondaires lorsque l’utilisateur clique sur un muscle.

### Description
- Modifié `ui-volume.js` pour que la détection des exercices « Secondaire » utilise `exercise.secondaryMuscles` au lieu de `muscleGroup1/2/3`.
- Remplacé la logique de collecte des clés musculaires dans `getExerciseMuscleKeys` pour ne renvoyer que `exercise.muscle` et les entrées de `exercise.secondaryMuscles`, en supprimant le fallback sur `muscleGroup*` et le décodage des groupes.
- Ajustement du calcul global (`computeVolumeStats` / rendu du détail muscle) pour n’agréger séances/séries que pour les muscles principaux et les muscles secondaires explicitement déclarés.

### Testing
- Exécuté `node --check ui-volume.js` et la vérification de syntaxe a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09940f7520833282e41a4a77679b01)