### PR TITLE
Fermer popup commentaire exercice et respecter retours à la ligne dans les aperçus

### DIFF
--- a/style.css
+++ b/style.css
@@ -2241,6 +2241,7 @@ textarea:focus{
     display:block;
     min-height: 1.2em;
     font-size: var(--fs-small);
+    white-space: pre-wrap;
 }
 .session-comments-text[data-empty="true"]::before{
     content: attr(data-placeholder);

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -648,11 +648,15 @@
             execDetailsInput.value = nextDetails;
             updateExecDetailsPreview(commentsState.exercise);
         }
-        await flushExecDetailsSave();
         if (A.closeDialog) {
             A.closeDialog(dlgExecDetails);
         } else {
             dlgExecDetails.close();
+        }
+        try {
+            await flushExecDetailsSave();
+        } catch (error) {
+            console.error('Impossible de sauvegarder les commentaires exercice.', error);
         }
         if (!revert && isSessionScreenActive()) {
             await refreshSessionViews();


### PR DESCRIPTION
### Motivation
- Corriger un blocage UX où la popup "commenter" d'un exercice ne pouvait pas être fermée et afficher correctement les retours à la ligne dans les aperçus "commentaires"/"instructions".

### Description
- Mise à jour de `ui-session-execution-edit.js` pour fermer le `dialog` (`dlgExecDetails`) avant d'attendre la persistance et entourer la sauvegarde de `flushExecDetailsSave()` d'un `try/catch` afin que la fermeture visuelle ne soit pas bloquée par une erreur de persistance, et ajout de `white-space: pre-wrap;` à la classe `.session-comments-text` dans `style.css` pour respecter les sauts de ligne dans les aperçus.

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132e59cfb4833290cef34140f418b9)