### PR TITLE
Aligner systématiquement la séance sélectionnée dans l’historique

### DIFF
--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -511,30 +511,45 @@
 
     function scheduleActiveTabScroll(tab) {
         requestAnimationFrame(() => {
-            const { screenExecEdit, execEditTabs, execReadHistoryContent } = assertRefs();
-            const content = screenExecEdit?.querySelector('.content');
-            if (!content || screenExecEdit.hidden || state.activeTab !== tab) {
-                return;
-            }
-            if (tab === 'stats') {
-                content.scrollTo({ top: 0, behavior: 'auto' });
-                return;
-            }
-            if (tab !== 'history') {
-                return;
-            }
-            const selectedSession = execReadHistoryContent?.querySelector('.exercise-history-session.is-selected');
-            if (!selectedSession) {
-                return;
-            }
-            const contentRect = content.getBoundingClientRect();
-            const selectedRect = selectedSession.getBoundingClientRect();
-            const tabsHeight = execEditTabs?.getBoundingClientRect().height || 0;
-            content.scrollTo({
-                top: content.scrollTop + selectedRect.top - contentRect.top - tabsHeight - 12,
-                behavior: 'auto'
-            });
+            // Attend que l'écran et l'onglet nouvellement affichés aient leurs dimensions finales.
+            requestAnimationFrame(() => scrollActiveTab(tab));
         });
+    }
+
+    function scrollActiveTab(tab) {
+        const {
+            screenExecEdit,
+            execEditTabs,
+            execEditTabHistory,
+            execReadHistoryContent
+        } = assertRefs();
+        const content = screenExecEdit?.querySelector('.content');
+        if (!content || screenExecEdit.hidden || state.activeTab !== tab) {
+            return;
+        }
+        if (tab === 'stats') {
+            content.scrollTo({ top: 0, behavior: 'auto' });
+            return;
+        }
+        if (tab !== 'history') {
+            return;
+        }
+        execEditTabHistory.style.paddingBottom = '';
+        const selectedSession = execReadHistoryContent?.querySelector('.exercise-history-session.is-selected');
+        if (!selectedSession) {
+            return;
+        }
+
+        const contentRect = content.getBoundingClientRect();
+        const selectedRect = selectedSession.getBoundingClientRect();
+        const tabsHeight = execEditTabs?.getBoundingClientRect().height || 0;
+        const targetTop = content.scrollTop + selectedRect.top - contentRect.top - tabsHeight - 12;
+        const maxScrollTop = content.scrollHeight - content.clientHeight;
+        const missingScrollSpace = Math.max(0, targetTop - maxScrollTop);
+        if (missingScrollSpace > 0) {
+            execEditTabHistory.style.paddingBottom = `${missingScrollSpace}px`;
+        }
+        content.scrollTo({ top: targetTop, behavior: 'auto' });
     }
 
     function setSessionTabVisibility(visible) {


### PR DESCRIPTION
### Motivation
- Garantir que, lorsqu’on ouvre l’onglet Historique depuis l’écran Exercice (ou qu’on y revient), la séance source soit mise en évidence et positionnée alignée en haut de la zone de défilement même si elle est proche de la fin de la liste.
- Prévoir un comportement robuste vis-à-vis des dimensions de l’écran/onglet (attendre la stabilisation du rendu) pour éviter des calculs de position incorrects.

### Description
- Ajout d’un délai de stabilisation avant le recalcul du scroll en remplaçant l’ancien `scheduleActiveTabScroll` par un double `requestAnimationFrame` et en extrayant la logique dans `scrollActiveTab` dans `ui-session-execution-edit.js`.
- `scrollActiveTab` calcule la position cible (`targetTop`) pour aligner la séance marquée `.exercise-history-session.is-selected` sous les onglets et effectue le `scrollTo` correspondant.
- Lorsque la séance sélectionnée est trop proche de la fin, on ajoute dynamiquement un `padding-bottom` sur le panneau d’historique (`execEditTabHistory.style.paddingBottom`) pour créer l’espace de défilement nécessaire, puis on réinitialise cet espacement si aucune séance n’est sélectionnée.
- Le marquage visuel (`.is-selected`) et la bordure d’emphase reposent sur l’implémentation CSS/JS déjà présente (`ui-exercise-read.js` / `style.css`) et sont conservés.

### Testing
- Vérifications syntaxiques JavaScript via `node --check` sur tous les fichiers `.js` et composants réussies.
- Contrôle statique `git diff --check` effectué et sans avertissements bloquants.
- Chargement de `index.html` et `ui-session-execution-edit.js` via un serveur HTTP local (`python3 -m http.server`) et tests `curl` réussis pour valider le chargement statique des ressources.
- Validation visuelle par capture d’écran non réalisée car aucun navigateur Chromium-compatible n’était disponible dans l’environnement de test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a241d3b40448332b2c1c3cde9c3fcec)