### PR TITLE
Uniformiser l'UI d'édition du Plan avec l'écran Routine

### DIFF
--- a/index.html
+++ b/index.html
@@ -839,17 +839,19 @@
             <div id="planEditTitle" class="title">Plan</div>
         </div>
         <div class="header-right">
-            <button id="planEditEdit" class="btn" type="button" title="Éditer le plan" aria-label="Éditer le plan">✎</button>
-            <button id="planEditMenu" class="btn" type="button" aria-label="Actions du plan">…</button>
+            <button id="planEditEdit" class="btn primary" type="button" title="Éditer le plan" aria-label="Éditer le plan">✎</button>
         </div>
     </header>
 
     <main class="content">
         <div class="bloque">
             <div class="row">
-                <button id="btnPlanComment" class="session-comments-content" type="button" aria-label="Ajouter un commentaire de plan">
-                    <span id="planCommentPreview" class="session-comments-text" data-empty="true">Ajouter un commentaire de plan</span>
-                </button>
+                <div class="session-comments-header plan-comments-header">
+                    <button id="btnPlanComment" class="session-comments-content" type="button" aria-label="Ajouter un commentaire de plan">
+                        <span id="planCommentPreview" class="session-comments-text details" data-empty="true" data-placeholder="Ajouter un commentaire de plan"></span>
+                    </button>
+                    <button id="planEditMenu" class="btn ghost session-comments-more" type="button" aria-label="Actions du plan">...</button>
+                </div>
             </div>
             <div class="planning-plan-actions">
                 <button id="btnPlanEditCycle" class="exercise-card list-card planning-action-card clickable" type="button">

--- a/style.css
+++ b/style.css
@@ -991,7 +991,7 @@ textarea:focus{
 
 .planning-plan-actions{
     display:grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap:var(--gap);
 }
 
@@ -2258,6 +2258,19 @@ textarea:focus{
 .session-comments-more:focus-visible{
     outline: 2px solid var(--focusedBord);
     outline-offset: 2px;
+}
+.plan-comments-header{
+    min-height: 96px;
+}
+.plan-comments-header .session-comments-content{
+    min-height: 72px;
+}
+.plan-comments-header .session-comments-text{
+    min-height: 2.6em;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
 }
 .session-comment-textarea{
     min-height: 180px;


### PR DESCRIPTION
### Motivation
- Rendre l’écran d’édition d’un plan visuellement identique à l’écran `routine` en suivant les demandes de design : seul le bouton crayon emphase à droite, pas de `…` dans le header, ligne de commentaire plus haute et les trois blocs Cycle/Méso/Progression en pleine largeur.

### Description
- Dans `index.html` le bouton d’édition `planEditEdit` devient `class="btn primary"` et le bouton `planEditMenu` est retiré du header pour ne laisser qu’un seul bouton à droite.
- Le bouton `planEditMenu` est réinséré dans la ligne commentaire et le markup de la ligne commentaire a été remplacé par la structure `session-comments-header` contenant `btnPlanComment` et la nouvelle `session-comments-more` pour reproduire le look routine; le `span` utilise désormais `data-placeholder` et la classe `details`.
- Dans `style.css` la grille `.planning-plan-actions` passe d’une rangée 3-colonnes à une colonne pleine largeur (`grid-template-columns: minmax(0, 1fr);`) pour afficher chaque bloc Cycle / Méso / Progression sur une ligne entière.
- Dans `style.css` ajout de règles `.plan-comments-header` et ajustements sur `.plan-comments-header .session-comments-text` pour augmenter la hauteur tactile et limiter l’affichage à deux lignes (`-webkit-line-clamp: 2`).

### Testing
- Aucun test automatisé n’a été exécuté pour ces modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a161466a37c8332965d9b07f953fe2d)