### PR TITLE
Add superset support to routine move editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1425,11 +1425,15 @@
     <form method="dialog" class="modal-context-form">
         <button id="routineMoveUp" class="modal-context-action" type="button">Remonter</button>
         <button id="routineMoveDown" class="modal-context-action" type="button">Descendre</button>
+        <button id="routineMoveSuperset" class="modal-context-action" type="button">Superset</button>
         <button id="routineMoveAnnotate" class="modal-context-action" type="button">Expliquer</button>
         <button id="routineMoveDuplicate" class="modal-context-action" type="button">Dupliquer</button>
         <button id="routineMoveReplace" class="modal-context-action" type="button">Remplacer</button>
         <button id="routineMoveDelete" class="modal-context-action is-danger" type="button">Supprimer</button>
     </form>
+</dialog>
+<dialog id="dlgRoutineSupersetEditor" class="modal modal-context">
+    <form method="dialog" class="modal-context-form" id="routineSupersetList"></form>
 </dialog>
 <!-- ==================== -->
 

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -634,7 +634,7 @@
     }
 
     function createEmptyRoutine(id) {
-        return { id, name: 'Routine', icon: ICONS[0], instructions_routine_global: '', moves: [] };
+        return { id, name: 'Routine', icon: ICONS[0], instructions_routine_global: '', supersets: [], moves: [] };
     }
 
     function pickTextValue(...values) {
@@ -655,6 +655,7 @@
             name: routine.name || 'Routine',
             icon: routine.icon || ICONS[0],
             instructions_routine_global: pickTextValue(routine.instructions_routine_global, routine.details),
+            supersets: Array.isArray(routine.supersets) ? [...routine.supersets] : [],
             moves: Array.isArray(routine.moves) ? [...routine.moves] : []
         };
         normalized.moves = normalized.moves.map((move, index) => ({
@@ -975,6 +976,10 @@
         const { card, start, body } = structure;
         card.dataset.moveId = move.id;
         start.classList.add('list-card__start--solo');
+        const superset = getSupersetForMove(move.id);
+        if (superset?.color) {
+            card.style.border = `2px solid ${superset.color}`;
+        }
 
         const name = document.createElement('div');
         name.className = 'element exercise-card-name';
@@ -1355,6 +1360,15 @@
             name: routine.name,
             icon: routine.icon,
             instructions_routine_global: routine.instructions_routine_global || '',
+            supersets: Array.isArray(routine.supersets)
+                ? routine.supersets
+                    .map((superset, index) => ({
+                        id: superset.id || `ss_${index + 1}`,
+                        color: superset.color || '#0f62fe',
+                        moveIds: Array.isArray(superset.moveIds) ? superset.moveIds.map((moveId) => String(moveId)) : []
+                    }))
+                    .filter((superset) => superset.moveIds.length > 0)
+                : [],
             moves: routine.moves.map((move, index) => ({
                 id: move.id,
                 pos: safeInt(move.pos, index + 1),
@@ -1384,6 +1398,13 @@
             const other = b[index];
             return entry.moveId === other.moveId && entry.pos === other.pos;
         });
+    }
+
+    function getSupersetForMove(moveId) {
+        if (!state.routine || !Array.isArray(state.routine.supersets)) {
+            return null;
+        }
+        return state.routine.supersets.find((superset) => Array.isArray(superset.moveIds) && superset.moveIds.includes(moveId)) || null;
     }
 
     function getRpeDatasetValue(value) {

--- a/ui-routine-execution-edit.js
+++ b/ui-routine-execution-edit.js
@@ -141,6 +141,9 @@
         refs.routineMoveDown = document.getElementById('routineMoveDown');
         refs.routineMoveAnnotate = document.getElementById('routineMoveAnnotate');
         refs.routineMoveDuplicate = document.getElementById('routineMoveDuplicate');
+        refs.routineMoveSuperset = document.getElementById('routineMoveSuperset');
+        refs.dlgRoutineSupersetEditor = document.getElementById('dlgRoutineSupersetEditor');
+        refs.routineSupersetList = document.getElementById('routineSupersetList');
         refs.dlgRoutineMoveDetails = document.getElementById('dlgRoutineMoveDetails');
         refs.routineMoveDetailsInput = document.getElementById('routineMoveDetailsInput');
         refs.routineMoveDetailsClose = document.getElementById('routineMoveDetailsClose');
@@ -180,6 +183,9 @@
             'routineMoveDown',
             'routineMoveAnnotate',
             'routineMoveDuplicate',
+            'routineMoveSuperset',
+            'dlgRoutineSupersetEditor',
+            'routineSupersetList',
             'dlgRoutineMoveDetails',
             'routineMoveDetailsInput',
             'routineMoveDetailsClose',
@@ -299,7 +305,8 @@
             routineMoveUp,
             routineMoveDown,
             routineMoveAnnotate,
-            routineMoveDuplicate
+            routineMoveDuplicate,
+            routineMoveSuperset
         } = assertRefs();
         routineMoveAddSet.addEventListener('click', () => {
             addSet();
@@ -327,6 +334,9 @@
         });
         routineMoveDuplicate.addEventListener('click', () => {
             void duplicateMove();
+        });
+        routineMoveSuperset.addEventListener('click', () => {
+            void openSupersetEditorFromCurrentMove();
         });
     }
 
@@ -966,10 +976,17 @@
             return;
         }
         moves.splice(index, 1);
+        const removedMoveId = state.moveId;
         moves.forEach((move, idx) => {
             move.pos = idx + 1;
         });
         state.routine.moves = moves;
+        state.routine.supersets = ensureRoutineSupersets()
+            .map((superset) => ({
+                ...superset,
+                moveIds: (superset.moveIds || []).filter((moveId) => moveId !== removedMoveId)
+            }))
+            .filter((superset) => Array.isArray(superset.moveIds) && superset.moveIds.length > 0);
         await persistRoutine({ refresh: false });
         if (A.closeDialog) {
             A.closeDialog(refs.dlgRoutineMoveEditor);
@@ -1172,6 +1189,15 @@
             name: routine.name || 'Routine',
             icon: routine.icon || '🏋️',
             instructions_routine_global: pickTextValue(routine.instructions_routine_global, routine.details),
+            supersets: Array.isArray(routine.supersets)
+                ? routine.supersets.map((superset, index) => ({
+                    id: superset.id || `ss_${index + 1}`,
+                    color: typeof superset.color === 'string' ? superset.color : getSupersetPalette()[0],
+                    moveIds: Array.isArray(superset.moveIds)
+                        ? superset.moveIds.map((moveId) => String(moveId))
+                        : []
+                })).filter((superset) => superset.moveIds.length > 0)
+                : [],
             moves: Array.isArray(routine.moves)
                 ? routine.moves.map((move, index) => ({
                     id: move.id || uid('move'),
@@ -1203,6 +1229,15 @@
             name: routine.name,
             icon: routine.icon,
             instructions_routine_global: routine.instructions_routine_global || '',
+            supersets: Array.isArray(routine.supersets)
+                ? routine.supersets
+                    .map((superset, index) => ({
+                        id: superset.id || `ss_${index + 1}`,
+                        color: superset.color || getSupersetPalette()[0],
+                        moveIds: Array.isArray(superset.moveIds) ? superset.moveIds.map((moveId) => String(moveId)) : []
+                    }))
+                    .filter((superset) => superset.moveIds.length > 0)
+                : [],
             moves: Array.isArray(routine.moves)
                 ? routine.moves.map((move, index) => ({
                     id: move.id || uid('move'),
@@ -1248,6 +1283,71 @@
         }
         switchScreen(state.callerScreen || 'screenRoutineEdit');
         void A.refreshRoutineEdit();
+    }
+
+    function getSupersetPalette() {
+        return ['#0f62fe', '#ff7d00', '#8a3ffc', '#198038', '#d12771', '#005d5d', '#a56eff'];
+    }
+
+    function ensureRoutineSupersets() {
+        if (!state.routine) return [];
+        if (!Array.isArray(state.routine.supersets)) state.routine.supersets = [];
+        return state.routine.supersets;
+    }
+
+    function getSupersetForMove(moveId) {
+        return ensureRoutineSupersets().find((s) => Array.isArray(s.moveIds) && s.moveIds.includes(moveId)) || null;
+    }
+
+    async function openSupersetEditorFromCurrentMove() {
+        const { dlgRoutineMoveEditor } = assertRefs();
+        if (A.closeDialog) A.closeDialog(dlgRoutineMoveEditor); else dlgRoutineMoveEditor?.close();
+        const move = findMove();
+        if (!move?.id) return;
+        let superset = getSupersetForMove(move.id);
+        if (!superset) {
+            const supersets = ensureRoutineSupersets();
+            const used = new Set(supersets.map((s) => s.color));
+            const color = getSupersetPalette().find((c) => !used.has(c)) || getSupersetPalette()[0];
+            superset = { id: `ss_${Date.now()}`, color, moveIds: [move.id] };
+            supersets.push(superset);
+        }
+        renderRoutineSupersetEditor(superset.id);
+    }
+
+    function renderRoutineSupersetEditor(supersetId) {
+        const { dlgRoutineSupersetEditor, routineSupersetList } = assertRefs();
+        const target = ensureRoutineSupersets().find((s) => s.id === supersetId);
+        if (!target || !Array.isArray(state.routine?.moves)) return;
+        routineSupersetList.innerHTML = '';
+        state.routine.moves.forEach((move) => {
+            const row = document.createElement('button');
+            row.type = 'button';
+            row.className = 'modal-context-action';
+            row.textContent = (move.exerciseName || 'Exercice').trim();
+            const existing = getSupersetForMove(move.id);
+            if (existing?.color) row.style.borderLeft = `6px solid ${existing.color}`;
+            if (target.moveIds.includes(move.id)) row.classList.add('selected');
+            row.addEventListener('click', () => {
+                if (target.moveIds.includes(move.id)) {
+                    target.moveIds = target.moveIds.filter((id) => id !== move.id);
+                } else {
+                    const owner = getSupersetForMove(move.id);
+                    if (owner) owner.moveIds = owner.moveIds.filter((id) => id !== move.id);
+                    target.moveIds.push(move.id);
+                }
+                renderRoutineSupersetEditor(supersetId);
+            });
+            routineSupersetList.appendChild(row);
+        });
+        dlgRoutineSupersetEditor.showModal();
+        dlgRoutineSupersetEditor.onclick = (event) => {
+            if (event.target === dlgRoutineSupersetEditor) {
+                state.routine.supersets = ensureRoutineSupersets().filter((s) => Array.isArray(s.moveIds) && s.moveIds.length > 0);
+                dlgRoutineSupersetEditor.close();
+                void persistRoutine();
+            }
+        };
     }
 
     function syncRoutineListOrder() {


### PR DESCRIPTION
### Motivation
- Ajouter la fonctionnalité « superset » aux routines pour permettre de grouper des mouvements au même titre que pour une séance, avec édition et persistance des groupes dans la routine.
- Fournir une UI cohérente avec le flux de séance existant (sélection d’exercices, attribution exclusive à un superset, couleur identifiante).

### Description
- Ajout d’un bouton `routineMoveSuperset` et d’un dialog `dlgRoutineSupersetEditor` dans `index.html` pour l’édition des supersets de routine.
- Implémentation côté UI-move-edit dans `ui-routine-execution-edit.js` : références, binding du bouton, fonctions `openSupersetEditorFromCurrentMove`, `renderRoutineSupersetEditor`, `ensureRoutineSupersets`, `getSupersetForMove` et `getSupersetPalette` pour créer/éditer/fermer les supersets et persister la routine.
- Conservation et sérialisation/desérialisation des `supersets` dans les routines via `normalizeRoutine` et `serializeRoutine` dans `ui-routine-execution-edit.js` et `ui-routine-edit.js` afin d’enregistrer/recharger les groupes.
- Nettoyage automatique des `supersets` lors de la suppression d’un move et mise en évidence visuelle d’un move appartenant à un superset via une bordure colorée dans `ui-routine-edit.js`.

### Testing
- Vérification de présence des nouvelles références et points d’entrée via `rg -n "routineMoveSuperset|dlgRoutineSupersetEditor|routineSupersetList"` which matched the added symbols (succeeded).
- Exécution d’un petit runtime smoke check `node -e "console.log('ok')"` to ensure environment JS runs (succeeded).
- Project changes scanned with `rg` to confirm insertion points and function names (searches completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1454c16dfc8332adbf1c8d6e9196d0)