### PR TITLE
Corrige la fermeture de la popup instructions/commentaires d'exercice

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -995,6 +995,14 @@
         }
         const actions = document.createElement('div');
         actions.className = 'exec-details-popover__actions';
+        const closeButton = document.createElement('button');
+        closeButton.type = 'button';
+        closeButton.className = 'btn ghost';
+        closeButton.textContent = 'Fermer';
+        closeButton.addEventListener('click', (event) => {
+            event.stopPropagation();
+            clearDetailsPopover();
+        });
         const editButton = document.createElement('button');
         editButton.type = 'button';
         editButton.className = 'btn ghost';
@@ -1004,7 +1012,7 @@
             clearDetailsPopover();
             void openExecDetailsDialog();
         });
-        actions.appendChild(editButton);
+        actions.append(closeButton, editButton);
         popover.append(text, actions);
         document.body.appendChild(popover);
         const rect = target.getBoundingClientRect();

--- a/ui-session.js
+++ b/ui-session.js
@@ -325,7 +325,18 @@
                 text.appendChild(commentsNode);
             }
         }
-        popover.append(text);
+        const actions = document.createElement('div');
+        actions.className = 'exec-details-popover__actions';
+        const closeButton = document.createElement('button');
+        closeButton.type = 'button';
+        closeButton.className = 'btn ghost';
+        closeButton.textContent = 'Fermer';
+        closeButton.addEventListener('click', (event) => {
+            event.stopPropagation();
+            clearDetailsPopover();
+        });
+        actions.appendChild(closeButton);
+        popover.append(text, actions);
         document.body.appendChild(popover);
         const rect = target.getBoundingClientRect();
         const popRect = popover.getBoundingClientRect();


### PR DESCRIPTION
### Motivation
- La popup "Instructions et commentaire d’exercice" pouvait rester bloquée et impossible à fermer parce que la fermeture reposait uniquement sur le clic extérieur ou les écouteurs d'événements. 
- Il faut un contrôle explicite pour garantir la fermeture dans tous les contextes d'interaction (mobile, focus, animations). 

### Description
- Ajout d'un bouton explicite `Fermer` dans la popover des détails d'exercice dans `ui-session.js` pour fournir un moyen direct de fermer la popup. 
- Ajout du même bouton `Fermer` dans `ui-session-execution-edit.js` et conservation du bouton `Éditer` existant pour garder l'accès à l'édition. 
- Les boutons utilisent `event.stopPropagation()` puis appellent `clearDetailsPopover()` pour éviter les interactions conflictuelles avec les écouteurs globaux et garantir la fermeture visible. 

### Testing
- Vérification de la syntaxe JavaScript sur les fichiers modifiés avec `node --check ui-session.js` et `node --check ui-session-execution-edit.js`, les deux commandes ont réussi. 
- Tests manuels attendus en UI : ouverture de la popover puis clic sur `Fermer` pour confirmer la disparition du popover (test de régression simple, manuel).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1332c145cc833291f62bb59e9db9c7)