### PR TITLE
Fix exercise details popup close actions

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -455,6 +455,19 @@
         execDetailsCancel?.addEventListener('click', () => {
             void closeExecDetailsDialog({ revert: true });
         });
+        dlgExecDetails.addEventListener('click', (event) => {
+            if (event.target === dlgExecDetails) {
+                void closeExecDetailsDialog({ revert: false });
+            }
+        });
+        dlgExecDetails.addEventListener('cancel', (event) => {
+            event.preventDefault();
+            void closeExecDetailsDialog({ revert: false });
+        });
+        dlgExecDetails.querySelector('form')?.addEventListener('submit', (event) => {
+            event.preventDefault();
+            void closeExecDetailsDialog({ revert: false });
+        });
         dlgExecDetails.addEventListener('close', () => {
             void flushExecDetailsSave();
         });


### PR DESCRIPTION
### Motivation
- Ensure the "Instructions et commentaire d’exercice" dialog can be closed reliably from all expected interactions (OK, ✕, clicking backdrop, Escape, or accidental form submit) to prevent the modal from becoming stuck open.

### Description
- Added handlers on `dlgExecDetails` to close via backdrop click, handle the `cancel` event (Escape) with `preventDefault`, and intercept the dialog form `submit` to call `closeExecDetailsDialog` instead of letting default behavior interfere.
- Kept existing `execDetailsClose` (OK) and `execDetailsCancel` (✕) handlers and left the `close` listener that triggers `flushExecDetailsSave` unchanged.

### Testing
- Ran `node --check ui-session-execution-edit.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132ff65874833290e78525a0d0eaca)