### PR TITLE
Ouvre les routines en haut depuis la liste

### DIFF
--- a/ui-routine-edit.js
+++ b/ui-routine-edit.js
@@ -51,13 +51,19 @@
 
     /* ACTIONS */
     A.openRoutineEdit = async function openRoutineEdit(options = {}) {
-        const { routineId = 'routine-test', callerScreen = 'screenSettings' } = options;
+        const { routineId = 'routine-test', callerScreen = 'screenSettings', resetScroll = false } = options;
         state.routineId = routineId;
         state.callerScreen = callerScreen;
         state.active = true;
+        if (resetScroll) {
+            resetRoutineScroll();
+        }
         await loadRoutine(true);
         renderRoutine();
         switchScreen('screenRoutineEdit');
+        if (resetScroll) {
+            resetRoutineScroll();
+        }
     };
 
     A.refreshRoutineEdit = async function refreshRoutineEdit() {
@@ -170,6 +176,16 @@
         }
         routineScrollState.top = container.scrollTop || 0;
         routineScrollState.pendingRestore = true;
+    }
+
+    function resetRoutineScroll() {
+        routineScrollState.top = 0;
+        routineScrollState.pendingRestore = false;
+        routineScrollState.targetMoveId = null;
+        const container = getRoutineScrollContainer();
+        if (container) {
+            container.scrollTop = 0;
+        }
     }
 
     const ROUTINE_SCROLL_TOP_GAP_PX = 10;

--- a/ui-routines-list.js
+++ b/ui-routines-list.js
@@ -178,7 +178,7 @@
             const id = createRoutineId();
             highlightCallerTab(state.callerScreen);
             storeRoutineListScroll();
-            A.openRoutineEdit({ routineId: id, callerScreen: state.callerScreen });
+            A.openRoutineEdit({ routineId: id, callerScreen: state.callerScreen, resetScroll: true });
         });
     }
 
@@ -450,7 +450,7 @@
             card.addEventListener('click', () => {
                 highlightCallerTab(state.callerScreen);
                 storeRoutineListScroll();
-                A.openRoutineEdit({ routineId: routine?.id, callerScreen: state.callerScreen });
+                A.openRoutineEdit({ routineId: routine?.id, callerScreen: state.callerScreen, resetScroll: true });
             });
         }
 


### PR DESCRIPTION
### Motivation
- Lorsqu’on ouvrait une routine depuis la liste, l’écran réappliquait parfois le scrolling sauvegardé alors qu’il doit s’ouvrir systématiquement en haut pour une ouverture depuis la liste.

### Description
- Ajout d’un paramètre optionnel `resetScroll` à `A.openRoutineEdit` et implémentation de `resetRoutineScroll()` dans `ui-routine-edit.js`, puis passage de `resetScroll: true` depuis `ui-routines-list.js` pour les actions de création et d’ouverture depuis la liste afin d’ouvrir la vue routine en haut tout en conservant la restauration de scroll pour les autres flux.

### Testing
- Exécutions automatiques: `node --check ui-routine-edit.js`, `node --check ui-routines-list.js`, `for file in *.js components/*.js; do node --check "$file"; done` et `git diff --check`, toutes réussies; aucune vérification visuelle (navigateur non disponible).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24380ec620833281c538a6e850620c)