### PR TITLE
Rendre les cartes d’historique de la fiche exercice navigables vers la séance

### DIFF
--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -557,6 +557,7 @@
                 }
                 return {
                     session,
+                    exerciseInstanceId: match.id || match.exercise_id || null,
                     sets: match.sets.filter(
                         (set) =>
                             set?.done === true &&
@@ -582,7 +583,7 @@
         }
 
         const weightUnit = exercise?.weight_unit === 'imperial' ? 'lb' : 'kg';
-        items.forEach(({ session, sets }) => {
+        items.forEach(({ session, exerciseInstanceId, sets }) => {
             const wrapper = document.createElement('div');
             wrapper.className = 'exercise-history-session';
 
@@ -606,8 +607,57 @@
                 });
             }
 
+            wrapper.tabIndex = 0;
+            wrapper.role = 'button';
+            wrapper.setAttribute('aria-label', `Ouvrir la séance du ${formatSessionDate(session)}`);
+            wrapper.addEventListener('click', () => {
+                void openSessionFromHistory(session, exerciseInstanceId);
+            });
+            wrapper.addEventListener('keydown', (event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') {
+                    return;
+                }
+                event.preventDefault();
+                void openSessionFromHistory(session, exerciseInstanceId);
+            });
+
             container.appendChild(wrapper);
         });
+    }
+
+    async function openSessionFromHistory(session, exerciseInstanceId) {
+        const dateKey = session?.date || session?.id;
+        const targetDate = parseDateKey(dateKey);
+        if (!targetDate || Number.isNaN(targetDate.getTime())) {
+            return;
+        }
+        A.activeDate = targetDate;
+        A.currentAnchor = A.startOfWeek(A.activeDate);
+        if (typeof A.populateRoutineSelect === 'function') {
+            await A.populateRoutineSelect();
+        }
+        if (typeof A.renderWeek === 'function') {
+            await A.renderWeek();
+        }
+        if (exerciseInstanceId) {
+            A.setSessionScrollTarget?.(exerciseInstanceId, { topGapPx: 0 });
+        }
+        if (typeof A.renderSession === 'function') {
+            await A.renderSession();
+        }
+        switchScreen('screenSessions');
+        A.restoreSessionScroll?.();
+    }
+
+    function parseDateKey(dateKey) {
+        if (!dateKey || typeof dateKey !== 'string') {
+            return null;
+        }
+        const [year, month, day] = dateKey.split('-').map((part) => Number.parseInt(part, 10));
+        if (!year || !month || !day) {
+            return null;
+        }
+        return new Date(year, month - 1, day, 12);
     }
 
     function cleanInstructionStep(step) {

--- a/ui-session.js
+++ b/ui-session.js
@@ -24,7 +24,8 @@
     const sessionScrollState = {
         top: 0,
         pendingRestore: false,
-        targetExerciseId: null
+        targetExerciseId: null,
+        targetTopGapPx: null
     };
     let activeContextCard = null;
     const ROUTINE_ADD_MODIFIER_OPTIONS = [
@@ -537,11 +538,13 @@
         card.addEventListener('click', onClickCapture, true);
     }
 
-    function setSessionScrollTarget(exerciseId) {
+    function setSessionScrollTarget(exerciseId, options = {}) {
         if (!exerciseId) {
             return;
         }
         sessionScrollState.targetExerciseId = exerciseId;
+        const requestedGap = Number(options?.topGapPx);
+        sessionScrollState.targetTopGapPx = Number.isFinite(requestedGap) ? Math.max(0, requestedGap) : null;
         storeSessionScroll();
     }
 
@@ -1867,10 +1870,12 @@
             if (target) {
                 const containerRect = container.getBoundingClientRect();
                 const targetRect = target.getBoundingClientRect();
-                container.scrollTop = container.scrollTop + (targetRect.top - containerRect.top) - SESSION_SCROLL_TOP_GAP_PX;
+                const scrollGap = sessionScrollState.targetTopGapPx ?? SESSION_SCROLL_TOP_GAP_PX;
+                container.scrollTop = container.scrollTop + (targetRect.top - containerRect.top) - scrollGap;
                 restored = true;
             }
             sessionScrollState.targetExerciseId = null;
+            sessionScrollState.targetTopGapPx = null;
         }
         if (!restored) {
             container.scrollTop = sessionScrollState.top;
@@ -1880,7 +1885,7 @@
 
     A.storeSessionScroll = () => storeSessionScroll();
     A.restoreSessionScroll = () => restoreSessionScroll();
-    A.setSessionScrollTarget = (exerciseId) => setSessionScrollTarget(exerciseId);
+    A.setSessionScrollTarget = (exerciseId, options = {}) => setSessionScrollTarget(exerciseId, options);
     A.ensureSessionCardInView = (exerciseId) => {
         if (!exerciseId) {
             return false;


### PR DESCRIPTION
### Motivation
- Permettre depuis la fiche exercice > onglet Historique d’ouvrir directement la séance correspondante en cliquant une carte historique.
- Garantir l’accessibilité clavier (Enter / Espace) pour ces cartes.
- Aligner la carte cible juste sous la barre header de navigation en ajustant le défilement de la séance.

### Description
- `ui-exercise-read.js` : les éléments de l’historique reçoivent `exerciseInstanceId` (depuis `match.id`) et deviennent focusables/activables (`tabIndex`, `role`, `click`, `keydown`).
- `ui-exercise-read.js` : ajout de `openSessionFromHistory(session, exerciseInstanceId)` qui positionne `A.activeDate`, rerend semaine/séance, demande un `setSessionScrollTarget` sur l’exercice, bascule sur `screenSessions` et restaure le scroll.
- `ui-session.js` : étend `sessionScrollState` avec `targetTopGapPx`, change `setSessionScrollTarget(exerciseId, options)` pour accepter `options.topGapPx`, et utilise ce gap dans `restoreSessionScroll()` (fallback à `SESSION_SCROLL_TOP_GAP_PX`).
- `ui-session.js` : l’API exposée `A.setSessionScrollTarget` accepte désormais le second argument `options` et le relaie au handler interne.

### Testing
- Vérification syntaxique JS exécutée avec `node --check ui-exercise-read.js` (succès).
- Vérification syntaxique JS exécutée avec `node --check ui-session.js` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132b26c324833299816f6203aa19cf)