### PR TITLE
Harmonize save/cancel behavior for session and routine popups

### DIFF
--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -782,20 +782,15 @@
             routineDetailsInput.value = routineDetailsSnapshot;
             dlgRoutineDetails.showModal();
         });
-        routineDetailsInput.addEventListener('input', () => {
+        routineDetailsClose?.addEventListener('click', () => {
             if (!state.routine) {
+                closeRoutineDetailsDialog();
+                routineDetailsSnapshot = null;
                 return;
             }
             state.routine.instructions_routine_global = routineDetailsInput.value;
             updateRoutineDetailsPreview(state.routine);
-            scheduleSave();
-        });
-        routineDetailsClose?.addEventListener('click', () => {
-            if (state.pendingSave) {
-                clearTimeout(state.pendingSave);
-                state.pendingSave = null;
-                void persistRoutine();
-            }
+            void persistRoutine();
             closeRoutineDetailsDialog();
             routineDetailsSnapshot = null;
         });
@@ -804,14 +799,7 @@
                 closeRoutineDetailsDialog();
                 return;
             }
-            if (state.pendingSave) {
-                clearTimeout(state.pendingSave);
-                state.pendingSave = null;
-            }
-            state.routine.instructions_routine_global = routineDetailsSnapshot;
             routineDetailsInput.value = routineDetailsSnapshot;
-            updateRoutineDetailsPreview(state.routine);
-            void persistRoutine();
             closeRoutineDetailsDialog();
             routineDetailsSnapshot = null;
         });

--- a/ui-session.js
+++ b/ui-session.js
@@ -2066,14 +2066,6 @@
             void flushSessionCommentSave();
         });
 
-        sessionCommentInput?.addEventListener('input', () => {
-            if (!sessionCommentState.session) {
-                return;
-            }
-            sessionCommentState.session.comments_session_global = sessionCommentInput.value;
-            updateSessionCommentsPreview(sessionCommentState.session);
-            scheduleSessionCommentSave();
-        });
     }
 
     async function updateSessionNavigation() {
@@ -2221,26 +2213,21 @@
         if (!dlgSessionComment || !sessionCommentInput) {
             return;
         }
-        if (revert && sessionCommentState.session) {
-            sessionCommentState.session.comments_session_global = sessionCommentState.initialComments || '';
-            sessionCommentInput.value = sessionCommentState.initialComments || '';
-            updateSessionCommentsPreview(sessionCommentState.session);
+        if (!sessionCommentState.session) {
+            return;
         }
-        await flushSessionCommentSave();
+        if (revert) {
+            sessionCommentInput.value = sessionCommentState.initialComments || '';
+        } else {
+            sessionCommentState.session.comments_session_global = sessionCommentInput.value;
+            updateSessionCommentsPreview(sessionCommentState.session);
+            await flushSessionCommentSave();
+        }
         if (A.closeDialog) {
             A.closeDialog(dlgSessionComment);
         } else {
             dlgSessionComment.close();
         }
-    }
-
-    function scheduleSessionCommentSave() {
-        if (sessionCommentState.saveTimer) {
-            clearTimeout(sessionCommentState.saveTimer);
-        }
-        sessionCommentState.saveTimer = setTimeout(() => {
-            void flushSessionCommentSave();
-        }, 300);
     }
 
     async function flushSessionCommentSave() {


### PR DESCRIPTION
### Motivation
- Unifier le comportement des popups de texte pour que le bouton `ok` enregistre et ferme, et la croix `✕` ferme sans enregistrer, comme pour la popup « Instructions et commentaires d'exercice ». 
- Supprimer l'enregistrement automatique pendant la frappe pour éviter des persistances partielles et rendre l'action de sauvegarde explicite.

### Description
- In `ui-session.js` : supprimé l'écouteur `input` qui autosauvegardait les commentaires pendant la frappe, et modifié `closeSessionCommentDialog` pour appliquer ou restaurer les valeurs selon `revert` et appeler `flushSessionCommentSave()` uniquement lors de la fermeture par `ok` (non-revert). 
- Toujours dans `ui-session.js` : supprimée la fonction `scheduleSessionCommentSave()` et conservée `flushSessionCommentSave()` utilisée lors du `ok`. 
- In `ui-routine-edit.js` : retiré l'écouteur `input` d'autosave pour les instructions de routine, modifié le handler du bouton `routineDetailsClose` pour persister explicitement le contenu actuel et fermer, et modifié `routineDetailsCancel` pour restaurer le snapshot sans persister. 
- Conservé la capture/restauration du snapshot (`routineDetailsSnapshot`) à l'ouverture/annulation et le focus du textarea à l'ouverture pour préserver l'ergonomie.

### Testing
- Exécuté `node --check ui-session.js` et la vérification a réussi. 
- Exécuté `node --check ui-routine-edit.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132f6577648332a0ba2ad30beef716)