### PR TITLE
Filtrer les indicateurs par RPE suivi et afficher totaux dans l’historique

### DIFF
--- a/style.css
+++ b/style.css
@@ -1496,7 +1496,7 @@ textarea:focus{
 }
 .exercise-history-set-line{
     display:grid;
-    grid-template-columns: 3ch 6ch 4.5ch auto auto auto auto;
+    grid-template-columns: 5ch 8ch 4.5ch auto auto auto auto;
     column-gap: .35rem;
     align-items: baseline;
 }

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -733,13 +733,15 @@
         const line = document.createElement('div');
         line.className = 'details exercise-history-set-line exercise-history-stats-line';
         const stats = computeHistorySessionStats(sets);
+        const totalReps = Number.isFinite(stats?.totalReps) ? `${formatNumber(stats.totalReps)}x` : '—';
+        const totalVolume = Number.isFinite(stats?.totalVolume) ? `${formatNumber(stats.totalVolume)}${weightUnit}` : `—${weightUnit}`;
         const rpeAvg = Number.isFinite(stats?.rpeAvg) ? formatRpeValue(stats.rpeAvg) : '—';
         const orm = Number.isFinite(stats?.orm) ? `${formatOrmValue(stats.orm)}${weightUnit}` : `—${weightUnit}`;
         const ormRpe = Number.isFinite(stats?.ormRpe) ? `${formatOrmValue(stats.ormRpe)}${weightUnit}` : `—${weightUnit}`;
 
         line.append(
-            createHistoryPart('exercise-history-set-line__reps', ''),
-            createHistoryPart('exercise-history-set-line__weight', ''),
+            createHistoryPart('exercise-history-set-line__reps', totalReps),
+            createHistoryPart('exercise-history-set-line__weight', totalVolume),
             createHistoryPart('exercise-history-set-line__rpe', rpeAvg),
             createHistoryPart('exercise-history-set-line__sep', ''),
             createHistoryPart('exercise-history-set-line__orm', orm),
@@ -750,14 +752,29 @@
     }
 
     function computeHistorySessionStats(sets) {
-        const eligibleSets = (Array.isArray(sets) ? sets : []).filter((set) => {
+        const minTrackedRpe = A.getMinTrackedRpe?.() ?? 7;
+        const trackedSets = (Array.isArray(sets) ? sets : []).filter((set) => {
             const rpe = Number(set?.rpe);
+            return Number.isFinite(rpe) && rpe >= minTrackedRpe;
+        });
+        const totalReps = trackedSets.reduce((total, set) => {
+            const reps = Number(set?.reps);
+            return Number.isFinite(reps) && reps > 0 ? total + reps : total;
+        }, 0);
+        const totalVolume = trackedSets.reduce((total, set) => {
             const reps = Number(set?.reps);
             const weight = Number(set?.weight);
-            return Number.isFinite(rpe) && rpe >= 7 && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
+            return Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0
+                ? total + reps * weight
+                : total;
+        }, 0);
+        const eligibleSets = trackedSets.filter((set) => {
+            const reps = Number(set?.reps);
+            const weight = Number(set?.weight);
+            return Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
         });
         if (!eligibleSets.length) {
-            return { rpeAvg: null, orm: null, ormRpe: null };
+            return { totalReps, totalVolume, rpeAvg: null, orm: null, ormRpe: null };
         }
 
         let rpeSum = 0;
@@ -782,6 +799,8 @@
             }
         });
         return {
+            totalReps,
+            totalVolume,
             rpeAvg: rpeSum / eligibleSets.length,
             orm: ormCount ? ormSum / ormCount : null,
             ormRpe: ormRpeCount ? ormRpeSum / ormRpeCount : null

--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -1557,7 +1557,7 @@
             const rpe = Number(set?.rpe);
             const reps = Number(set?.reps);
             const weight = Number(set?.weight);
-            return Number.isFinite(rpe) && rpe >= 7 && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
+            return Number.isFinite(rpe) && rpe >= (A.getMinTrackedRpe?.() ?? 7) && Number.isFinite(reps) && reps > 0 && Number.isFinite(weight) && weight > 0;
         });
         if (!eligibleSets.length) {
             return {

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -2321,7 +2321,7 @@
 
     function isSetEligibleForOrmMeanForSessionEdit(set) {
         const rpe = Number(set?.rpe);
-        return Number.isFinite(rpe) && rpe >= 7;
+        return Number.isFinite(rpe) && rpe >= (A.getMinTrackedRpe?.() ?? 7);
     }
 
     function resolveSetOrmValueForSessionEdit(set) {

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -1821,10 +1821,14 @@
         let rpeSum = 0;
         let rpeCount = 0;
         let hasData = false;
+        const minTrackedRpe = A.getMinTrackedRpe?.() ?? 7;
         sets.forEach((set) => {
             const reps = parseNumber(set?.reps);
             const weight = parseNumber(set?.weight);
             const rpe = parseNumber(set?.rpe);
+            if (!Number.isFinite(rpe) || rpe < minTrackedRpe) {
+                return;
+            }
             if (Number.isFinite(reps) || Number.isFinite(weight) || Number.isFinite(rpe)) {
                 setCount += 1;
             }
@@ -1836,11 +1840,9 @@
                 maxWeight = weight;
                 hasData = true;
             }
-            if (Number.isFinite(rpe) && rpe >= (A.getMinTrackedRpe?.() ?? 7) && rpe <= 10) {
-                rpeSum += rpe;
-                rpeCount += 1;
-                hasData = true;
-            }
+            rpeSum += rpe;
+            rpeCount += 1;
+            hasData = true;
             if (Number.isFinite(weight) && weight > 0 && Number.isFinite(reps) && reps === 10) {
                 maxTenRmReal = Number.isFinite(maxTenRmReal) ? Math.max(maxTenRmReal, weight) : weight;
                 hasData = true;


### PR DESCRIPTION
### Motivation

- Uniformiser l’usage du seuil RPE commun (via `A.getMinTrackedRpe()`) dans les calculs de statistiques et d’en-tête pour que toutes les métriques utilisent le même filtre.
- Afficher, dans l’onglet Historique d’un exercice, des totaux utiles (répétitions et volume) visibles au-dessus des colonnes Répétitions et Poids.
- S’assurer que le graphe et les indicateurs (répétitions, volume, séries/semaine, etc.) n’utilisent que les séries atteignant le seuil RPE configuré.

### Description

- Ajout des totaux `totalReps` et `totalVolume` dans la ligne d’en-tête des blocs d’historique et affichage au-dessus des colonnes Répétitions et Poids dans `ui-exercise-read.js`.
- Calcul des totaux et filtrage des séries basés sur `A.getMinTrackedRpe?.() ?? 7` (seuil RPE centralisé) dans `ui-exercise-read.js` et `ui-stats.js` pour harmoniser le comportement.
- Modification de `computeMetrics` dans `ui-stats.js` pour exclure les séries dont le RPE est inférieur au seuil suivi et n’agréger que les séries éligibles (impacte volume, répétitions, avgRpe, setsWeek, etc.).
- Remplacement des occurrences codées en dur de `rpe >= 7` par le paramètre commun `A.getMinTrackedRpe?.() ?? 7` dans `ui-routine-edit.js` et `ui-session-execution-edit.js`.
- Ajustement CSS (`style.css`) : élargissement des deux premières colonnes de la grille d’une ligne d’historique pour loger les nouveaux totaux.

Fichiers modifiés : `ui-exercise-read.js`, `ui-stats.js`, `ui-routine-edit.js`, `ui-session-execution-edit.js`, `style.css`.

### Testing

- Exécution de vérifications de syntaxe : `node --check ui-exercise-read.js`, `node --check ui-stats.js`, `node --check ui-routine-edit.js`, `node --check ui-session-execution-edit.js` — toutes réussies.
- Test ciblé Node (exécution d’un petit scénario JS exposant `computeMetrics` et `computeHistorySessionStats`) vérifiant que les séries sous le seuil RPE sont exclues et que les totaux d’historique (répétitions et volume) sont correctement calculés — test passé.
- Contrôles supplémentaires automatisés : `git diff --check` et recherche d’occurrences restantes (`rg`) pour les expressions RPE attendues — OK.
- Pas de test UI visuel automatisé (navigateur non disponible dans l’environnement de test), les changements CSS ont été limités à l’élargissement de colonnes uniquement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a241a4c40708332b0ffef2d41bc0528)