### PR TITLE
Ajoute le nom des routines aux commentaires de séance

### DIFF
--- a/ui-session.js
+++ b/ui-session.js
@@ -1123,6 +1123,7 @@
             if (!routine) {
                 continue;
             }
+            appendRoutineNameToSessionComments(session, routine.name || 'Routine');
             for (const move of routine.moves) {
                 if (existingIds.has(move.exerciseId)) {
                     continue;
@@ -1521,6 +1522,13 @@
     }
 
     /* UTILS */
+    function appendRoutineNameToSessionComments(session, routineName) {
+        const comments = typeof session?.comments_session_global === 'string'
+            ? session.comments_session_global.trimEnd()
+            : '';
+        session.comments_session_global = comments ? `${comments}\n${routineName}` : routineName;
+    }
+
     function createSession(date) {
         return {
             id: A.sessionId(date),


### PR DESCRIPTION
### Motivation

- Faire en sorte que, lorsqu'une routine est ajoutée à une séance, son nom soit ajouté aux commentaires globaux de la séance pour que l'utilisateur voie quelles routines ont été insérées.

### Description

- Appelle `appendRoutineNameToSessionComments(session, routine.name || 'Routine')` pour chaque routine valide dans `A.addRoutineToSession` afin d'ajouter son nom avant d'ajouter les exercices de la routine.
- Ajoute la fonction utilitaire `appendRoutineNameToSessionComments(session, routineName)` qui conserve les commentaires existants en les `trimEnd()`, puis ajoute le nom sur une nouvelle ligne ou remplace par le nom si les commentaires étaient vides.
- Ne modifie pas la logique d'ajout des exercices ni la sauvegarde de la séance en aval; seuls les commentaires globaux sont mis à jour.

### Testing

- Vérifié la syntaxe avec `node --check ui-session.js` (succès).
- Vérifié les erreurs git avec `git diff --check` (succès).
- Exécuté un harnais Node/VM simulant `db.getSession`/`db.get('routines')` puis appelé `A.addRoutineToSession` et validé que `session.comments_session_global` contient les noms ajoutés sur des lignes séparées (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a241e966eb48332a1cd3f7b6080f30f)