### PR TITLE
Mettre en évidence la séance sélectionnée dans l’écran Exercice

### DIFF
--- a/style.css
+++ b/style.css
@@ -1491,6 +1491,9 @@ textarea:focus{
     border-radius: var(--radius);
     background: var(--panelBack);
 }
+.exercise-history-session.is-selected{
+    border-color: var(--emphase);
+}
 .exercise-history-set-line{
     display:grid;
     grid-template-columns: 3ch 6ch 4.5ch auto auto auto auto;

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -88,13 +88,13 @@
     };
 
     A.renderExerciseReadHistoryPanel = async function renderExerciseReadHistoryPanel(options = {}) {
-        const { exercise, exerciseId, container } = options;
-        await renderExerciseHistoryPanel({ exercise, exerciseId, container });
+        const { exercise, exerciseId, container, selectedDateKey = null } = options;
+        await renderExerciseHistoryPanel({ exercise, exerciseId, container, selectedDateKey });
     };
 
     A.renderExerciseReadStatsPanel = async function renderExerciseReadStatsPanel(options = {}) {
-        const { exerciseId, container } = options;
-        await renderExerciseStatsPanel({ exerciseId, container });
+        const { exerciseId, container, selectedDateKey = null } = options;
+        await renderExerciseStatsPanel({ exerciseId, container, selectedDateKey });
     };
 
     /* UTILS */
@@ -522,7 +522,7 @@
     }
 
 
-    async function renderExerciseStatsPanel({ exerciseId, container = null }) {
+    async function renderExerciseStatsPanel({ exerciseId, container = null, selectedDateKey = null }) {
         if (!exerciseId) {
             return;
         }
@@ -536,13 +536,13 @@
         }
         const { exReadTabStats } = assertRefs();
         if (target === exReadTabStats) {
-            await A.renderExerciseStatsEmbedded(exerciseId);
+            await A.renderExerciseStatsEmbedded(exerciseId, { selectedDateKey });
             return;
         }
-        await A.renderExerciseStatsEmbedded(exerciseId, { container: target });
+        await A.renderExerciseStatsEmbedded(exerciseId, { container: target, selectedDateKey });
     }
 
-    async function renderExerciseHistoryPanel({ exercise, exerciseId, container }) {
+    async function renderExerciseHistoryPanel({ exercise, exerciseId, container, selectedDateKey = null }) {
         if (!exerciseId || !container) {
             return;
         }
@@ -586,6 +586,12 @@
         items.forEach(({ session, exerciseInstanceId, sets }) => {
             const wrapper = document.createElement('div');
             wrapper.className = 'exercise-history-session';
+            const sessionDateKey = session?.date || session?.id || '';
+            if (selectedDateKey && sessionDateKey === selectedDateKey) {
+                wrapper.classList.add('is-selected');
+                wrapper.setAttribute('aria-current', 'true');
+            }
+            wrapper.dataset.sessionDate = sessionDateKey;
 
             const dateLabel = document.createElement('div');
             dateLabel.className = 'lbl';

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -506,6 +506,35 @@
         execEditTabExec.hidden = tab !== 'exec';
         execEditTabHistory.hidden = tab !== 'history';
         execEditTabStats.hidden = tab !== 'stats';
+        scheduleActiveTabScroll(tab);
+    }
+
+    function scheduleActiveTabScroll(tab) {
+        requestAnimationFrame(() => {
+            const { screenExecEdit, execEditTabs, execReadHistoryContent } = assertRefs();
+            const content = screenExecEdit?.querySelector('.content');
+            if (!content || screenExecEdit.hidden || state.activeTab !== tab) {
+                return;
+            }
+            if (tab === 'stats') {
+                content.scrollTo({ top: 0, behavior: 'auto' });
+                return;
+            }
+            if (tab !== 'history') {
+                return;
+            }
+            const selectedSession = execReadHistoryContent?.querySelector('.exercise-history-session.is-selected');
+            if (!selectedSession) {
+                return;
+            }
+            const contentRect = content.getBoundingClientRect();
+            const selectedRect = selectedSession.getBoundingClientRect();
+            const tabsHeight = execEditTabs?.getBoundingClientRect().height || 0;
+            content.scrollTo({
+                top: content.scrollTop + selectedRect.top - contentRect.top - tabsHeight - 12,
+                behavior: 'auto'
+            });
+        });
     }
 
     function setSessionTabVisibility(visible) {
@@ -541,13 +570,14 @@
             await A.renderExerciseReadHistoryPanel({
                 exercise: mergedExercise,
                 exerciseId: linkedExerciseId,
-                container: execReadHistoryContent
+                container: execReadHistoryContent,
+                selectedDateKey: state.dateKey
             });
         }
-        await renderStatsDuplicate(mergedExercise, execEditTabStats, linkedExerciseId);
+        await renderStatsDuplicate(mergedExercise, execEditTabStats, linkedExerciseId, state.dateKey);
     }
 
-    async function renderStatsDuplicate(exercise, container, exerciseId) {
+    async function renderStatsDuplicate(exercise, container, exerciseId, selectedDateKey = null) {
         if (!container) {
             return;
         }
@@ -562,7 +592,8 @@
         }
         await A.renderExerciseReadStatsPanel({
             exerciseId,
-            container
+            container,
+            selectedDateKey
         });
     }
 

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -154,14 +154,14 @@
     };
 
     A.renderExerciseStatsEmbedded = async function renderExerciseStatsEmbedded(exerciseId, options = {}) {
-        const { container = null } = options;
+        const { container = null, selectedDateKey = null } = options;
         ensureRefs();
         await loadData(true);
         const exercise = state.exercises.find((item) => item.id === exerciseId) || (await db.get('exercises', exerciseId));
         state.activeExercise = exercise || null;
         renderExerciseDetail();
         if (container) {
-            renderEmbeddedStatsContent(container, exerciseId);
+            renderEmbeddedStatsContent(container, exerciseId, selectedDateKey);
         }
     };
 
@@ -430,12 +430,17 @@
         renderTimeline();
     }
 
-    function renderEmbeddedStatsContent(container, exerciseId) {
+    function renderEmbeddedStatsContent(container, exerciseId, selectedDateKey = null) {
         if (!container) {
             return;
         }
         if (exerciseId) {
             container.dataset.statsExerciseId = exerciseId;
+        }
+        if (selectedDateKey) {
+            container.dataset.statsSelectedDateKey = selectedDateKey;
+        } else {
+            delete container.dataset.statsSelectedDateKey;
         }
         const { statsMetricTags, statsChart, statsChartEmpty, statsRangeTags, statsTimeline, statsExerciseSubtitle, statsTimelineTitle } =
             assertStatsRefs();
@@ -473,7 +478,8 @@
         renderChart({
             statsChart: embeddedChart || statsChart,
             statsChartEmpty: embeddedChartEmpty || statsChartEmpty,
-            statsExerciseSubtitle: embeddedSubtitle || statsExerciseSubtitle
+            statsExerciseSubtitle: embeddedSubtitle || statsExerciseSubtitle,
+            selectedDateKey
         });
 
         if (!container.dataset.statsEmbeddedWired) {
@@ -484,7 +490,10 @@
                     if (nextMetric && METRIC_MAP[nextMetric]) {
                         state.activeMetric = nextMetric;
                         const targetExerciseId = container.dataset.statsExerciseId || exerciseId;
-                        void A.renderExerciseStatsEmbedded(targetExerciseId, { container });
+                        void A.renderExerciseStatsEmbedded(targetExerciseId, {
+                            container,
+                            selectedDateKey: container.dataset.statsSelectedDateKey || null
+                        });
                     }
                     return;
                 }
@@ -500,7 +509,10 @@
                 if (nextRange && RANGE_MAP[nextRange]) {
                     state.activeRange = nextRange;
                     const targetExerciseId = container.dataset.statsExerciseId || exerciseId;
-                    void A.renderExerciseStatsEmbedded(targetExerciseId, { container });
+                    void A.renderExerciseStatsEmbedded(targetExerciseId, {
+                        container,
+                        selectedDateKey: container.dataset.statsSelectedDateKey || null
+                    });
                 }
             });
             container.dataset.statsEmbeddedWired = 'true';
@@ -930,7 +942,12 @@
         const metricDefinition = METRIC_MAP[state.activeMetric] || METRIC_DEFINITIONS[0];
         const rangeDefinition = RANGE_MAP[state.activeRange] || RANGE_OPTIONS[0];
         const cutoff = computeRangeCutoff(rangeDefinition);
-        const filtered = cutoff ? usage.filter((entry) => entry.dateObj >= cutoff) : [...usage];
+        const filtered = includeSelectedUsage(
+            cutoff ? usage.filter((entry) => entry.dateObj >= cutoff) : [...usage],
+            usage,
+            context.selectedDateKey,
+            state.activeMetric
+        );
         const aggregated =
             state.activeMetric === 'setsWeek' ? aggregateUsageByWeek(filtered) : aggregateUsageByDay(filtered);
         if (!aggregated.length) {
@@ -1168,7 +1185,11 @@
             svg.appendChild(circle);
         });
 
-        updateFocusAtPoint(points[points.length - 1]);
+        const selectedPoint = findSelectedChartPoint(points, context.selectedDateKey, state.activeMetric);
+        if (selectedPoint) {
+            isSelectionLocked = true;
+        }
+        updateFocusAtPoint(selectedPoint || points[points.length - 1]);
 
         statsChart.setAttribute(
             'aria-label',
@@ -1177,6 +1198,31 @@
             })`
         );
         statsChart.appendChild(svg);
+    }
+
+    function includeSelectedUsage(filtered, usage, selectedDateKey, metricKey) {
+        const selectedDate = parseDate(selectedDateKey);
+        if (!selectedDate) {
+            return filtered;
+        }
+        const targetKey = metricKey === 'setsWeek' ? getWeekKey(selectedDate) : A.ymd?.(selectedDate);
+        const selectedEntries = usage.filter((entry) => {
+            const entryKey = metricKey === 'setsWeek' ? getWeekKey(entry?.dateObj) : entry?.date;
+            return entryKey === targetKey;
+        });
+        return Array.from(new Set([...filtered, ...selectedEntries]));
+    }
+
+    function findSelectedChartPoint(points, selectedDateKey, metricKey) {
+        const selectedDate = parseDate(selectedDateKey);
+        if (!selectedDate || !Array.isArray(points)) {
+            return null;
+        }
+        const targetKey = metricKey === 'setsWeek' ? getWeekKey(selectedDate) : A.ymd?.(selectedDate);
+        return points.find((point) => {
+            const pointKey = metricKey === 'setsWeek' ? getWeekKey(point.date) : A.ymd?.(point.date);
+            return pointKey === targetKey;
+        }) || null;
     }
 
     function buildGoalMarkers(metricKey, exercise, usage) {


### PR DESCRIPTION
### Motivation
- Lors de l'ouverture des onglets Historique/Statistiques de la fiche Exercice on doit mettre en évidence la séance d'origine et positionner le scroll / la sélection afin d'améliorer la navigation entre séance et fiche exercice.

### Description
- Passe la clé de date sélectionnée via `selectedDateKey` depuis `ui-session-execution-edit.js` vers `ui-exercise-read.js` et `ui-stats.js` pour propager la séance courante aux panneaux Historique et Statistiques.
- Dans `ui-exercise-read.js` la fonction `renderExerciseHistoryPanel` marque la séance correspondante avec la classe `is-selected`, ajoute `aria-current` et stocke `data-session-date` sur le bloc de séance.
- Ajoute `scheduleActiveTabScroll` dans `ui-session-execution-edit.js` pour positionner le bloc `is-selected` en haut du conteneur quand l'onglet Historique est affiché et remet le scroll en haut pour l'onglet Statistiques.
- Dans `ui-stats.js` : inclusion de la séance sélectionnée hors période via `includeSelectedUsage`, sélection du point du graphique via `findSelectedChartPoint` et verrouillage de la sélection pour afficher le point correspondant au `selectedDateKey`; et propagation du `selectedDateKey` aux rendus embarqués.
- Ajoute une règle CSS `.exercise-history-session.is-selected{ border-color: var(--emphase); }` dans `style.css` pour mettre en évidence visuellement la séance sélectionnée.

### Testing
- Exécution de la vérification syntaxique JavaScript sur tous les fichiers avec `node --check` (succès). 
- Démarrage d'un serveur local avec `python3 -m http.server 8765` et récupération de `index.html` avec `curl` pour valider le chargement de la page (succès). 
- Vérification de l'absence d'erreurs avec `git diff --check` (succès). 
- Commit effectué (`Highlight selected exercise session`) ; aucun navigateur headless (Chromium/Playwright) n'était disponible donc aucune capture d'écran automatisée n'a été produite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2413647f48833296d09e36ea87f01a)