### PR TITLE
Harmonise les espacements verticaux des cartes et la hauteur des boutons Réglages/Application

### DIFF
--- a/style.css
+++ b/style.css
@@ -2290,8 +2290,34 @@ textarea:focus{
 .session-list{
     display:flex;
     flex-direction:column;
+    gap: var(--gap);
     margin:16px 0; 
 }
+
+#planningPlansList{
+    display:flex;
+    flex-direction:column;
+    gap: var(--gap);
+}
+
+/* Harmonisation des espacements verticaux entre fiches/cartes */
+#screenSettings .bloque,
+#screenExercises .bloque,
+#screenPreferences .bloque,
+#screenData .bloque,
+#screenApplication .bloque,
+#screenPlanEdit .planning-plan-actions,
+#routineList,
+#sessionList{
+    gap: var(--gap);
+}
+
+/* Boutons Réglages/Application alignés sur la hauteur des cartes Préférences */
+#screenSettings .row > .btn,
+#screenApplication .row > .btn{
+    min-height: 68px;
+}
+
 
 
 /* Grille des séries (3 par ligne) */


### PR DESCRIPTION
### Motivation
- Uniformiser les écarts verticaux entre les cartes/fiches sur plusieurs écrans pour une présentation cohérente.
- Aligner la hauteur des boutons des écrans Réglages et Application sur la hauteur des boutons/cartes de l’écran Préférences pour l’uniformité visuelle.

### Description
- Mise à jour unique de `style.css` pour ajouter `gap: var(--gap)` à `.session-list` et `#planningPlansList` afin d’appliquer un espacement vertical commun.
- Ajout de `gap: var(--gap)` sur les conteneurs ciblés `#screenSettings .bloque`, `#screenExercises .bloque`, `#screenPreferences .bloque`, `#screenData .bloque`, `#screenApplication .bloque`, `#screenPlanEdit .planning-plan-actions`, `#routineList` et `#sessionList` pour harmoniser les espacements entre fiches/cartes.
- Ajout de `min-height: 68px` pour `#screenSettings .row > .btn` et `#screenApplication .row > .btn` pour égaler la hauteur des boutons de l’écran Préférences.

### Testing
- Vérification du diff via `git diff -- style.css` et inspection du fichier modifié `style.css` (opération réussie).
- Commit des changements avec `git add style.css && git commit -m "Harmonise les écarts de cartes et la hauteur des boutons réglages"` (opération réussie).
- Affichage des lignes modifiées avec `nl -ba style.css | sed -n '2288,2338p'` pour valider l’insertion (opération réussie).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16198b8c5c83329058a707a96c47f7)