### PR TITLE
Corriger le positionnement du scroll vers un exercice de séance

### DIFF
--- a/ui-session.js
+++ b/ui-session.js
@@ -1856,12 +1856,19 @@
 
     const SESSION_SCROLL_TOP_GAP_PX = 10;
 
+    function getSessionVisibleTop(container) {
+        const containerRect = container.getBoundingClientRect();
+        const paddingTop = Number.parseFloat(window.getComputedStyle(container).paddingTop) || 0;
+        return containerRect.top + paddingTop;
+    }
+
     function restoreSessionScroll() {
         if (!sessionScrollState.pendingRestore) {
             return;
         }
+        const { screenSessions } = ensureRefs();
         const container = getSessionScrollContainer();
-        if (!container) {
+        if (!container || screenSessions?.hidden) {
             return;
         }
         let restored = false;
@@ -1870,10 +1877,9 @@
                 `[data-exercise-id="${CSS.escape(sessionScrollState.targetExerciseId)}"]`
             );
             if (target) {
-                const containerRect = container.getBoundingClientRect();
                 const targetRect = target.getBoundingClientRect();
                 const scrollGap = sessionScrollState.targetTopGapPx ?? SESSION_SCROLL_TOP_GAP_PX;
-                container.scrollTop = container.scrollTop + (targetRect.top - containerRect.top) - scrollGap;
+                container.scrollTop += targetRect.top - getSessionVisibleTop(container) - scrollGap;
                 restored = true;
             }
             sessionScrollState.targetExerciseId = null;
@@ -1902,7 +1908,7 @@
         }
         const containerRect = container.getBoundingClientRect();
         const targetRect = target.getBoundingClientRect();
-        const targetTopLimit = containerRect.top + SESSION_SCROLL_TOP_GAP_PX;
+        const targetTopLimit = getSessionVisibleTop(container) + SESSION_SCROLL_TOP_GAP_PX;
         if (targetRect.top < targetTopLimit) {
             container.scrollTop += targetRect.top - targetTopLimit;
         } else if (targetRect.bottom > containerRect.bottom) {


### PR DESCRIPTION
### Motivation
- La navigation depuis l’onglet historique vers une séance affichait la bonne date mais le défilement n’alignait pas précisément l’exercice cliqué en haut de la zone visible.
- La cible de scroll pouvait être consommée alors que l’écran `screenSessions` était masqué, empêchant de restaurer correctement la position au moment de l’affichage.
- Le calcul du haut visible ne prenait pas en compte le padding/top fixe réservé par l’en-tête, d’où un mauvais positionnement vertical.

### Description
- Ajout de `getSessionVisibleTop(container)` pour calculer le haut réellement visible de la zone de session en tenant compte du `paddingTop` et de la position du container.
- Empêche la consommation de la cible de scroll tant que `screenSessions` est masqué en vérifiant `screenSessions?.hidden` dans `restoreSessionScroll` afin de conserver `sessionScrollState.targetExerciseId` jusqu’à l’affichage.
- Remplacement des calculs de position pour aligner la carte ciblée en haut en utilisant `getSessionVisibleTop(container)` dans `restoreSessionScroll` et dans `A.ensureSessionCardInView` pour appliquer la même limite visible.
- Fichier modifié : `ui-session.js` (ajout de la fonction utilitaire et ajustements du positionnement du scroll).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `for file in *.js components/*.js; do node --check "$file"; done` et validation réussie.
- Vérification des diffs avec `git diff --check` exécutée et sans erreurs signalées.
- Le changement a été commité localement (`Fix session exercise scroll targeting`) et la branche est propre après commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2416b2935883329252e9c86eddf370)