### PR TITLE
Close context popup before opening superset editor

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -2591,6 +2591,14 @@
     }
 
     async function openSupersetEditorFromCurrentExercise() {
+        const { dlgExecMoveEditor } = assertRefs();
+        if (dlgExecMoveEditor?.open) {
+            if (A.closeDialog) {
+                A.closeDialog(dlgExecMoveEditor);
+            } else {
+                dlgExecMoveEditor.close();
+            }
+        }
         const exercise = getExercise();
         if (!exercise?.id) return;
         let superset = getSupersetForExercise(exercise.id);


### PR DESCRIPTION
### Motivation
- Le popup contextuel d’exercice (`dlgExecMoveEditor`) restait visible après l’ouverture/fermeture de l’éditeur de superset, il faut le fermer explicitement avant d’ouvrir l’éditeur pour éviter ce comportement.

### Description
- Dans `ui-session-execution-edit.js` la fonction `openSupersetEditorFromCurrentExercise` appelle désormais `assertRefs()` pour récupérer `dlgExecMoveEditor` et ferme ce dialogue s’il est ouvert en utilisant `A.closeDialog(dlgExecMoveEditor)` si disponible, sinon `dlgExecMoveEditor.close()`, puis poursuit l’ouverture de l’éditeur de superset.

### Testing
- Vérification statique du fichier modifié avec `node --check ui-session-execution-edit.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14407ec9d88332bc620b52dc73976f)