### PR TITLE
Refonte écran Plan : header, commentaire et menu d'actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -836,24 +836,20 @@
             <button id="btnPlanEditBack" class="btn" title="Retour">◀︎</button>
         </div>
         <div class="header-center">
-            <div class="title">Modification du plan</div>
+            <div id="planEditTitle" class="title">Plan</div>
         </div>
-        <div class="header-right"></div>
+        <div class="header-right">
+            <button id="planEditEdit" class="btn" type="button" title="Éditer le plan" aria-label="Éditer le plan">✎</button>
+            <button id="planEditMenu" class="btn" type="button" aria-label="Actions du plan">…</button>
+        </div>
     </header>
 
     <main class="content">
         <div class="bloque">
             <div class="row">
-                <input id="planEditName" class="input full" type="text" placeholder="Nom du plan" />
-            </div>
-            <div class="row">
-                <textarea id="planEditComment" class="input full" rows="4" placeholder="Commentaire du plan"></textarea>
-            </div>
-            <div class="row">
-                <button id="btnPlanApply" class="btn full" type="button">✅ Appliquer ce plan</button>
-            </div>
-            <div class="row">
-                <button id="btnPlanDuplicate" class="btn full" type="button">📄 Dupliquer ce plan</button>
+                <button id="btnPlanComment" class="session-comments-content" type="button" aria-label="Ajouter un commentaire de plan">
+                    <span id="planCommentPreview" class="session-comments-text" data-empty="true">Ajouter un commentaire de plan</span>
+                </button>
             </div>
             <div class="planning-plan-actions">
                 <button id="btnPlanEditCycle" class="exercise-card list-card planning-action-card clickable" type="button">
@@ -897,6 +893,69 @@
     </main>
 
 </section>
+<!-- ==================== -->
+
+<!-- ========== Plan : modale méta ========== -->
+<dialog id="dlgPlanEditor" class="modal modal-fixed modal-centered modal-top">
+    <form method="dialog" class="modal-form">
+        <div class="modal-header">
+            <div class="title modal-title">Éditer</div>
+            <button id="planEditorCancel" class="btn ghost modal-close" type="button">✕</button>
+        </div>
+        <div class="modal-body">
+            <div class="bloque">
+                <div class="vstack">
+                    <label class="lbl" for="planEditName">Nom</label>
+                    <input id="planEditName" class="input" placeholder="Nom du plan" />
+                </div>
+            </div>
+            <div class="bloque">
+                <div class="vstack">
+                    <label class="lbl" for="planEditIcon">Icône</label>
+                    <select id="planEditIcon" class="input" aria-label="Icône du plan">
+                        <option>📋</option><option>🏋️</option><option>💪</option><option>🔥</option><option>⚡</option><option>🧠</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button id="planEditorClose" class="btn cta full" type="button">ok</button>
+        </div>
+    </form>
+</dialog>
+<!-- ==================== -->
+
+<!-- ========== Plan : actions ========== -->
+<dialog id="dlgPlanActions" class="modal modal-context">
+    <form method="dialog" class="modal-context-form">
+        <button id="planUseAction" class="modal-context-action" type="button">utiliser</button>
+        <button id="planShareAction" class="modal-context-action" type="button">partager</button>
+        <button id="planDuplicateAction" class="modal-context-action" type="button">dupliquer</button>
+        <button id="planDeleteAction" class="modal-context-action is-danger" type="button">supprimer</button>
+    </form>
+</dialog>
+<!-- ==================== -->
+
+<!-- ========== Plan : commentaire ========== -->
+<dialog id="dlgPlanComment" class="modal modal-fixed modal-centered modal-top">
+    <form method="dialog" class="modal-form">
+        <div class="modal-header">
+            <div class="title modal-title">Commentaire de plan</div>
+            <button id="planCommentCancel" class="btn ghost modal-close" type="button">✕</button>
+        </div>
+        <div class="modal-body">
+            <div class="bloque">
+                <div class="vstack">
+                    <label class="lbl" for="planEditComment">Commentaire de plan</label>
+                    <textarea id="planEditComment" class="input session-comment-textarea" rows="8" placeholder="Ajouter un commentaire de plan"></textarea>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button id="planCommentClose" class="btn cta full" type="button">ok</button>
+        </div>
+    </form>
+</dialog>
 <!-- ==================== -->
 
 <!-- ========== Planning : Cycle ========== -->

--- a/ui-planning.js
+++ b/ui-planning.js
@@ -28,6 +28,8 @@
     const planEditState = {
         plan: null
     };
+    let planMetaSnapshot = null;
+    let planCommentSnapshot = null;
 
     document.addEventListener('DOMContentLoaded', () => {
         ensureRefs();
@@ -413,9 +415,10 @@
 
     function renderPlanEdit(plan) {
         const {
+            planEditTitle,
+            planCommentPreview,
             planEditName,
             planEditComment,
-            btnPlanApply,
             planEditCycleDetails,
             planEditMesoDetails,
             planEditProgressionDetails
@@ -423,12 +426,16 @@
         if (!planEditName || !planEditComment) {
             return;
         }
+        if (planEditTitle) {
+            const icon = plan?.icon || '📋';
+            planEditTitle.textContent = `${icon} ${plan?.name || 'Plan'}`;
+        }
         planEditName.value = plan?.name || '';
         planEditComment.value = plan?.comment || '';
-        if (btnPlanApply) {
-            const isActive = Boolean(plan?.active);
-            btnPlanApply.disabled = isActive;
-            btnPlanApply.textContent = isActive ? '✅ Plan actuel' : '✅ Appliquer ce plan';
+        if (planCommentPreview) {
+            const comment = String(plan?.comment || '').trim();
+            planCommentPreview.textContent = comment || 'Ajouter un commentaire de plan';
+            planCommentPreview.dataset.empty = comment ? 'false' : 'true';
         }
         if (planEditCycleDetails) {
             planEditCycleDetails.textContent = buildPlanCycleDetails(plan);
@@ -820,11 +827,15 @@
         refs.tabPlanning = document.getElementById('tabPlanning');
         refs.planningPlansList = document.getElementById('planningPlansList');
         refs.planningRoutinesList = document.getElementById('planningRoutinesList');
+        refs.planEditTitle = document.getElementById('planEditTitle');
+        refs.planEditEdit = document.getElementById('planEditEdit');
+        refs.planEditMenu = document.getElementById('planEditMenu');
         refs.btnPlanEditBack = document.getElementById('btnPlanEditBack');
         refs.planEditName = document.getElementById('planEditName');
+        refs.planEditIcon = document.getElementById('planEditIcon');
         refs.planEditComment = document.getElementById('planEditComment');
-        refs.btnPlanApply = document.getElementById('btnPlanApply');
-        refs.btnPlanDuplicate = document.getElementById('btnPlanDuplicate');
+        refs.btnPlanComment = document.getElementById('btnPlanComment');
+        refs.planCommentPreview = document.getElementById('planCommentPreview');
         refs.btnPlanEditCycle = document.getElementById('btnPlanEditCycle');
         refs.btnPlanEditMeso = document.getElementById('btnPlanEditMeso');
         refs.btnPlanEditProgression = document.getElementById('btnPlanEditProgression');
@@ -839,6 +850,17 @@
         refs.planningStartDay = document.getElementById('planningStartDay');
         refs.planningDurationCancel = document.getElementById('planningDurationCancel');
         refs.planningDurationSave = document.getElementById('planningDurationSave');
+        refs.dlgPlanEditor = document.getElementById('dlgPlanEditor');
+        refs.planEditorClose = document.getElementById('planEditorClose');
+        refs.planEditorCancel = document.getElementById('planEditorCancel');
+        refs.dlgPlanActions = document.getElementById('dlgPlanActions');
+        refs.planUseAction = document.getElementById('planUseAction');
+        refs.planShareAction = document.getElementById('planShareAction');
+        refs.planDuplicateAction = document.getElementById('planDuplicateAction');
+        refs.planDeleteAction = document.getElementById('planDeleteAction');
+        refs.dlgPlanComment = document.getElementById('dlgPlanComment');
+        refs.planCommentClose = document.getElementById('planCommentClose');
+        refs.planCommentCancel = document.getElementById('planCommentCancel');
         refsResolved = true;
         return refs;
     }
@@ -846,10 +868,23 @@
     function wireButtons() {
         const {
             btnPlanEditBack,
+            planEditEdit,
+            planEditMenu,
             planEditName,
+            planEditIcon,
             planEditComment,
-            btnPlanApply,
-            btnPlanDuplicate,
+            btnPlanComment,
+            dlgPlanEditor,
+            planEditorClose,
+            planEditorCancel,
+            dlgPlanActions,
+            planUseAction,
+            planShareAction,
+            planDuplicateAction,
+            planDeleteAction,
+            dlgPlanComment,
+            planCommentClose,
+            planCommentCancel,
             btnPlanEditCycle,
             btnPlanEditMeso,
             btnPlanEditProgression,
@@ -864,22 +899,90 @@
             void A.openPlanning({ section: planningState.returnSection || 'plans' });
         });
 
-        planEditName?.addEventListener('input', (event) => {
-            const value = event.target?.value || '';
-            void persistPlanField('name', value.trim());
+        planEditEdit?.addEventListener('click', () => {
+            if (!planEditState.plan) return;
+            planMetaSnapshot = {
+                name: planEditState.plan.name || '',
+                icon: planEditState.plan.icon || '📋'
+            };
+            planEditName.value = planMetaSnapshot.name;
+            if (planEditIcon) {
+                planEditIcon.value = planMetaSnapshot.icon;
+            }
+            dlgPlanEditor?.showModal();
         });
 
-        planEditComment?.addEventListener('input', (event) => {
-            const value = event.target?.value || '';
-            void persistPlanField('comment', value.trim());
+        planEditorClose?.addEventListener('click', () => {
+            if (!planEditState.plan) return;
+            planEditState.plan.name = (planEditName?.value || '').trim() || 'Plan';
+            planEditState.plan.icon = (planEditIcon?.value || '📋').trim();
+            void db.put('plans', planEditState.plan);
+            renderPlanEdit(planEditState.plan);
+            dlgPlanEditor?.close();
+            planMetaSnapshot = null;
         });
 
-        btnPlanApply?.addEventListener('click', () => {
-            void handleApplyPlan();
+        planEditorCancel?.addEventListener('click', () => {
+            if (planMetaSnapshot && planEditName) {
+                planEditName.value = planMetaSnapshot.name;
+                if (planEditIcon) planEditIcon.value = planMetaSnapshot.icon;
+            }
+            dlgPlanEditor?.close();
+            planMetaSnapshot = null;
         });
 
-        btnPlanDuplicate?.addEventListener('click', () => {
-            void handleDuplicatePlan();
+        btnPlanComment?.addEventListener('click', () => {
+            if (!planEditState.plan) return;
+            planCommentSnapshot = planEditState.plan.comment || '';
+            if (planEditComment) {
+                planEditComment.value = planCommentSnapshot;
+            }
+            dlgPlanComment?.showModal();
+        });
+
+        planCommentClose?.addEventListener('click', () => {
+            if (!planEditState.plan) return;
+            planEditState.plan.comment = (planEditComment?.value || '').trim();
+            void db.put('plans', planEditState.plan);
+            renderPlanEdit(planEditState.plan);
+            dlgPlanComment?.close();
+            planCommentSnapshot = null;
+        });
+
+        planCommentCancel?.addEventListener('click', () => {
+            if (planEditComment && typeof planCommentSnapshot === 'string') {
+                planEditComment.value = planCommentSnapshot;
+            }
+            dlgPlanComment?.close();
+            planCommentSnapshot = null;
+        });
+
+        const closePlanActions = () => dlgPlanActions?.close();
+        planEditMenu?.addEventListener('click', () => dlgPlanActions?.showModal());
+        dlgPlanActions?.addEventListener('click', (event) => {
+            if (event.target === dlgPlanActions) closePlanActions();
+        });
+        planUseAction?.addEventListener('click', () => { closePlanActions(); void handleApplyPlan(); });
+        planDuplicateAction?.addEventListener('click', () => { closePlanActions(); void handleDuplicatePlan(); });
+        planDeleteAction?.addEventListener('click', async () => {
+            closePlanActions();
+            const plan = planEditState.plan;
+            if (!plan?.id) return;
+            await db.del('plans', plan.id);
+            await A.openPlanning({ section: planningState.returnSection || 'plans' });
+        });
+        planShareAction?.addEventListener('click', async () => {
+            closePlanActions();
+            const plan = planEditState.plan;
+            if (!plan) return;
+            const text = `Plan ${plan.name || 'sans nom'}\n` + buildPlanCycleDetails(plan);
+            if (navigator.share) {
+                await navigator.share({ title: 'Plan de séances', text });
+            } else if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(text);
+            } else {
+                window.prompt('Copiez ce texte pour le partager :', text);
+            }
         });
 
         btnPlanEditCycle?.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Harmoniser l’écran d’édition d’un plan avec le modèle des routines en affichant le nom dans le header et en fournissant des contrôles pour éditer méta et actions; remplacer les contrôles inline redondants par des dialogs pour une UX cohérente.

### Description
- Remplacement du header de `screenPlanEdit` pour afficher le nom + icône du plan et ajout des boutons `✎` (édition méta) et `…` (menu d'actions) dans `index.html`.
- Suppression des boutons inline `Appliquer ce plan` et `Dupliquer ce plan` et remplacement du champ commentaire par un bouton d’aperçu qui ouvre la modale `dlgPlanComment` pour éditer le `comment` du plan.
- Ajout de trois modales dans `index.html`: `dlgPlanEditor` (éditer nom + icône), `dlgPlanActions` (menu contextuel avec `utiliser`, `partager`, `dupliquer`, `supprimer`) et `dlgPlanComment` (édition du commentaire de plan).
- Mise à jour de `ui-planning.js` pour enregistrer les nouvelles références DOM, afficher le titre dynamique dans `renderPlanEdit`, et ajouter les handlers pour l’édition méta, l’aperçu/édition du commentaire et les actions du menu (avec fallback partage via le presse-papiers / prompt).

### Testing
- `node -c ui-planning.js` a été exécuté pour une vérification de syntaxe et a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145ed5f97c8332b4d413f503ce12bd)