### PR TITLE
Ajoute l’aperçu de durée estimée sur l'écran Routine

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,6 +573,7 @@
 
     <main class="content">
         <div class="session-comments-header">
+            <input id="routineDurationPreview" class="input session-duration-preview" type="text" readonly aria-label="Durée estimée de la routine" value="0m" />
             <button id="btnRoutineDetails" class="session-comments-content" type="button" aria-label="Ajouter des instructions de routine">
                 <span id="routineDetailsPreview" class="session-comments-text details" data-empty="true" data-placeholder="Instructions de routine"></span>
             </button>

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -102,6 +102,7 @@
         refs.routineName = document.getElementById('routineName');
         refs.routineIcon = document.getElementById('routineIcon');
         refs.btnRoutineDetails = document.getElementById('btnRoutineDetails');
+        refs.routineDurationPreview = document.getElementById('routineDurationPreview');
         refs.routineDetailsPreview = document.getElementById('routineDetailsPreview');
         refs.dlgRoutineDetails = document.getElementById('dlgRoutineDetails');
         refs.routineDetailsInput = document.getElementById('routineDetailsInput');
@@ -876,6 +877,7 @@
             routineEditTitle.textContent = state.routine.name || 'Routine';
         }
         updateRoutineDetailsPreview(state.routine);
+        updateRoutineDurationPreview(state.routine);
         refreshValueStates();
         renderRoutineList();
     }
@@ -888,6 +890,41 @@
         const instructions = routine?.instructions_routine_global || '';
         routineDetailsPreview.textContent = instructions;
         routineDetailsPreview.dataset.empty = instructions.trim() ? 'false' : 'true';
+    }
+
+    function updateRoutineDurationPreview(routine) {
+        const { routineDurationPreview } = ensureRefs();
+        if (!routineDurationPreview) {
+            return;
+        }
+        const totalSeconds = computeRoutineEstimatedDurationSeconds(routine);
+        routineDurationPreview.value = formatSessionDuration(totalSeconds);
+    }
+
+    function computeRoutineEstimatedDurationSeconds(routine) {
+        const repDurationSeconds = Math.max(1, safeInt(A.preferences?.getRepDurationSeconds?.(), 4));
+        const moves = Array.isArray(routine?.moves) ? routine.moves : [];
+        let totalSeconds = 0;
+        for (const move of moves) {
+            const sets = Array.isArray(move?.sets) ? move.sets : [];
+            for (const set of sets) {
+                const reps = Math.max(0, safeInt(set?.reps, 0));
+                const rest = Math.max(0, safeInt(set?.rest, 0));
+                totalSeconds += rest + (reps * repDurationSeconds);
+            }
+        }
+        return totalSeconds;
+    }
+
+    function formatSessionDuration(totalSeconds) {
+        const safeSeconds = Math.max(0, safeInt(totalSeconds, 0));
+        const totalMinutes = Math.round(safeSeconds / 60);
+        if (totalMinutes < 60) {
+            return `${totalMinutes}m`;
+        }
+        const hours = Math.floor(totalMinutes / 60);
+        const minutes = totalMinutes % 60;
+        return `${hours}h${String(minutes).padStart(2, '0')}`;
     }
 
     function renderIconPreview() {


### PR DESCRIPTION
### Motivation
- Rendre visible la durée estimée d'une routine dans l'écran d'édition avec la même logique et le même affichage que pour une séance afin d'améliorer la cohérence de l'interface.

### Description
- `index.html` : insertion d'un champ `input` `#routineDurationPreview` dans le bloc `.session-comments-header` de `screenRoutineEdit` pour afficher la durée.
- `ui-routine-edit.js` : ajout de la référence DOM `routineDurationPreview` et appel de la mise à jour depuis `renderRoutine` via `updateRoutineDurationPreview`. 
- `ui-routine-edit.js` : ajout des fonctions `updateRoutineDurationPreview(routine)`, `computeRoutineEstimatedDurationSeconds(routine)` et `formatSessionDuration(totalSeconds)` pour calculer la durée (somme des `rest` + `reps × durée_par_rep` provenant des préférences) et la formater en `Xm` ou `XhYY`.
- Le calcul réutilise la même logique que pour la séance (`rep duration` via `A.preferences?.getRepDurationSeconds`) pour assurer un affichage cohérent.

### Testing
- Aucune suite de tests automatisés n'a été ajoutée ou exécutée pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1453aa1e20833286dbbd36d428081f)