### PR TITLE
Adjust Volume screen counting to use primary muscles only

### DIFF
--- a/ui-volume.js
+++ b/ui-volume.js
@@ -899,9 +899,8 @@
                 if (!exercise) {
                     return;
                 }
-                const muscles = getExerciseMuscleKeys(exercise);
                 const primaryMuscle = normalizeKey(exercise.muscle);
-                if (!muscles.length && !primaryMuscle) {
+                if (!primaryMuscle) {
                     return;
                 }
                 const sets = Array.isArray(sessionExercise.sets) ? sessionExercise.sets : [];
@@ -910,10 +909,10 @@
                     return;
                 }
 
-                if (muscles.includes(muscleKey)) {
+                if (primaryMuscle === muscleKey) {
                     stats.sets += doneSets;
                 }
-                if (!sessionCounted && muscles.includes(muscleKey)) {
+                if (!sessionCounted && primaryMuscle === muscleKey) {
                     stats.sessions += 1;
                     sessionCounted = true;
                 }
@@ -979,9 +978,8 @@
                 if (!exercise) {
                     return;
                 }
-                const muscles = getExerciseMuscleKeys(exercise);
                 const primaryMuscle = normalizeKey(exercise.muscle);
-                if (!muscles.length && !primaryMuscle) {
+                if (!primaryMuscle) {
                     return;
                 }
                 const sets = Array.isArray(sessionExercise.sets) ? sessionExercise.sets : [];
@@ -989,18 +987,10 @@
                 if (doneSets === 0) {
                     return;
                 }
-                muscles.forEach((muscleKey) => {
-                    if (!statsByKey.has(muscleKey)) {
-                        return;
-                    }
-                    sessionMuscles.add(muscleKey);
-                });
-                muscles.forEach((muscleKey) => {
-                    if (!statsByKey.has(muscleKey)) {
-                        return;
-                    }
-                    statsByKey.get(muscleKey).sets += doneSets;
-                });
+                if (statsByKey.has(primaryMuscle)) {
+                    sessionMuscles.add(primaryMuscle);
+                    statsByKey.get(primaryMuscle).sets += doneSets;
+                }
             });
 
             sessionMuscles.forEach((muscleKey) => {


### PR DESCRIPTION
### Motivation
- The Volume screen currently attributes sessions and sets to a muscle when that muscle appears either as the exercise’s primary or secondary target, but the intent is to count only exercises where the muscle is the primary target (`exercise.muscle`).
- The muscle detail screen should still show the full list of exercises (both primary and secondary) while muscle totals must follow the primary-only rule.

### Description
- Updated `ui-volume.js` to attribute aggregate stats only to the exercise primary muscle by modifying `computeVolumeStats` to use `exercise.muscle` for counting instead of `getExerciseMuscleKeys`.
- Updated `computeMuscleStats` in `ui-volume.js` so session and set totals for a selected muscle are incremented only when `normalizeKey(exercise.muscle)` equals the selected muscle key.
- Preserved the existing exercise listing logic and sections (`Principal` and `Secondaire`) in the muscle detail screen so the detail list still shows both primary and secondary exercises.
- Changes are contained in `ui-volume.js` and remove secondary-group attribution from the counting loops while keeping other UI behavior intact.

### Testing
- Ran a syntax/check: `node --check ui-volume.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099531bc0c8332b744f16a6c11a32c)