### PR TITLE
Stats: remove embedded timeline and make summary clickable to open Histo

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,10 +448,6 @@
 
                 <button id="statsGoal" class="btn primary full" type="button" title="Objectif">Objectif</button>
 
-                <section>
-                    <h2 class="stats-section-title" id="statsTimelineTitle">Historique</h2>
-                    <ul id="statsTimeline" class="stats-timeline" aria-live="polite"></ul>
-                </section>
             </div>
         </section>
 	</main>  

--- a/style.css
+++ b/style.css
@@ -3107,6 +3107,19 @@ input[type="number"]{ -moz-appearance:textfield; }
     text-align: center;
 }
 
+.stats-subtitle[data-stats-summary-link] {
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 3px;
+}
+
+.stats-subtitle[data-stats-summary-link]:focus-visible {
+    outline: 2px solid var(--emphase);
+    outline-offset: 4px;
+    border-radius: 8px;
+}
+
 .stats-chart-card {
     margin-bottom: 16px;
     padding: 0;

--- a/ui-exercise-read.js
+++ b/ui-exercise-read.js
@@ -26,7 +26,7 @@
      * @returns {Promise<void>} Promesse résolue après rendu.
      */
     A.openExerciseRead = async function openExerciseRead(options) {
-        const { currentId, callerScreen = 'screenExercises', tab = 'exec' } = options || {};
+        const { currentId, callerScreen = 'screenExercises', tab = 'exec', selectedDateKey = null } = options || {};
         if (!currentId) {
             return;
         }
@@ -35,7 +35,8 @@
                 exerciseRefId: currentId,
                 callerScreen,
                 showSessionTab: false,
-                initialTab: tab
+                initialTab: tab,
+                selectedDateKey
             });
             return;
         }
@@ -57,7 +58,8 @@
         await renderExerciseHistoryPanel({
             exercise,
             exerciseId: state.currentId,
-            container: refs.exReadHistoryList
+            container: refs.exReadHistoryList,
+            selectedDateKey
         });
         setActiveTab(tab);
 
@@ -568,8 +570,14 @@
             .filter((item) => item && item.sets.length > 0);
 
         items.sort((a, b) => {
-            const timeA = new Date(a.session?.date || a.session?.id || 0).getTime();
-            const timeB = new Date(b.session?.date || b.session?.id || 0).getTime();
+            const keyA = a.session?.date || a.session?.id || '';
+            const keyB = b.session?.date || b.session?.id || '';
+            if (selectedDateKey) {
+                if (keyA === selectedDateKey && keyB !== selectedDateKey) return -1;
+                if (keyB === selectedDateKey && keyA !== selectedDateKey) return 1;
+            }
+            const timeA = new Date(keyA || 0).getTime();
+            const timeB = new Date(keyB || 0).getTime();
             return timeB - timeA;
         });
 

--- a/ui-session-execution-edit.js
+++ b/ui-session-execution-edit.js
@@ -122,7 +122,8 @@
             focusField = null,
             openMeta = false,
             showSessionTab = true,
-            initialTab = 'session'
+            initialTab = 'session',
+            selectedDateKey = null
         } = options;
         if (!currentId && !exerciseRefId) {
             return;
@@ -157,6 +158,7 @@
             state.exerciseId = null;
             state.exerciseRefId = exercise.id;
         }
+        state.historySelectedDateKey = selectedDateKey || state.dateKey;
         state.callerScreen = callerScreen;
         state.session = session;
         state.showSessionTab = Boolean(showSessionTab && hasSessionContext);
@@ -192,6 +194,25 @@
                 }
             }, 0);
         }
+    };
+
+
+    A.openExecHistoryForDate = async function openExecHistoryForDate(selectedDateKey = null) {
+        const { execReadHistoryContent } = assertRefs();
+        const linkedExerciseId = state.exerciseRefId;
+        if (!linkedExerciseId || typeof A.renderExerciseReadHistoryPanel !== 'function') {
+            setExecActiveTab('history');
+            return;
+        }
+        state.historySelectedDateKey = selectedDateKey || state.dateKey || null;
+        const baseExercise = await db.get('exercises', linkedExerciseId);
+        await A.renderExerciseReadHistoryPanel({
+            exercise: baseExercise,
+            exerciseId: linkedExerciseId,
+            container: execReadHistoryContent,
+            selectedDateKey: state.historySelectedDateKey
+        });
+        setExecActiveTab('history');
     };
 
     A.openExecMoveMeta = async function openExecMoveMeta(options = {}) {
@@ -586,10 +607,10 @@
                 exercise: mergedExercise,
                 exerciseId: linkedExerciseId,
                 container: execReadHistoryContent,
-                selectedDateKey: state.dateKey
+                selectedDateKey: state.historySelectedDateKey || state.dateKey
             });
         }
-        await renderStatsDuplicate(mergedExercise, execEditTabStats, linkedExerciseId, state.dateKey);
+        await renderStatsDuplicate(mergedExercise, execEditTabStats, linkedExerciseId, state.historySelectedDateKey || state.dateKey);
     }
 
     async function renderStatsDuplicate(exercise, container, exerciseId, selectedDateKey = null) {

--- a/ui-stats.js
+++ b/ui-stats.js
@@ -193,8 +193,6 @@
         refs.statsChartEmpty = document.getElementById('statsChartEmpty');
         refs.statsMetricTags = document.getElementById('statsMetricTags');
         refs.statsRangeTags = document.getElementById('statsRangeTags');
-        refs.statsTimeline = document.getElementById('statsTimeline');
-        refs.statsTimelineTitle = document.getElementById('statsTimelineTitle');
         refs.statsBack = document.getElementById('statsBack');
         refs.statsGoal = document.getElementById('statsGoal');
         refs.tabStats = document.getElementById('tabStats');
@@ -229,8 +227,6 @@
             'statsChartEmpty',
             'statsMetricTags',
             'statsRangeTags',
-            'statsTimeline',
-            'statsTimelineTitle',
             'statsGoal'
         ];
         const missing = required.filter((key) => !refs[key]);
@@ -275,7 +271,20 @@
                 renderExerciseDetail();
             });
         }
+        document.addEventListener('keydown', (event) => {
+            const summary = event.target.closest?.('[data-stats-summary-link]');
+            if (!summary || (event.key !== 'Enter' && event.key !== ' ')) {
+                return;
+            }
+            event.preventDefault();
+            void openHistoryForSummary(summary.dataset.selectedDateKey || null);
+        });
         document.addEventListener('click', (event) => {
+            const summary = event.target.closest('[data-stats-summary-link]');
+            if (summary) {
+                void openHistoryForSummary(summary.dataset.selectedDateKey || null);
+                return;
+            }
             const button = event.target.closest('[data-stats-section]');
             if (!button) {
                 return;
@@ -419,15 +428,13 @@
     }
 
     function renderExerciseDetail() {
-        const { statsExerciseTitle, statsExerciseSubtitle, statsTimelineTitle } = assertStatsRefs();
+        const { statsExerciseTitle, statsExerciseSubtitle } = assertStatsRefs();
         const exercise = state.activeExercise;
         statsExerciseTitle.textContent = exercise?.name || 'Exercice';
         renderMetricTags();
         renderRangeTags();
         updateExerciseSummary(statsExerciseSubtitle);
-        updateExerciseHistoryTitle(statsTimelineTitle);
         renderChart();
-        renderTimeline();
     }
 
     function renderEmbeddedStatsContent(container, exerciseId, selectedDateKey = null) {
@@ -442,7 +449,7 @@
         } else {
             delete container.dataset.statsSelectedDateKey;
         }
-        const { statsMetricTags, statsChart, statsChartEmpty, statsRangeTags, statsTimeline, statsExerciseSubtitle, statsTimelineTitle } =
+        const { statsMetricTags, statsChart, statsChartEmpty, statsRangeTags, statsExerciseSubtitle } =
             assertStatsRefs();
         container.innerHTML = '';
 
@@ -458,13 +465,6 @@
         goalButton.title = 'Objectif';
         goalButton.textContent = 'Objectif';
         container.appendChild(goalButton);
-        appendClonedParent(container, statsTimeline.closest('section'));
-
-        const embeddedTimelineTitle = container.querySelector('.stats-section-title');
-        if (embeddedTimelineTitle) {
-            embeddedTimelineTitle.textContent = statsTimelineTitle.textContent || 'Historique';
-        }
-
         const embeddedChartEmpty = container.querySelector('.stats-chart-empty');
         if (embeddedChartEmpty) {
             embeddedChartEmpty.textContent = statsChartEmpty.textContent || 'Aucune donnée enregistrée.';
@@ -474,6 +474,7 @@
         const embeddedSubtitle = container.querySelector('.stats-subtitle');
         if (embeddedSubtitle) {
             embeddedSubtitle.textContent = statsExerciseSubtitle.textContent || '';
+            prepareSummaryLink(embeddedSubtitle, selectedDateKey);
         }
         renderChart({
             statsChart: embeddedChart || statsChart,
@@ -499,6 +500,12 @@
                 }
                 const rangeButton = event.target.closest('[data-range]');
                 if (!rangeButton) {
+                    const summaryButton = event.target.closest('[data-stats-summary-link]');
+                    if (summaryButton) {
+                        event.stopPropagation();
+                        void openHistoryForSummary(summaryButton.dataset.selectedDateKey || container.dataset.statsSelectedDateKey || null);
+                        return;
+                    }
                     const goalButtonTarget = event.target.closest('[data-stats-goal]');
                     if (goalButtonTarget) {
                         openGoalDialog();
@@ -516,6 +523,41 @@
                 }
             });
             container.dataset.statsEmbeddedWired = 'true';
+        }
+    }
+
+
+    function prepareSummaryLink(element, selectedDateKey) {
+        if (!element) {
+            return;
+        }
+        element.dataset.statsSummaryLink = 'true';
+        if (selectedDateKey) {
+            element.dataset.selectedDateKey = selectedDateKey;
+        } else {
+            delete element.dataset.selectedDateKey;
+        }
+        element.setAttribute('role', 'button');
+        element.tabIndex = 0;
+        element.title = 'Ouvrir l’historique à cette date';
+    }
+
+    async function openHistoryForSummary(selectedDateKey) {
+        const exerciseId = state.activeExercise?.id;
+        if (!exerciseId) {
+            return;
+        }
+        if (typeof A.openExecHistoryForDate === 'function' && refs.screenExecEdit && !refs.screenExecEdit.hidden) {
+            await A.openExecHistoryForDate(selectedDateKey);
+            return;
+        }
+        if (typeof A.openExerciseRead === 'function') {
+            await A.openExerciseRead({
+                currentId: exerciseId,
+                callerScreen: 'screenExecEdit',
+                tab: 'history',
+                selectedDateKey
+            });
         }
     }
 
@@ -1096,6 +1138,7 @@
             }
             const goalValue = getGoalValueAtDate(state.activeMetric, point.date, exercise, usage);
             statsExerciseSubtitle.textContent = buildSummaryText(metricDefinition, point.value, point.date, goalValue);
+            prepareSummaryLink(statsExerciseSubtitle, A.ymd?.(point.date) || null);
         };
 
         const updateFocusAtPoint = (point) => {
@@ -1169,6 +1212,7 @@
             focusGroup.setAttribute('data-visible', 'false');
             points.forEach((item) => item.element?.classList.remove('is-active'));
             updateExerciseSummary(statsExerciseSubtitle);
+            prepareSummaryLink(statsExerciseSubtitle, null);
         };
 
         svg.addEventListener('pointerdown', handlePointerDown);


### PR DESCRIPTION
### Motivation
- Simplify the «Stats» view by removing the duplicated session list under the chart and provide a clear way to open the session history for the date shown in the summary above the chart.
- Allow keyboard and pointer users to jump from the chart summary directly to the exercise history with the session of the selected date scrolled to the top.

### Description
- Removed the embedded timeline HTML from `index.html` and stopped cloning/rendering the timeline under the chart in `ui-stats.js` so the Stats screen ends after the `Objectif` button.
- Made the stats subtitle (summary above the chart) interactive by adding `prepareSummaryLink` and `openHistoryForSummary` in `ui-stats.js`, wiring click and keyboard handlers, and updating the subtitle when a chart point is selected or cleared; integrated handling when the stats view is embedded (`renderEmbeddedStatsContent`).
- Propagated a `selectedDateKey` through `A.openExerciseRead` (`ui-exercise-read.js`) and `A.openExecEdit` (`ui-session-execution-edit.js`) so history rendering can prioritize and mark the selected session card; added `A.openExecHistoryForDate` to open the Histo tab and rerender history with the selected date focused.
- Added CSS to visually indicate the summary is clickable and to show keyboard focus (`style.css`).

### Testing
- Syntactic checks: `node --check ui-stats.js`, `node --check ui-exercise-read.js`, `node --check ui-session-execution-edit.js` all succeeded.
- Static diff check: `git diff --check` ran without reported problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a492960c80c833289b2ab6d6183d93c)