### PR TITLE
Ajuster le format de durée et afficher la durée dans la modal de commentaire de séance

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
         </div>
 
         <div class="session-comments-header">
-            <input id="sessionDurationPreview" class="input session-duration-preview" type="text" readonly aria-label="Durée estimée de la séance" value="0mn" />
+            <input id="sessionDurationPreview" class="input session-duration-preview" type="text" readonly aria-label="Durée estimée de la séance" value="0m" />
             <button id="btnSessionComments" class="session-comments-content" type="button" aria-label="Ajouter un commentaire de séance">
                 <span id="sessionCommentsPreview" class="session-comments-text details" data-empty="true" data-placeholder="commentaires"></span>
             </button>
@@ -1519,6 +1519,13 @@
         </div>
         <div class="modal-body">
             <div class="bloque">
+                <div class="session-comments-header">
+                    <input id="sessionCommentDurationPreview" class="input session-duration-preview" type="text" readonly aria-label="Durée estimée de la séance" value="0m" />
+                    <button class="session-comments-content" type="button" aria-label="Instructions de séance" disabled>
+                        <span id="sessionCommentInstructionsPreview" class="session-comments-text details" data-empty="true" data-placeholder="instructions"></span>
+                    </button>
+                    <button class="btn ghost session-comments-more" type="button" aria-label="Informations de séance" disabled>...</button>
+                </div>
                 <div class="vstack">
                     <label class="lbl" for="sessionCommentInstructions">Instructions</label>
                     <div id="sessionCommentInstructions" class="input session-comment-instructions" role="textbox" aria-readonly="true" data-empty="true" data-placeholder="Aucune instruction"></div>

--- a/ui-session.js
+++ b/ui-session.js
@@ -1795,6 +1795,8 @@
         refs.btnSessionComments = document.getElementById('btnSessionComments');
         refs.sessionCommentsPreview = document.getElementById('sessionCommentsPreview');
         refs.sessionDurationPreview = document.getElementById('sessionDurationPreview');
+        refs.sessionCommentDurationPreview = document.getElementById('sessionCommentDurationPreview');
+        refs.sessionCommentInstructionsPreview = document.getElementById('sessionCommentInstructionsPreview');
         refs.sessionCreateRoutine = document.getElementById('sessionCreateRoutine');
         refs.sessionDelete = document.getElementById('sessionDelete');
         refs.sessionShare = document.getElementById('sessionShare');
@@ -2254,12 +2256,21 @@
     }
 
     function updateSessionDurationPreview(session) {
-        const { sessionDurationPreview } = ensureRefs();
-        if (!sessionDurationPreview) {
+        const {
+            sessionDurationPreview,
+            sessionCommentDurationPreview
+        } = ensureRefs();
+        if (!sessionDurationPreview && !sessionCommentDurationPreview) {
             return;
         }
         const totalSeconds = computeSessionEstimatedDurationSeconds(session);
-        sessionDurationPreview.value = formatSessionDuration(totalSeconds);
+        const formattedDuration = formatSessionDuration(totalSeconds);
+        if (sessionDurationPreview) {
+            sessionDurationPreview.value = formattedDuration;
+        }
+        if (sessionCommentDurationPreview) {
+            sessionCommentDurationPreview.value = formattedDuration;
+        }
     }
 
     function computeSessionEstimatedDurationSeconds(session) {
@@ -2281,11 +2292,11 @@
         const safeSeconds = Math.max(0, safeInt(totalSeconds, 0));
         const totalMinutes = Math.round(safeSeconds / 60);
         if (totalMinutes < 60) {
-            return `${totalMinutes}mn`;
+            return `${totalMinutes}m`;
         }
         const hours = Math.floor(totalMinutes / 60);
         const minutes = totalMinutes % 60;
-        return `${hours}h${String(minutes).padStart(2, '0')}mn`;
+        return `${hours}h${String(minutes).padStart(2, '0')}`;
     }
 
     async function resolveSessionInstructionsText() {
@@ -2316,13 +2327,22 @@
     }
 
     function updateSessionInstructionsPreview(text) {
-        const { sessionCommentInstructions } = ensureRefs();
-        if (!sessionCommentInstructions) {
+        const {
+            sessionCommentInstructions,
+            sessionCommentInstructionsPreview
+        } = ensureRefs();
+        if (!sessionCommentInstructions && !sessionCommentInstructionsPreview) {
             return;
         }
         const instructions = typeof text === 'string' ? text.trim() : '';
-        sessionCommentInstructions.textContent = instructions;
-        sessionCommentInstructions.dataset.empty = instructions ? 'false' : 'true';
+        if (sessionCommentInstructions) {
+            sessionCommentInstructions.textContent = instructions;
+            sessionCommentInstructions.dataset.empty = instructions ? 'false' : 'true';
+        }
+        if (sessionCommentInstructionsPreview) {
+            sessionCommentInstructionsPreview.textContent = instructions;
+            sessionCommentInstructionsPreview.dataset.empty = instructions ? 'false' : 'true';
+        }
     }
 
     function focusTextareaAtEnd(textarea) {


### PR DESCRIPTION
### Motivation
- Uniformiser l’affichage de la durée de séance en retirant le suffixe `mn` et réutiliser la même première ligne durée/instructions dans la modal « Commentaire de séance ». 
- Permettre à l’utilisateur de voir rapidement la durée estimée et les instructions depuis la popup de commentaires sans dupliquer la logique.

### Description
- Modifie la fonction `formatSessionDuration` pour retourner `Xm` pour les durées < 1h et `XhYY` pour les durées ≥ 1h (suppression du suffixe `mn`).
- Synchronise l’aperçu de durée en haut de l’écran et dans la modal de commentaire via `updateSessionDurationPreview` (mise à jour de `sessionDurationPreview` et `sessionCommentDurationPreview`).
- Ajoute dans `index.html` une première ligne dans la modal `dlgSessionComment` contenant `sessionCommentDurationPreview`, `sessionCommentInstructionsPreview` et le bouton `...` (en lecture seule / désactivé) pour reproduire la structure de l’écran séance.
- Aligne l’aperçu d’instructions en réutilisant `updateSessionInstructionsPreview` pour remplir à la fois `sessionCommentInstructions` et `sessionCommentInstructionsPreview`.
- Fichiers modifiés : `ui-session.js`, `index.html`.

### Testing
- Vérification du diff avec `git diff` et inspection du contenu modifié ; la revue du diff montre les changements attendus (succès).
- Commit effectué avec message de changement (succès).
- Aucun test automatisé ajouté; aucun test unitaire automatique existant n’a été exécuté lors de cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13314605188332975bd66c067c9ff7)